### PR TITLE
CASMPET-4877 : Investigate why some keys tests are commented out

### DIFF
--- a/goss-testing/suites/ncn-kubernetes-tests-master.yaml
+++ b/goss-testing/suites/ncn-kubernetes-tests-master.yaml
@@ -3,11 +3,11 @@ gossfile:
   ../tests/goss-etcd-service.yaml: {}
   ../tests/goss-weave-IPAM-health.yaml: {}
   ../tests/goss-k8s-pods-ips-in-nmn-pool.yaml: {}
-# ../tests/goss-k8s-storage-configmaps.yaml: {}
-# ../tests/goss-k8s-verify-cluster.yaml: {}
+  ../tests/goss-k8s-storage-configmaps.yaml: {}
+  ../tests/goss-k8s-verify-cluster.yaml: {}
   ../tests/goss-k8s-all-loadbalancers-have-external-ips.yaml: {}
   ../tests/goss-k8s-certmanager-certs-ready.yaml: {}
   ../tests/goss-k8s-certmanager-issuers-ready.yaml: {}
-# ../tests/goss-k8s-trustedcerts-configmaps-exist.yaml: {}
-# ../tests/goss-k8s-vault-cluster-health.yaml: {}
+  ../tests/goss-k8s-trustedcerts-configmaps-exist.yaml: {}
+  ../tests/goss-k8s-vault-cluster-health.yaml: {}
   ../tests/goss-etcdlvm-drive-master.yaml: {}

--- a/goss-testing/suites/ncn-kubernetes-tests-worker.yaml
+++ b/goss-testing/suites/ncn-kubernetes-tests-worker.yaml
@@ -2,12 +2,12 @@
 gossfile:
   ../tests/goss-weave-IPAM-health.yaml: {}
   ../tests/goss-k8s-pods-ips-in-nmn-pool.yaml: {}
-# ../tests/goss-k8s-storage-configmaps.yaml: {}
-# ../tests/goss-k8s-verify-cluster.yaml: {}
+  ../tests/goss-k8s-storage-configmaps.yaml: {}
+  ../tests/goss-k8s-verify-cluster.yaml: {}
   ../tests/goss-k8s-all-loadbalancers-have-external-ips.yaml: {}
   ../tests/goss-k8s-certmanager-certs-ready.yaml: {}
   ../tests/goss-k8s-certmanager-issuers-ready.yaml: {}
-# ../tests/goss-k8s-trustedcerts-configmaps-exist.yaml: {}
-# ../tests/goss-k8s-vault-cluster-health.yaml: {}
+  ../tests/goss-k8s-trustedcerts-configmaps-exist.yaml: {}
+  ../tests/goss-k8s-vault-cluster-health.yaml: {}
   ../tests/goss-unbound-dns-entries.yaml: {}
   ../tests/goss-dedicated-drive-worker.yaml: {}


### PR DESCRIPTION
Resolves CASMPET-4877 for master
* Add back commented out tests from the ncn-kubernetes-tests suites - these tests were commented out in Feb before start-goss-server concurrently issues were addressed.
* Tested on surtur with 1.0.0 beta 69