### PR TITLE
CASMINST-2929 - Fix for ceph goss tests

### DIFF
--- a/goss-testing/scripts/ceph-service-status.sh
+++ b/goss-testing/scripts/ceph-service-status.sh
@@ -208,6 +208,11 @@ fi
 
 for node_num in $(seq 1 "$num_storage_nodes"); do
   nodename=$(printf "ncn-s%03d" "$node_num")
+  pdsh -N -w "$host" > ~/.ssh/known_hosts 2>&1
+done
+
+for node_num in $(seq 1 "$num_storage_nodes"); do
+  nodename=$(printf "ncn-s%03d" "$node_num")
   ssh-keyscan -H "$nodename" 2> /dev/null >> ~/.ssh/known_hosts
 done
 

--- a/goss-testing/tests/ncn/goss-ceph-storage-images.yaml
+++ b/goss-testing/tests/ncn/goss-ceph-storage-images.yaml
@@ -3,7 +3,7 @@ command:
   ceph_storage_images:
     title: Validates the ceph storage images have been loaded into podman
     meta:
-      desc: If this test fails, inspect the '/var/log/cloud-init-output.log' to determine if there were errors loading the docker images.
+      desc: If this test fails, run "/srv/cray/scripts/common/pre-load-images.sh" on the failed node.
       sev: 0
     exec: "podman images"
     stdout:


### PR DESCRIPTION
Fixes:
- invalid cached ssh keys
- Description for the image test to instruct how to re-cache the container images