### PR TITLE
CASMINST-3349 dowload initrd and name it correctly based on what is found in grub

### DIFF
--- a/goss-testing/scripts/validate-bootraid-artifacts-lib.sh
+++ b/goss-testing/scripts/validate-bootraid-artifacts-lib.sh
@@ -2,9 +2,9 @@
 set -eu
 set -o pipefail
 
-ARTIFACT_PATH="${1}"
+ARTIFACT_S3_PATH="${1}"
 
-if [[ -z ${ARTIFACT_PATH} ]]; then
+if [[ -z ${ARTIFACT_S3_PATH} ]]; then
 	echo "Path to a kernel or initrd in S3 is required as an argument"
 	# shellcheck disable=SC2154 # this is just an example command
 	echo "Try 'cray bss bootparameters list --hosts ${xname} | awk '/kernel = /'"
@@ -33,7 +33,7 @@ fi
 cleanup() {
 	if ! eval pit_check; then
 		if eval mount | grep "${BOOTRAID}" >/dev/null; then
-			umount $BOOTRAID
+			umount "${BOOTRAID}"
 		fi
 	fi
 
@@ -54,6 +54,7 @@ mount_bootraid() {
 }
 
 expected_initrd_name() {
+  local expected_name=""
 	# find the name the grub config expects
 	expected_name=$(grep initrdefi "${BOOTRAID}"/boot/grub2/grub.cfg | awk '{print $2}' | awk -F'/' '{print $NF}')
 	echo "${expected_name}"
@@ -62,21 +63,34 @@ expected_initrd_name() {
 get_artifact_from_s3() {
 	local artifact="${1}"
 	local path="${2}"
+  local liveos=/run/initramfs/live/LiveOS
 
 	mount_bootraid
 
-	echo "Getting $(basename ${artifact}) from s3 (${path})..."
-	curl -s -o ${artifact} http://rgw-vip.nmn/"${path/s3:\/\/}"
+	echo "Getting $(basename "${artifact}") from s3 (${path})..."
+	curl -s -o "${artifact}" http://rgw-vip.nmn/"${path/s3:\/\/}"
+
+  if ! check_boot_artifact "${artifact}"; then
+    echo "${artifact} is not a valid file type.  Is S3 working?"
+    echo "Copying local artifacts from ${liveos}/$(basename "${artifact}")"
+
+    if ! cp "${liveos}/$(basename "${artifact}")" "${artifact}"; then
+      echo "Unable to find a valid artifact"
+      exit 1
+    fi
+  
+  fi
 
 	REBOOT_NEEDED="true"
 }
 
 check_boot_artifact() {
 	local artifact="$1"
-	# check if the filesize is bigger than 217 (that is the size of an XML error message from s3)
+	# check if the filesize is bigger than 92 or 217 (that is the size of an XML error message from s3)
 	# or check if this is a filetype we expect for a kernel or initrd
-	if ! [[ "$(stat --format=%s $f)" -gt 217 ]] || ! [[ "$(file --brief --mime-type $f)" == application/octet-stream ]]; then
-		echo -e "\n${f} size is too small or not an expected file type ($(stat --format=%s $f):$(file --brief --mime-type $f))"
+	if ! [[ $(stat --format=%s "${artifact}") -gt 92 ]] || \
+    ! [[ $(stat --format=%s "${artifact}") -gt 217 ]] ||
+    ! [[ $(file --brief --mime-type "${artifact}") == application/octet-stream ]]; then
 		return 1
 	else
 		return 0
@@ -86,12 +100,12 @@ check_boot_artifact() {
 # mount the raid
 mount_bootraid
 
-if [[ "${ARTIFACT_PATH}" == *kernel* ]]; then
+if [[ "${ARTIFACT_S3_PATH}" == *kernel* ]]; then
 	printf "Examining kernel..."
 	f="${BOOTRAID}/boot/kernel"
-elif [[ "${ARTIFACT_PATH}" == *initrd* ]]; then
+elif [[ "${ARTIFACT_S3_PATH}" == *initrd* ]]; then
 	printf "Examining initrd..."
-	f="${BOOTRAID}/boot/initrd.img.xz"
+	f="${BOOTRAID}/boot/$(expected_initrd_name)"
 else
 	printf "Unknown artifact for this script."
 	exit 1
@@ -104,32 +118,35 @@ if [[ -f "${f}" ]]; then
 	# if the file is bad
 	if ! eval check_boot_artifact "${f}"; then
 
+    echo -e "\n${f} size is too small or not an expected file type ($(stat --format=%s "${f}"):$(file --brief --mime-type "${f}"))"
+
+    echo "Removing faulty file (${f})"
 		# remove the problematic file
 		rm -f "${f}"
 
 		# then get a known-good artifact from the path discovered in s3
-		get_artifact_from_s3 "${f}" "${ARTIFACT_PATH}"
+		get_artifact_from_s3 "${f}" "${ARTIFACT_S3_PATH}"
 
-		if [[ $(basename ${f}) == *initrd* ]]; then
+		if [[ $(basename "${f}") == *initrd* ]]; then
 			# Modify the filename if grub is expecting something else
 			# Sometimes it was named initrd, other times it has been initrd.img.xz
-			if [[ $(basename ${f}) != $(expected_initrd_name) ]]; then
-				echo mv "${f}" "$(dirname ${f})/$(expected_initrd_name)"
+			if [[ $(basename "${f}") != $(expected_initrd_name) ]]; then
+				echo mv "${f}" "$(dirname "${f}")/$(expected_initrd_name)"
 			fi
 
 		fi
 
 	else
 
-		printf "$(basename ${f}) is OK.\n"
+		printf '%s is OK.\n' "$(basename "${f}")"
 
 	fi
 
 else
 
-	echo "$(basename ${f}) not found in BOOTRAID."
+	echo '%s not found in BOOTRAID.' "$(basename "${f}")"
 
-	get_artifact_from_s3 "${f}" "${ARTIFACT_PATH}"
+	get_artifact_from_s3 "${f}" "${ARTIFACT_S3_PATH}"
 
 fi
 


### PR DESCRIPTION


Prior to this, a hardcode of initrd.img.xz happened to be in place.  This name
varies across vintages of csm so this accounts for both by checking what is
expected by grub.

These changes also attempt to cp the local artifact from
/run/initramfs/live/LiveOS in the event S3 is unavailable.  If that fails, the
script fails.

The artifact from S3 is also now checked immediately after downloading it to ensure it meets the requirements.

The script produces new output:

```
==> ncn-w003...
validate-bootraid-artifacts-lib.sh                                                                        100% 3956     5.1MB/s   00:00
Examining kernel...kernel is OK.
Examining initrd...
/metal/recovery/boot/initrd size is too small or not an expected file type (92:text/html)
Removing faulty file (/metal/recovery/boot/initrd)
Getting initrd from s3 (s3://ncn-images/k8s/0.1.109/initrd)...
/metal/recovery/boot/initrd is not a valid file type.  Is S3 working?
Attempting to copy local artifacts from /run/initramfs/live/LiveOS/initrd
The new on-disk boot artifacts will not take effect until a restart of the machine.
==> ncn-w001...
validate-bootraid-artifacts-lib.sh                                                                        100% 3956     6.6MB/s   00:00
Examining kernel...kernel is OK.
Examining initrd...initrd is OK.
```

Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>