### PR TITLE
CASMPET-5132 : Create a no-wipe test

### DIFF
--- a/goss-testing/automated/ncn-healthcheck-master
+++ b/goss-testing/automated/ncn-healthcheck-master
@@ -33,8 +33,10 @@ if [ -f "/etc/dnsmasq.d/statics.conf" ]; then
   cat /etc/dnsmasq.d/statics.conf | grep -ohE "ncn-[m]([0-9]{3})" | grep -v ncn-m001 | awk '!a[$0]++' | \
     while read node ; do run_ncn_tests "$node" "8994" "ncn-healthcheck-master" ; done
 else
-  cat /etc/hosts | grep -ohE "ncn-[m]([0-9]{3})" | awk '!a[$0]++' | while read node ; do run_ncn_tests "$node" "8994" \
-    "ncn-healthcheck-master" ; done
+  cat /etc/hosts | grep -ohE "ncn-[m]([0-9]{3})" | awk '!a[$0]++' | while read node ; do \
+    run_ncn_tests "$node" "8994" "ncn-healthcheck-master" ; \
+    run_ncn_tests "$node" "9004" "ncn-afterpitreboot-healthcheck-master" ; \
+    done
 fi
 
 exit

--- a/goss-testing/automated/ncn-healthcheck-storage
+++ b/goss-testing/automated/ncn-healthcheck-storage
@@ -33,8 +33,10 @@ if [ -f "/etc/dnsmasq.d/statics.conf" ]; then
   cat /etc/dnsmasq.d/statics.conf | grep -ohE "ncn-[s]([0-9]{3})" | grep -v ncn-m001 | awk '!a[$0]++' | \
     while read node ; do run_ncn_tests "$node" "9001" "ncn-healthcheck-storage" ; done
 else
-  cat /etc/hosts | grep -ohE "ncn-[s]([0-9]{3})" | awk '!a[$0]++' | while read node ; do run_ncn_tests "$node" "9001" \
-    "ncn-healthcheck-storage" ; done
+  cat /etc/hosts | grep -ohE "ncn-[s]([0-9]{3})" | awk '!a[$0]++' | while read node ; do \
+    run_ncn_tests "$node" "9001" "ncn-healthcheck-storage" ; \
+    run_ncn_tests "$node" "9006" "ncn-afterpitreboot-healthcheck-storage" ; \
+    done
 fi
 
 exit

--- a/goss-testing/automated/ncn-healthcheck-worker
+++ b/goss-testing/automated/ncn-healthcheck-worker
@@ -33,8 +33,10 @@ if [ -f "/etc/dnsmasq.d/statics.conf" ]; then
   cat /etc/dnsmasq.d/statics.conf | grep -ohE "ncn-[w]([0-9]{3})" | grep -v ncn-m001 | awk '!a[$0]++' | \
     while read node ; do run_ncn_tests "$node" "9000" "ncn-healthcheck-worker" ; done
 else
-  cat /etc/hosts | grep -ohE "ncn-[w]([0-9]{3})" | awk '!a[$0]++' | while read node ; do run_ncn_tests "$node" "9000" \
-    "ncn-healthcheck-worker" ; done
+  cat /etc/hosts | grep -ohE "ncn-[w]([0-9]{3})" | awk '!a[$0]++' | while read node ; do \
+    run_ncn_tests "$node" "9000" "ncn-healthcheck-worker" ; \
+    run_ncn_tests "$node" "9005" "ncn-afterpitreboot-healthcheck-worker" ; \
+    done
 fi
 
 # Specify the switch passwords and call the switch BGP neighbors tests.

--- a/goss-testing/scripts/check_no_wipe_flag.sh
+++ b/goss-testing/scripts/check_no_wipe_flag.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+
+function get_token() {
+  cnt=0
+  TOKEN=""
+  endpoint="https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token"
+  client_secret=$(kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d)
+  while [ "$TOKEN" == "" ]; do
+    cnt=$((cnt+1))
+    TOKEN=$(curl -k -s -S -d grant_type=client_credentials -d client_id=admin-client -d client_secret=$client_secret $endpoint)
+    if [[ "$TOKEN" == *"error"* ]]; then
+      TOKEN=""
+      if [ "$cnt" -eq 5 ]; then
+        break
+      fi
+      sleep 5
+    else
+      TOKEN=$(echo $TOKEN | jq -r '.access_token')
+      break
+    fi
+  done
+  echo $TOKEN
+}
+
+no_wipe_status() {
+    echo "Note that before the PIT node has been rebooted into ncn-m001,"
+    echo "metal.no-wipe status may not available which will cause this test to fail."
+    noWipeFail=0
+    export TOKEN=$(get_token)
+    if [[ -z $TOKEN ]]
+    then
+        echo "Failed to get token, skipping metal.no-wipe checks."
+        noWipeFail=2
+    fi
+
+    xName=$(cat /etc/cray/xname)
+    if [[ -z $xName ]]
+    then
+        echo "Failed to obtain xname, skipping metal.no-wipe checks."
+        noWipeFail=2
+    fi
+
+    if [[ $noWipeFail -eq 0 ]]
+    then
+        noWipe=""
+        iter=0
+        # Because we're using bootparameters instead of bootscript, this loop is likely no longer
+        # necessary. However, it also doesn't hurt to have it.
+        while [[ -z $noWipe && $iter -lt 5 ]]; do
+            noWipe=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" "https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters?name=${xName}" | grep -o "metal.no-wipe=[01]")
+            if [[ -z $noWipe ]]; then sleep 3; fi
+            iter=$(($iter + 1))
+        done
+        if [[ -z $noWipe ]]
+        then
+            noWipe='unavailable'
+            noWipeFail=1
+        else
+            noWipeVal=$(echo $noWipe | cut -d "=" -f2)
+            if [[ $noWipeVal -ne 1 ]]; then noWipeFail=1; fi
+        fi
+        echo "$xName - $noWipe"
+    fi
+
+    if [[ $noWipeFail -eq 1 ]]
+    then
+        echo " --- FAILED --- metal.no-wipe status is not 1. (note: node_status = upgrade/rebuild, then metal.no-wipe=0 is valid)";
+        failureMsg="FAIL: metal.no-wipe status is not 1 or unavailable. (note: node_status = upgrade/rebuild, then metal.no-wipe=0 is valid)."
+        exit_code=1
+    elif [[ $noWipeFail -eq 2 ]]
+    then
+        echo " --- FAILED --- Failed to get token or xname."
+        failureMsg="FAIL: Failed to get token or xname, skipped metal.no-wipe check. Could not verify no-wipe status."
+        exit_code=2
+    else
+        echo " --- PASSED ---"
+        exit_code=0
+    fi
+
+    exit $exit_code
+}
+
+no_wipe_status

--- a/goss-testing/suites/ncn-afterpitreboot-healthcheck-master.yaml
+++ b/goss-testing/suites/ncn-afterpitreboot-healthcheck-master.yaml
@@ -1,0 +1,3 @@
+# Copyright 2014-2021 Hewlett Packard Enterprise Development LP
+gossfile:
+  ../tests/goss-boot-parameter-check-no-wipe.yaml: {}

--- a/goss-testing/suites/ncn-afterpitreboot-healthcheck-storage.yaml
+++ b/goss-testing/suites/ncn-afterpitreboot-healthcheck-storage.yaml
@@ -1,0 +1,3 @@
+# Copyright 2014-2021 Hewlett Packard Enterprise Development LP
+gossfile:
+  ../tests/goss-boot-parameter-check-no-wipe.yaml: {}

--- a/goss-testing/suites/ncn-afterpitreboot-healthcheck-worker.yaml
+++ b/goss-testing/suites/ncn-afterpitreboot-healthcheck-worker.yaml
@@ -1,0 +1,3 @@
+# Copyright 2014-2021 Hewlett Packard Enterprise Development LP
+gossfile:
+  ../tests/goss-boot-parameter-check-no-wipe.yaml: {}

--- a/goss-testing/tests/ncn/goss-boot-parameter-check-no-wipe.yaml
+++ b/goss-testing/tests/ncn/goss-boot-parameter-check-no-wipe.yaml
@@ -1,0 +1,11 @@
+# Copyright 2014-2021 Hewlett Packard Enterprise Development LP
+command:
+  boot_parameter_check_no_wipe:
+    title: Check Boot Parameter is Set to Not Wipe the Disk (metal.no-wipe=1)
+    meta:
+      desc: If this test fails, run `csi handoff bss-update-param --set metal.no-wipe=1 --limit <SERVER_XNAME>` to set metal.no-wipe to 1. This test is not meant to be run if the PIT has not been rebooted into m001 or if metal.no-wipe has been set to 0 for a node image upgraded.
+      sev: 0
+    exec: "{{.Env.GOSS_BASE}}/scripts/check_no_wipe_flag.sh"
+    exit-status: 0
+    timeout: 30000
+    skip: false

--- a/start-goss-servers.sh
+++ b/start-goss-servers.sh
@@ -2,7 +2,6 @@
 # Goss server start up commands to serve health check endpoints
 #
 # (C) Copyright 2020 Hewlett Packard Enterprise Development LP.
-# Author: Forrest Jadick
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -81,7 +80,7 @@ ip=$(host $(hostname).hmn | grep -Po '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{
 [[ -z $ip ]] && exit 2
 
 # start servers with NCN test suites
-# designated goss-servers port range: 8994-9002
+# designated goss-servers port range: 8994-9006
 
 echo "starting ncn-preflight-tests in background"
 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-preflight-tests.yaml --vars $tmpvars serve \
@@ -145,6 +144,27 @@ nohup /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-spire-healthchecks
   --max-concurrent 4 \
   --endpoint /ncn-spire-healthchecks \
   --listen-addr $ip:9003 &
+
+echo "starting ncn-afterpitreboot-healthcheck-master in background"
+nohup /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-healthcheck-master.yaml --vars $tmpvars serve \
+  --format json \
+  --max-concurrent 4 \
+  --endpoint /ncn-afterpitreboot-healthcheck-master \
+  --listen-addr $ip:9004 &
+
+echo "starting ncn-afterpitreboot-healthcheck-worker in background"
+nohup /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-healthcheck-worker.yaml --vars $tmpvars serve \
+  --format json \
+  --max-concurrent 4 \
+  --endpoint /ncn-afterpitreboot-healthcheck-worker \
+  --listen-addr $ip:9005 &
+
+echo "starting ncn-afterpitreboot-healthcheck-storage in background"
+nohup /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-healthcheck-storage.yaml --vars $tmpvars serve \
+  --format json \
+  --max-concurrent 4 \
+  --endpoint /ncn-afterpitreboot-healthcheck-storage \
+  --listen-addr $ip:9006 &
 
 echo "Goss servers started in background"
 


### PR DESCRIPTION
Resolves for master
* CASMPET-5132 : Create a no-wipe test 
* Adds suites & servers to handle tests that can only be run afterpitreboot

Tested on fanta (1.0) and wasp (1.2)