### PR TITLE
Workflow for blocking merge commits

### DIFF
--- a/.github/workflows/merge-strategy.yml
+++ b/.github/workflows/merge-strategy.yml
@@ -1,0 +1,17 @@
+name: Merge Strategy
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  message-check:
+    name: Block Merge Commits
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Block Merge Commits
+        uses: Morishiri/block-merge-commits-action@v1.0.1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Prevents merge commits from sneaking their way in, making it hard to diff master/main and release branches.

