### PR TITLE
CASMINST-3417: remove bogus curl call

### DIFF
--- a/goss-testing/automated/livecd-preflight-checks
+++ b/goss-testing/automated/livecd-preflight-checks
@@ -1,5 +1,3 @@
-curl -H "X-JFrog-Art-API:AKCp8jQd48jCCgaZVxFzNLdXCqLHTLJkTMd1jTKX3jNVGtgWFoP4GCtPmbLWSPcTHXNjuSndB" -X POST "http://localhost:8081/artifactory/api/system/decrypt"
-
 #!/usr/bin/env bash
 #
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP.


### PR DESCRIPTION
The original author of this line of code can't recall its purpose,
and it has no obvious discernible purpose on the face of it. Further,
it fails when invoked because this reaches out to nexus, not arti,
and nexus has no idea what to do with that attempted endpoint/api
reference, generating obnoxious error/warning spew. This commit
removes the mystery curl.