### PR TITLE
CASMINST-4176 retry skew check three times to reduce false positives

### DIFF
--- a/goss-testing/scripts/check_clock_skew.sh
+++ b/goss-testing/scripts/check_clock_skew.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 
 # (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
 #
@@ -49,6 +72,11 @@ for node in $nodes; do
   pdsh_node_args="$pdsh_node_args -w $node"
 done
 
+for try in {1..3}; do
+echo "Checking clock skew...attempt $try of 3..."
+# short delay between tries
+sleep 2
+
 node_times=$(pdsh $pdsh_node_args 'date -u "+%s"' 2>/dev/null)
 node_times_array=( $node_times )
 array_length=${#node_times_array[@]}
@@ -75,5 +103,5 @@ while [[ "$cnt" -lt "$array_length" ]]; do
     exit_code=1
   fi
 done
-
+done
 exit $exit_code


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

Wraps the existing check in a loop that tries three times.

## Issues and Related PRs

* Resolves CASMINST-4176

## Testing

- `redbull`
- `fanta`

### Test description:

```
ncn-m001:~/jsalmela # ./!$
./test
Checking clock skew...attempt 1 of 3...
Epoch seconds by node (allowing 1 seconds of drift):
ncn-s001: 1646746048
ncn-s002: 1646746048
ncn-s003: 1646746048
ncn-s004: 1646746048
ncn-m001: 1646746048
ncn-m002: 1646746048
ncn-m003: 1646746048
ncn-w001: 1646746048
ncn-w002: 1646746049
ncn-w004: 1646746049
ncn-w003: 1646746049

Checking clock skew...attempt 2 of 3...
Epoch seconds by node (allowing 1 seconds of drift):
ncn-s001: 1646746059
ncn-s003: 1646746059
ncn-s002: 1646746059
ncn-s004: 1646746059
ncn-m001: 1646746059
ncn-m002: 1646746059
ncn-m003: 1646746059
ncn-w001: 1646746059
ncn-w002: 1646746060
ncn-w004: 1646746060
ncn-w003: 1646746060

Checking clock skew...attempt 3 of 3...
Epoch seconds by node (allowing 1 seconds of drift):
ncn-s002: 1646746070
ncn-s001: 1646746070
ncn-s003: 1646746070
ncn-s004: 1646746070
ncn-m001: 1646746070
ncn-m002: 1646746070
ncn-m003: 1646746070
ncn-w001: 1646746070
ncn-w002: 1646746071
ncn-w004: 1646746071
ncn-w003: 1646746071

ncn-m001:~/jsalmela # echo $?
0
ncn-m001:~/jsalmela #
```

## Risks and Mitigations

Low.  This just loops existing code three times with a small delay.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

