### PR TITLE
CASMTRIAGE-2050 Add possible cause to test title

### DIFF
--- a/goss-testing/tests/ncn/goss-spire-bss-metadata-exist.yaml
+++ b/goss-testing/tests/ncn/goss-spire-bss-metadata-exist.yaml
@@ -1,7 +1,7 @@
 # Copyright 2014-2021 Hewlett Packard Enterprise Development LP
 command:
   spire_in_bss_cloudinit:
-    title: Kubernetes Query BSS Cloud-init for spire meta data
+    title: Kubernetes Query BSS Cloud-init for spire meta data. If this fails then check to verify that the spire-update-bss job in the spire namespace ran successfully and recreate the job if it failed.
     meta:
       desc: Kubernetes Query BSS Cloud-init for spire meta data
       sev: 0


### PR DESCRIPTION
The spire-bss-metadata-exist test will almost always fail because the spire-update-bss job didn't run to update BSS with the spire information. This adds some text to the output to tell the user to check to see if the job ran successfully when the test fails.