### PR TITLE
CASMPET-4668 CASMPET-4669 : Automate goss test for kea lease and reso…

### DIFF
--- a/goss-testing/suites/validate-csm-health.yaml
+++ b/goss-testing/suites/validate-csm-health.yaml
@@ -4,6 +4,8 @@ gossfile:
   ../tests/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml: {}
   ../tests/goss-spire-healthcheck.yaml: {}
   ../tests/goss-k8s-vault-cluster-health.yaml: {}
+  ../tests/goss-kea-has-active-dhcp-leases.yaml: {}
+  ../tests/goss-resolve-external.dns.yaml: {}
 
 ## HMS
 

--- a/goss-testing/tests/ncn/goss-kea-has-active-dhcp-leases.yaml
+++ b/goss-testing/tests/ncn/goss-kea-has-active-dhcp-leases.yaml
@@ -1,0 +1,31 @@
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+command:
+  kea_has_active_dhcp_leases:
+    title: Kea has Active DHCP Leases
+    meta:
+      desc: Validates KEA has active DHCP leases. If the test fails, no leases were found. Check the DHCP Troubleshooting guide.
+      sev: 0
+    exec: |-
+          TOKEN=$(curl -s -S -d grant_type=client_credentials \
+                 -d client_id=admin-client \
+                 -d client_secret=`kubectl get secrets admin-client-auth \
+                 -o jsonpath='{.data.client-secret}' | base64 -d` \
+                  https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+          if [[ ! $TOKEN ]]; then
+             echo "Unable to get a token so cannot check Kea for active DHCP Leases"
+             exit 1
+          fi
+          LEASES=$(curl -s -S -H "Authorization: Bearer ${TOKEN}" -X POST -H "Content-Type: application/json" \
+                 -d '{ "command": "lease4-get-all", "service": [ "dhcp4" ] }' https://api-gw-service-nmn.local/apis/dhcp-kea \
+                 | jq -r '.[] | .text' | cut -d ' ' -f 1)
+
+          if [[ ! $LEASES -ge 1 ]]; then
+            echo "Kea has no active DHCP Leases"
+            exit 1
+          fi
+          echo "PASS"
+    exit-status: 0
+    stdout:
+      - PASS
+    timeout: 10000
+    skip: false

--- a/goss-testing/tests/ncn/goss-resolve-external.dns.yaml
+++ b/goss-testing/tests/ncn/goss-resolve-external.dns.yaml
@@ -1,0 +1,13 @@
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+command:
+  resolve_external_dns:
+    title: Resolve external DNS
+    meta:
+      desc: Validates external DNS name is resolvable. If the test fails, cray.com was not resolvable. Check the External DNS Troubleshooting guide.
+      sev: 0
+    exec: "nslookup cray.com | grep cray.com -A 1 | grep Address"
+    exit-status: 0
+    stdout:
+      - /^Address.*/
+    timeout: 10000
+    skip: false


### PR DESCRIPTION
Resolves
* CASMPET-4668 : Automate a check to verify that KEA has active DHCP leases
* CASMPET-4669 : Automate a check to verify the ability to resolve external DNS
Also adds the above new tests to the validate-csm-health.yml suite

Tested on surtur
```
ncn-m001:/opt/cray/tests/install/ncn/tests # goss -g /opt/cray/tests/install/ncn/tests/goss-kea-has-active-dhcp-leases.yaml validate
..

Total Duration: 0.297s
Count: 2, Failed: 0, Skipped: 0

ncn-m001:/opt/cray/tests/install/ncn/tests # goss -g /opt/cray/tests/install/ncn/tests/goss-resolve-external.dns.yaml validate
..

Total Duration: 0.010s
Count: 2, Failed: 0, Skipped: 0

ncn-m001:/opt/cray/tests/install/ncn/suites: cat validate-cms-health.yaml
# Copyright 2021 Hewlett Packard Enterprise Development LP
gossfile:
## Platform services
  ../tests/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml: {}
  ../tests/goss-spire-healthcheck.yaml: {}
  ../tests/goss-k8s-vault-cluster-health.yaml: {}
  ../tests/goss-kea-has-active-dhcp-leases.yaml: {}
  ../tests/goss-resolve-external.dns.yaml: {}

## HMS

## CMS

## UAI

ncn-m001:/opt/cray/tests/install/ncn/tests # SW_ARUBA_PASSWORD=\!nitial0 SW_MELLANOX_PASSWORD=\!nitial0 GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/suites/validate-cms-health.yaml  --vars /opt/cray/tests/install/ncn/vars/variables-livecd.yaml validate
.........

Total Duration: 1.722s
Count: 9, Failed: 0, Skipped: 0
```