### PR TITLE
CASMPET-5128 : Remove spire healthcheck from PIT node storage check

### DIFF
--- a/goss-testing/suites/ncn-afterpitreboot-healthcheck-storage.yaml
+++ b/goss-testing/suites/ncn-afterpitreboot-healthcheck-storage.yaml
@@ -1,3 +1,4 @@
 # Copyright 2014-2021 Hewlett Packard Enterprise Development LP
 gossfile:
   ../tests/goss-boot-parameter-check-no-wipe.yaml: {}
+  ../tests/goss-storage-spire-healthcheck.yaml: {}

--- a/goss-testing/suites/ncn-healthcheck-storage.yaml
+++ b/goss-testing/suites/ncn-healthcheck-storage.yaml
@@ -9,4 +9,3 @@ gossfile:
   ../tests/goss-bond-members-have-correct-mtu.yaml: {}
   ../tests/goss-dns-nodes.yaml: {}
   ../tests/goss-default-gateway-points-to-CAN-gateway.yaml: {}
-  ../tests/goss-storage-spire-healthcheck.yaml: {}


### PR DESCRIPTION
Resolves for csm-1.2:
* CASMPET-5128 : Remove spire healthcheck from PIT node storage check