### PR TITLE
CASMINST-4030 master : TESTS - Kubernetes Postgresql Check that Automated Backups are Working

### DIFF
--- a/goss-testing/scripts/postgresql_backups_check.sh
+++ b/goss-testing/scripts/postgresql_backups_check.sh
@@ -1,4 +1,25 @@
 #!/bin/bash
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
 
 print_results=0
 while getopts ph stack
@@ -60,12 +81,14 @@ do
 
     # NameSpace and PostgreSQL cluster name
     c_ns="$(echo $c | awk -F, '{print $1;}')"
-    c_name="$(echo $c | awk -F, '{print $2;}')"
-    c_name=${c_name%"ql-db-backup"}     # remove suffix 'ql-db-backup'
-    c_name=${c_name#"cray-"}            # remove prefix 'cray-'
+    c_cronjob_name="$(echo $c | awk -F, '{print $2;}')"
+    c_name=${c_cronjob_name%"ql-db-backup"}     # remove suffix 'ql-db-backup'
+    c_name=${c_name#"cray-"}                    # remove prefix 'cray-'
     c_name=$(kubectl get postgresql -n ${c_ns} | grep $c_name |awk '{print $1}')
 
-    c_age=$(kubectl get postgresql ${c_name} -n ${c_ns} -o jsonpath='{.metadata.creationTimestamp}')
+    # Base the c_age on the cronjob creation time instead of when the postgres resource was created.
+    # During upgrades, cronjobs may get re-created if they failed to start due to too many missed starts.
+    c_age=$(kubectl get cronjobs.batch ${c_cronjob_name} -n ${c_ns} -o jsonpath='{.metadata.creationTimestamp}')
     c_age_sec=$(date -d "${c_age}" "+%s")
 
     if [[ ! -z $c_age && ! -z $c_age_sec ]]


### PR DESCRIPTION
## Summary and Scope
During the csm 1.2 upgrade, cronjobs may get re-created because of too many failed attempts to start.
Postgresql cronjob based backup are expected to exist 24hr after the cluster is created. This window needs to be based on when the cronjobs were created (or re-created in the case of the upgrade) and not when the cluster was created.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix? Yes

## Issues and Related PRs

* Resolves [CASMINST-4030](issue link)
* Change will also be needed in `release/csm-1.2`
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

vshasta
drax 

### Tested on:

### Test description:

Verified on drax that the script passes as expected.  Some of the postgresql cronjobs had been re-created as part of the upgrade (but not all)

```
ncn-m001:~ # /tmp/kimj/postgresql_backups_check.sh -p
keycloak-postgres -- recent backup found: keycloak-postgres-2022-02-15T15:41:06.manifest
cray-sls-postgres is less than 24 hours old. Did not check if recent backups exist.
cray-smd-postgres is less than 24 hours old. Did not check if recent backups exist.
gitea-vcs-postgres is less than 24 hours old. Did not check if recent backups exist.
spire-postgres is less than 24 hours old. Did not check if recent backups exist.
PASS

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? NA
- Were continuous integration tests run? NA
- Was upgrade tested? NA
- Was downgrade tested? NA
- Were new tests (or test issues/Jiras) created for this change? NA

## Risks and Mitigations

low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

