### PR TITLE
CASMINST-2120 Use new interface names

### DIFF
--- a/goss-testing/scripts/python/pyTest-ip-not-in-ip-pools.py
+++ b/goss-testing/scripts/python/pyTest-ip-not-in-ip-pools.py
@@ -5,7 +5,7 @@ import sys, ipaddress, logging, subprocess
 '''
 USAGE: pyTest-ip-not-in-ip-pools.py GOSS.VARS.ALL-INTERFACES
 Re-write of the original script
-This version of Goss passes the list in an ugly fashion "[bond0, vlan002...]" so
+This version of Goss passes the list in an ugly fashion "[bond0, bond0.nmn0...]" so
   the script needs to account for this and the prettier way future versions pass them
 This script will now get the ip pools from /etc/dnsmasq.d/*.conf
 The file names are in a hard-coded list in this script - this may be better done using goss variables

--- a/goss-testing/vars/variables-livecd.yaml
+++ b/goss-testing/vars/variables-livecd.yaml
@@ -20,9 +20,9 @@ networks:
 
 network_interfaces:
   - bond0
-  - vlan002
-  - vlan004
-  - vlan007
+  - bond0.nmn0
+  - bond0.hmn0
+  - bond0.can0
 
 services_enabled:
   - dnsmasq

--- a/goss-testing/vars/variables-ncn.yaml
+++ b/goss-testing/vars/variables-ncn.yaml
@@ -17,9 +17,9 @@ networks:
   - "can"
 
 network_interfaces:
-  - vlan002
-  - vlan004
-  - vlan007
+  - bond0.nmn0
+  - bond0.hmn0
+  - bond0.can0
 
 services_enabled:
   - cloud-config


### PR DESCRIPTION
Do not merge this without checking, since this has to merge with a few other PRs at the same time.


This effectively requires all of these to merge first:

- https://github.com/Cray-HPE/cray-site-init/pull/15
- https://github.com/Cray-HPE/metal-ipxe/pull/14
- https://stash.us.cray.com/projects/CLOUD/repos/node-image-non-compute-common/pull-requests/175/diff#provisioners/metal/install.sh
- https://stash.us.cray.com/projects/MTL/repos/cray-pre-install-toolkit/pull-requests/194/diff#suse/x86_64/cray-pre-install-toolkit-sle15sp2/root/root/bin/csi-setup-can.sh
- https://stash.us.cray.com/projects/CLOUD/repos/node-image-kubernetes/pull-requests/152/diff
- https://stash.us.cray.com/projects/CLOUD/repos/node-image-storage-ceph/pull-requests/97/diff#provisioners/common/install.sh

