### PR TITLE
CASMPET-4668 CASMPET-4669 CASMPET-4678 : Add test for kea leases, resolving external dns and monitoring URL access

### DIFF
--- a/goss-testing/suites/validate-csm-health.yaml
+++ b/goss-testing/suites/validate-csm-health.yaml
@@ -1,0 +1,16 @@
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+gossfile:
+## Platform services
+  ../tests/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml: {}
+  ../tests/goss-spire-healthcheck.yaml: {}
+  ../tests/goss-k8s-vault-cluster-health.yaml: {}
+  ../tests/goss-k8s-kea-has-active-dhcp-leases.yaml: {}
+  ../tests/goss-k8s-resolve-external-dns.yaml: {}
+  ../tests/goss-k8s-monitoring-url.yaml: {}
+
+## HMS
+
+## CMS
+
+## UAI
+

--- a/goss-testing/tests/ncn/goss-k8s-kea-has-active-dhcp-leases.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-kea-has-active-dhcp-leases.yaml
@@ -1,0 +1,31 @@
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+command:
+  kea_has_active_dhcp_leases:
+    title: Kea has Active DHCP Leases
+    meta:
+      desc: Validates KEA has active DHCP leases. If the test fails, no leases were found. Check the DHCP Troubleshooting guide.
+      sev: 0
+    exec: |-
+          TOKEN=$(curl -s -S -d grant_type=client_credentials \
+                 -d client_id=admin-client \
+                 -d client_secret=`kubectl get secrets admin-client-auth \
+                 -o jsonpath='{.data.client-secret}' | base64 -d` \
+                  https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+          if [[ ! $TOKEN ]]; then
+             echo "Unable to get a token; unable to check Kea for active DHCP Leases"
+             exit 1
+          fi
+          LEASES=$(curl -s -S -H "Authorization: Bearer ${TOKEN}" -X POST -H "Content-Type: application/json" \
+                 -d '{ "command": "lease4-get-all", "service": [ "dhcp4" ] }' https://api-gw-service-nmn.local/apis/dhcp-kea \
+                 | jq -r '.[] | .text' | cut -d ' ' -f 1)
+
+          if [[ ! $LEASES -ge 1 ]]; then
+            echo "Kea has no active DHCP Leases"
+            exit 1
+          fi
+          echo "PASS"
+    exit-status: 0
+    stdout:
+      - PASS
+    timeout: 10000
+    skip: false

--- a/goss-testing/tests/ncn/goss-k8s-monitoring-url.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-monitoring-url.yaml
@@ -1,0 +1,74 @@
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+# example HOST=gamora.dev.cray.com
+http:
+  https://grafana.{{.Env.HOST}}/:
+    title: Grafana URL access
+    meta:
+      desc: Checks whether URL https://grafana.{{.Env.HOST}}/ is accessible. If the test fails, expected 200 status was not returned. Check the System Management Health information in the Operations section.
+      sev: 0
+    # required attributes
+    status: 200
+    # optional attributes
+    allow-insecure: false
+    no-follow-redirects: false # Setting this to true will NOT follow redirects
+    timeout: 1000
+
+  https://prometheus.{{.Env.HOST}}/:
+    title: Prometheus URL access
+    meta:
+      desc: Checks whether URL https://prometheus.{{.Env.HOST}}/ is accessible. If the test fails, expected 200 status was not returned. Check the System Management Health information in the Operations section.
+      sev: 0
+    # required attributes
+    status: 200
+    # optional attributes
+    allow-insecure: false
+    no-follow-redirects: false # Setting this to true will NOT follow redirects
+    timeout: 1000
+
+  https://alertmanager.{{.Env.HOST}}/:
+    title: Alertmanager URL access
+    meta:
+      desc: Checks whether URL https://alertmanager.{{.Env.HOST}}/ is accessible. If the test fails, expected 200 status was not returned. Check the System Management Health information in the Operations section.
+      sev: 0
+    # required attributes
+    status: 200
+    # optional attributes
+    allow-insecure: false
+    no-follow-redirects: false # Setting this to true will NOT follow redirects
+    timeout: 1000
+
+  https://kiali-istio.{{.Env.HOST}}/:
+    title: Kiali-istio URL access
+    meta:
+      desc: Checks whether URL https://kiali-istio.{{.Env.HOST}}/ is accessible. If the test fails, expected 200 status was not returned. Check the System Management Health information in the Operations section.
+      sev: 0
+    # required attributes
+    status: 200
+    # optional attributes
+    allow-insecure: false
+    no-follow-redirects: false # Setting this to true will NOT follow redirects
+    timeout: 1000
+
+  https://jaeger-istio.{{.Env.HOST}}/:
+    title: Jaeger-istio URL access
+    meta:
+      desc: Checks whether URL https://jaeger-istio.{{.Env.HOST}}/ is accessible. If the test fails, expected 200 status was not returned. Check the System Management Health information in the Operations section.
+      sev: 0
+    # required attributes
+    status: 200
+    # optional attributes
+    allow-insecure: false
+    no-follow-redirects: false # Setting this to true will NOT follow redirects
+    timeout: 1000
+
+  https://prometheus-istio.{{.Env.HOST}}/:
+    title: Prometheus-istio URL access
+    meta:
+      desc: Checks whether URL https://prometheus-istio.{{.Env.HOST}}/ is accessible. If the test fails, expected 200 status was not returned. Check the System Management Health information in the Operations section.
+      sev: 0
+    # required attributes
+    status: 200
+    # optional attributes
+    allow-insecure: false
+    no-follow-redirects: false # Setting this to true will NOT follow redirects
+    timeout: 1000

--- a/goss-testing/tests/ncn/goss-k8s-resolve-external-dns.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-resolve-external-dns.yaml
@@ -1,0 +1,13 @@
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+command:
+  resolve_external_dns:
+    title: Resolve external DNS
+    meta:
+      desc: Validates external DNS name is resolvable. If the test fails, cray.com was not resolvable. Check the External DNS Troubleshooting guide.
+      sev: 0
+    exec: "nslookup cray.com | grep cray.com -A 1 | grep Address"
+    exit-status: 0
+    stdout:
+      - /^Address.*/
+    timeout: 10000
+    skip: false


### PR DESCRIPTION
Resolves:
CASMPET-4668: Automate a check to verify that KEA has active DHCP leases
CASMPET-4669: Automate a check to verify the ability to resolve external DNS
CASMPET-4678: Automate a check for system management monitoring tools - URLs are accessible

Adds the above tests to the validate-csm-health.yaml suite

Tested on gamora and vshasta