### PR TITLE
CASMPET-4654:  Add test to check for completion of the keycloak-users-localize job

### DIFF
--- a/goss-testing/automated/run-ncn-tests.sh
+++ b/goss-testing/automated/run-ncn-tests.sh
@@ -29,6 +29,9 @@ function k8s_local_tests {
   echo "Test Name: Kubernetes Nodes Have Valid Age"
   /usr/bin/goss -g $GOSS_BASE/tests/goss-k8s-nodes-age-valid.yaml v
   echo
+  echo "Test Name: Keycloak Users Localize Is Complete"
+  /usr/bin/goss -g $GOSS_BASE/tests/goss-k8s-keycloak-localize-job-completed.yaml v
+  echo
 }
 
 function run_ncn_tests {

--- a/goss-testing/tests/ncn/goss-k8s-keycloak-localize-job-completed.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-keycloak-localize-job-completed.yaml
@@ -1,0 +1,11 @@
+# Copyright 2014-2021 Hewlett Packard Enterprise Development LP
+command:
+  keycloak_users_localize_job_completed:
+    title: Keycloak Users Localize Job Completed 
+    meta:
+      desc: If this test fails, see /usr/share/doc/csm/troubleshooting/known_issues/craycli_403_forbidden_errors.md 
+      sev: 0
+    exec: kubectl -n services wait --for=condition=complete --timeout=3s job/`kubectl -n services get jobs | grep users-localize | awk '{print $1}'` 
+    exit-status: 0
+    timeout: 10000
+    skip: false


### PR DESCRIPTION
This test runs at the beginning of ncn-kubernetes-check to make sure that the keycloak-users-localize job is not stuck.   If it fails, the description directs to look at the runbook for this known issue in docs-csm (CASMINST-2242).

Tested this on surtur where the known issue was seen.   Tested both while the job was stuck and after the workaround was applied.