### PR TITLE
Reconcile missed master items by adding to release/1.2 first

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,13 @@
+name: backport
+
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  backport:
+    runs-on: self-hosted
+    if: github.event.issue.pull_request
+    steps:
+      - uses: Cray-HPE/backport-command-action@main


### PR DESCRIPTION
This PR brings back missed items from the offline attempt of syncing master.