### PR TITLE
CASMINST-4161 adjust interface mac bond check test and fix shellcheck warnings

### DIFF
--- a/goss-testing/scripts/check_interface_mac_matches_bond.sh
+++ b/goss-testing/scripts/check_interface_mac_matches_bond.sh
@@ -44,7 +44,7 @@ function error
     rc=$1
     shift
     echo "ERROR: $*" 1>&2
-    exit $rc
+    exit "$rc"
 }
 
 # usage <exit code> <error message>
@@ -63,20 +63,22 @@ Exits 0 if this is the case. Exits non-0 if not, or if there are any errors.
 # cmdfail <script exit code> <command exit code> <command + args>
 function cmdfail
 {
-    error $1 "Command failed (exit code $2): $3"
+    error "$1" "Command failed (exit code $2): $3"
 }
 
-if [[ $# -eq 0 ]]; then
-    usage 5 "No interface specified"
-elif [[ $# -gt 1 ]]; then
-    usage 10 "Too many arguments"
-elif [[ -z $1 ]]; then
-    usage 15 "Interface argument may not be null"
-fi
+
 
 TMPFILE=/tmp/check_interface_mac_matches_bound.$$.$RANDOM.tmp
-INTERFACE="$1"
+INTERFACES=( "$@" )
 
+if [[ ${#INTERFACES[@]} -eq 0 ]]; then
+    usage 5 "No interface specified"
+elif [[ -z ${#INTERFACES[@]} ]]; then
+    usage 15 "Interface argument(s) may not be null"
+fi
+
+for INTERFACE in "${INTERFACES[@]}"
+do
 echo "Checking that MAC address of interface '$INTERFACE' matches MAC address of bond0..."
 echo
 
@@ -115,12 +117,13 @@ echo
 [[ -n $BND_MAC ]] || error 75 "No MAC address found for bond0"
 
 # Finally, validate that they match
-[[ $INT_MAC == $BND_MAC ]] || error 90 "MAC address of $INTERFACE does not match MAC address of bond0"
+[[ $INT_MAC == "$BND_MAC" ]] || error 90 "MAC address of $INTERFACE does not match MAC address of bond0"
 
 # Clean up the temporary file
 cleanup
 
 # Looks good!
-echo ""MAC address of $INTERFACE matches MAC address of bond0""
+echo ""MAC address of "$INTERFACE" matches MAC address of bond0""
 echo "Test passed!"
+done
 exit 0

--- a/goss-testing/tests/common/goss-interfaces-have-same-mac.yaml
+++ b/goss-testing/tests/common/goss-interfaces-have-same-mac.yaml
@@ -22,14 +22,12 @@
 
 # Variable set: network_interfaces
 command:
-  {{range $interface := index .Vars "network_interfaces"}}
-  check_mac_{{$interface}}:
+  check_mac:
     title: Interfaces Have Same MAC
     meta:
-      desc: Validates that interface '{{$interface}}' has same MAC address as bond0.
+      desc: Validates that interface has same MAC address as bond0.
       sev: 0
-    exec: "{{.Env.GOSS_BASE}}/scripts/check_interface_mac_matches_bond.sh" "{{$interface}}"
+    exec: "{{.Env.GOSS_BASE}}/scripts/check_interface_mac_matches_bond.sh {{range.Vars.network_interfaces}}{{.}} {{end}}"
     exit-status: 0
     timeout: 1000
     skip: false
-  {{end}}


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

- Adjusts `check_interface_mac_matches_bond.sh` to accept multiple arguments to facilitate 
- Adjusts `goss-interfaces-have-same-mac.yaml` to utilize a small loop while retaining functionality of the `.Env.GOSS_BASE` variable since that variable cannot be evaluated in the current loop of `network_interfaces`.

## Issues and Related PRs

- CASMINST-4161

## Testing

Tested manually

### Tested on:

  * `surtur`

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.  This changes the script slightly to accept any arguments and then loops through them, using the existing logic. 


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

