### PR TITLE
CASMINST-2775  Improve ca cert match check

### DIFF
--- a/goss-testing/scripts/validate_ca_certs_match_cloud_init.sh
+++ b/goss-testing/scripts/validate_ca_certs_match_cloud_init.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# This script validates that the platform-ca-certs.crt file matches what is in
+# BSS. Since the meta-data request may return the certificates in a different
+# order than what was originally provided this will check against multiple
+# order differences.
+# Copyright 2014-2021 Hewlett Packard Enterprise Development LP
+
+set -euo pipefail
+
+MAXARRAY=$(($(curl -s http://10.92.100.71:8888/meta-data | jq -r '.Global."ca-certs".trusted | length') - 1))
+SERVER=http://10.92.100.71:8888/meta-data
+LOCALCA=/etc/pki/trust/anchors/platform-ca-certs.crt
+TRUSTEDDATA=$(curl -s "$SERVER" | jq -r '.Global."ca-certs".trusted')
+TRUSTEDORDER=()
+
+for i in $(seq 0 $MAXARRAY); do
+  TRUSTEDORDER+=("\(.[${i}])")
+done
+
+# Iterate through all BSS trusted certificate sequences and test against the
+# platforms file
+for i in $(seq 0 $MAXARRAY); do
+  for j in $(seq 0 $((MAXARRAY - 1))); do
+    TMP=${TRUSTEDORDER[$j]}
+    TRUSTEDORDER[$j]=${TRUSTEDORDER[$((j + 1))]}
+    TRUSTEDORDER[$((j + 1))]=$TMP
+
+    STRING=$(echo "${TRUSTEDORDER[@]}" | tr -d " ")
+    if diff <(echo "$TRUSTEDDATA" | jq -r \""${STRING}"\" | sed '/^$/d') "$LOCALCA" >/dev/null; then
+      exit 0
+    fi
+  done
+done
+exit 1

--- a/goss-testing/tests/ncn/goss-platform-ca-certs-match-cloud-init.yaml
+++ b/goss-testing/tests/ncn/goss-platform-ca-certs-match-cloud-init.yaml
@@ -5,8 +5,7 @@ command:
     meta:
       desc: Validates that the local platform CA bundle matches the one in cloud-init
       sev: 0
-    exec: "curl -s http://10.92.100.71:8888/meta-data | jq -r '.Global.\"ca-certs\".trusted[]' | sed '/^$/d' > /tmp/trusted.goss;\
-           diff /etc/pki/trust/anchors/platform-ca-certs.crt /tmp/trusted.goss"
+    exec: "{{.Env.GOSS_BASE}}/scripts/validate_ca_certs_match_cloud_init.sh"
     exit-status: 0
     timeout: 10000
     skip: false


### PR DESCRIPTION
This fixes an issue where the certificates could be returned via BSS in
a separate order than what was originally used to create the
platform-ca-certs.crt.

This was tested on drax, hela, and gamora.