### PR TITLE
CASMINST-4001: Add tests to check static routes on workers and storage nodes.

### DIFF
--- a/goss-testing/suites/ncn-kubernetes-tests-worker.yaml
+++ b/goss-testing/suites/ncn-kubernetes-tests-worker.yaml
@@ -24,6 +24,7 @@
 # This test suite is run during CSM installs before CSM services are deployed
 
 gossfile:
+  ../tests/goss-check-static-routes.yaml: {}
   ../tests/goss-weave-IPAM-health.yaml: {}
   ../tests/goss-k8s-pods-ips-in-nmn-pool.yaml: {}
   ../tests/goss-ceph-csi-k8s-requirements.yaml: {}

--- a/goss-testing/suites/ncn-storage-tests.yaml
+++ b/goss-testing/suites/ncn-storage-tests.yaml
@@ -27,3 +27,4 @@ gossfile:
   ../tests/goss-ceph-csi-storage-node-requirements.yaml: {}
   ../tests/goss-ceph-storage-health.yaml: {}
   ../tests/goss-ceph-storage-services.yaml: {}
+  ../tests/goss-check-static-routes.yaml: {}


### PR DESCRIPTION

## Summary and Scope

This adds tests that are run on workers and storage nodes after the nodes have been deployed in fresh install (csi pit validate --ceph and csi pit validate --k8s) and after they are upgraded.

## Issues and Related PRs

* Resolves CASMINST-4001
* Related to CASMINST-3828

## Testing


### Tested on:

  * `fanta`

### Test description:

Ran `csi pit validate --ceph` and `csi pit validate --k8s` to test fresh install
Ran `ncn-upgrade-tests-storage.yaml` and `ncn-upgrade-tests-storage.yaml` to test upgrades.

Verified that the new test shows up in the output and passes.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

