### PR TITLE
CASMINST-4000

### DIFF
--- a/goss-testing/tests/common/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml
+++ b/goss-testing/tests/common/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml
@@ -24,9 +24,9 @@ command:
   bgp_neighbors_established:
     title: Switch BGP Neighbors
     meta:
-      desc: Validates connection to the BGP neighbors of a switch.
+      desc: Validates connection to the BGP neighbors of a switch.  If this test fails run 'canu validate network bgp --verbose' to see the status of all BGP neighbors.
       sev: 0
-    exec: canu validate network bgp --password {{.Env.SW_ADMIN_PASSWORD}}
+    exec: if $(kubectl -n metallb-system get cm metallb -o jsonpath='{.data.config}' | grep -q customer-management | wc-l); then     canu validate network bgp --network all --password ${SW_ADMIN_PASSWORD}; else     canu validate network bgp --network nmn --password ${SW_ADMIN_PASSWORD}; fi
     exit-status: 0
     stdout:
       - "!FAIL"

--- a/goss-testing/tests/common/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml
+++ b/goss-testing/tests/common/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml
@@ -26,7 +26,7 @@ command:
     meta:
       desc: Validates connection to the BGP neighbors of a switch.  If this test fails run 'canu validate network bgp --verbose' to see the status of all BGP neighbors.
       sev: 0
-    exec: if $(kubectl -n metallb-system get cm metallb -o jsonpath='{.data.config}' | grep -q customer-management | wc -l); then     canu validate network bgp --network all --password {{.Env.SW_ADMIN_PASSWORD}}; else     canu validate network bgp --network nmn --password {{.Env.SW_ADMIN_PASSWORD}}; fi
+    exec: if $(kubectl -n metallb-system get cm metallb -o jsonpath='{.data.config}' | grep -q customer-management | wc -l) -gt 1; then     canu validate network bgp --network all --password {{.Env.SW_ADMIN_PASSWORD}}; else     canu validate network bgp --network nmn --password {{.Env.SW_ADMIN_PASSWORD}}; fi
     exit-status: 0
     stdout:
       - "!FAIL"

--- a/goss-testing/tests/common/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml
+++ b/goss-testing/tests/common/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml
@@ -1,6 +1,6 @@
-# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP.
-#
 # MIT License
+#
+# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/goss-testing/tests/common/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml
+++ b/goss-testing/tests/common/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml
@@ -26,7 +26,7 @@ command:
     meta:
       desc: Validates connection to the BGP neighbors of a switch.  If this test fails run 'canu validate network bgp --verbose' to see the status of all BGP neighbors.
       sev: 0
-    exec: if $(kubectl -n metallb-system get cm metallb -o jsonpath='{.data.config}' | grep -q customer-management | wc-l); then     canu validate network bgp --network all --password {{.Env.SW_ADMIN_PASSWORD}}; else     canu validate network bgp --network nmn --password {{.Env.SW_ADMIN_PASSWORD}}; fi
+    exec: if $(kubectl -n metallb-system get cm metallb -o jsonpath='{.data.config}' | grep -q customer-management | wc -l); then     canu validate network bgp --network all --password {{.Env.SW_ADMIN_PASSWORD}}; else     canu validate network bgp --network nmn --password {{.Env.SW_ADMIN_PASSWORD}}; fi
     exit-status: 0
     stdout:
       - "!FAIL"

--- a/goss-testing/tests/common/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml
+++ b/goss-testing/tests/common/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml
@@ -1,6 +1,6 @@
-# MIT License
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
 #
-# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP.
+# MIT License
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/goss-testing/tests/common/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml
+++ b/goss-testing/tests/common/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml
@@ -26,7 +26,7 @@ command:
     meta:
       desc: Validates connection to the BGP neighbors of a switch.  If this test fails run 'canu validate network bgp --verbose' to see the status of all BGP neighbors.
       sev: 0
-    exec: if $(kubectl -n metallb-system get cm metallb -o jsonpath='{.data.config}' | grep -q customer-management | wc-l); then     canu validate network bgp --network all --password ${SW_ADMIN_PASSWORD}; else     canu validate network bgp --network nmn --password ${SW_ADMIN_PASSWORD}; fi
+    exec: if $(kubectl -n metallb-system get cm metallb -o jsonpath='{.data.config}' | grep -q customer-management | wc-l); then     canu validate network bgp --network all --password {{.Env.SW_ADMIN_PASSWORD}}; else     canu validate network bgp --network nmn --password {{.Env.SW_ADMIN_PASSWORD}}; fi
     exit-status: 0
     stdout:
       - "!FAIL"

--- a/goss-testing/tests/common/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml
+++ b/goss-testing/tests/common/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml
@@ -26,9 +26,10 @@ command:
     meta:
       desc: Validates connection to the BGP neighbors of a switch.  If this test fails run 'canu validate network bgp --verbose' to see the status of all BGP neighbors.
       sev: 0
-    exec: if $(kubectl -n metallb-system get cm metallb -o jsonpath='{.data.config}' | grep -q customer-management | wc -l) -gt 1; then     canu validate network bgp --network all --password {{.Env.SW_ADMIN_PASSWORD}}; else     canu validate network bgp --network nmn --password {{.Env.SW_ADMIN_PASSWORD}}; fi
+    exec: if $(kubectl -n metallb-system get cm metallb -o jsonpath='{.data.config}' | grep -q customer-management); then     canu validate network bgp --network all --password {{.Env.SW_ADMIN_PASSWORD}}; else     canu validate network bgp --network nmn --password {{.Env.SW_ADMIN_PASSWORD}}; fi
     exit-status: 0
     stdout:
       - "!FAIL"
     timeout: 20000
     skip: false
+ 


### PR DESCRIPTION
## Summary and Scope

BGP test now looks to see if the `customer management` network is configured in metallb.  If it is, CANU BGP test will run across all VRFS, if it's not it will only run the BGP test on the default VRF.  

## Issues and Related PRs

CASMINST-4000

## Testing

### Tested on:

Drax 1.0
Hela 1.2
### Test description:

Ran Goss test.  Both tests were successful.
