### PR TITLE
CASMINST-4196 adjust vlan test to ignore options bond0.can0 interface

### DIFF
--- a/goss-testing/tests/common/goss-network-interfaces.yaml
+++ b/goss-testing/tests/common/goss-network-interfaces.yaml
@@ -24,6 +24,7 @@
 # Variable set: network_interfaces
 command:
 {{range $interface := index .Vars "network_interfaces"}}
+  {{if ne $interface "bond0.can0"}}
   interface_{{$interface}}:
     title: Interface '{{$interface}}' Has VLAN
     meta:
@@ -33,4 +34,5 @@ command:
     exit-status: 0
     timeout: 10000
     skip: false
+  {{end}}
 {{end}}


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

Adjusts a test to ignore `bond0.can0` as it is now optional.

## Issues and Related PRs

* Resolves CASMINST-4196
* Relates to CASMINST-4195
* Relates to #222 

## Testing

  * `wasp`

### Test description:

```
ncn-m001:~ # export GOSS_BASE=/opt/cray/tests/install/ncn/
ncn-m001:~ # export GOSS_FILE=/opt/cray/tests/install/ncn/tests/goss-network-interfaces.yaml
ncn-m001:~ # goss --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
....

Total Duration: 0.014s
Count: 4, Failed: 0, Skipped: 0
ncn-m001:~ # echo $?
0
ncn-m001:~ #
```

## Risks and Mitigations

Low


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

