### PR TITLE
CASMPET-4997 master : refactor goss-k8s-resolve-external-dns.yaml for airgapped

### DIFF
--- a/goss-testing/suites/ncn-healthcheck-master.yaml
+++ b/goss-testing/suites/ncn-healthcheck-master.yaml
@@ -22,3 +22,4 @@ gossfile:
   ../tests/goss-check-clock-skew.yaml: {}
   ../tests/goss-k8s-psp-enabled.yaml: {}
   ../tests/goss-platform-ca-certs-match-cloud-init.yaml: {}
+  ../tests/goss-k8s-resolve-external-dns.yaml: {}

--- a/goss-testing/suites/ncn-healthcheck-worker.yaml
+++ b/goss-testing/suites/ncn-healthcheck-worker.yaml
@@ -18,3 +18,4 @@ gossfile:
   ../tests/goss-default-gateway-points-to-CAN-gateway.yaml: {}
   ../tests/goss-cray-service-etcd-health-check.yaml: {}
   ../tests/goss-platform-ca-certs-match-cloud-init.yaml: {}
+  ../tests/goss-k8s-resolve-external-dns.yaml: {}

--- a/goss-testing/suites/validate-csm-health.yaml
+++ b/goss-testing/suites/validate-csm-health.yaml
@@ -5,7 +5,6 @@ gossfile:
   ../tests/goss-spire-healthcheck.yaml: {}
   ../tests/goss-k8s-vault-cluster-health.yaml: {}
   ../tests/goss-k8s-kea-has-active-dhcp-leases.yaml: {}
-  ../tests/goss-k8s-resolve-external-dns.yaml: {}
   ../tests/goss-k8s-monitoring-url.yaml: {}
 
 ## HMS

--- a/goss-testing/tests/ncn/goss-k8s-resolve-external-dns.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-resolve-external-dns.yaml
@@ -3,11 +3,53 @@ command:
   resolve_external_dns:
     title: Resolve external DNS
     meta:
-      desc: Validates external DNS name is resolvable. If the test fails, cray.com was not resolvable. Check the External DNS Troubleshooting guide.
+      desc: Validates external DNS name resolves. If the test fails, the configured LDAP server was not pingable. Refer to 'operations/network/dns/Troubleshoot_Common_DNS_Issues.md' to troubleshoot external DNS issues.
       sev: 0
-    exec: "nslookup cray.com | grep cray.com -A 1 | grep Address"
+    exec: |-
+          # External DNS resolution is best tested by checking if the configured LDAP server is pingable.
+          # Pass if the test requirements are not met:
+          # - Unbound forward-addr is not configured.
+          # - LDAP providerId is not configured.
+          # Fail if the LDAP providerId is configured but the LDAP connectionURL is not.
+          # Pass/Fail based on exit code from ping of the LDAP server.
+
+          function get_master_token {
+
+              MASTER_USERNAME=$(kubectl get secret -n services keycloak-master-admin-auth -ojsonpath='{.data.user}' | base64 -d)
+              MASTER_PASSWORD=$(kubectl get secret -n services keycloak-master-admin-auth -ojsonpath='{.data.password}' | base64 -d)
+
+              curl -ks -d client_id=admin-cli -d username=$MASTER_USERNAME -d password=$MASTER_PASSWORD \
+                   -d grant_type=password https://api-gw-service-nmn.local/keycloak/realms/master/protocol/openid-connect/token | jq -r '.access_token'; 
+           }
+   
+           FORWARD_ADDR=$(kubectl -n services get cm cray-dns-unbound -o jsonpath='{.data.unbound\.conf}' \
+                          | grep "forward-zone:" -A 5 | yq r  - '"forward-zone"."forward-addr"')
+
+           LDAP_PROVIDER=$(curl -s -H "Authorization: Bearer $(get_master_token)" \
+                          https://api-gw-service-nmn.local/keycloak/admin/realms/shasta/components | jq -r '.[] | select(.providerId=="ldap")')
+
+           if [[ ! $FORWARD_ADDR ]]; then 
+              echo "Unbound must be configured for this test."
+              exit 0
+           fi
+
+           if [[ ! $LDAP_PROVIDER ]]; then 
+              echo "LDAP must be configured for this test."
+              exit 0
+           fi
+
+           echo "Unbound and LDAP are configured" 
+           CONNECTION_URL=$(curl -s -H "Authorization: Bearer $(get_master_token)" \
+                        https://api-gw-service-nmn.local/keycloak/admin/realms/shasta/components \
+                        | jq -r '.[] | select(.providerId=="ldap").config.connectionUrl[]' | cut -d / -f 3)
+
+           if [[ ! $CONNECTION_URL ]]; then
+              echo "LDAP provider is configured, but the connectionURL is missing from LDAP configuration."
+              exit 1
+           else
+              ping -q -c 1 $CONNECTION_URL
+           fi 
+
     exit-status: 0
-    stdout:
-      - /^Address.*/
     timeout: 10000
     skip: false


### PR DESCRIPTION
## Summary and Scope
CASMPET-4997 

AUTOMATION: refactor goss-k8s-resolve-external-dns.yaml for airgapped
Determine if unbound and LDAP are configured - if so, test if the LDAP server is resolveable/pingable.
In addition, move the test to the existing ncn-healthchecks for masters and workers.

## Issues and Related PRs
Resolves

CASMPET-4997 for master
## Testing
Tested on:

vshasta and shandy (1.0)
TBD wasp (1.2)
Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) NA
Was a fresh Install tested? Y/N If not, Why? NA
Was an Upgrade tested? Y/N If not, Why? NA
Was a Downgrade tested? Y/N. If not, Why? NA
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?

## Risks and Mitigations
Requires:
NA