### PR TITLE
CASMINST-4195 adjust ip test to ignore options bond0.can0 interface

### DIFF
--- a/goss-testing/tests/common/goss-interface-has-ip.yaml
+++ b/goss-testing/tests/common/goss-interface-has-ip.yaml
@@ -29,10 +29,18 @@ command:
     meta:
       desc: Validates that interface '{{$interface}}' has an IP address
       sev: 0
-    exec: "ip addr show dev {{$interface}} scope global | grep 'inet ' | awk '{print $2}'"
+    # For bond0.can0, if it does not exist, we do not fail. Echo a fake IP so the test passes
+    exec: |-
+      if ip link show dev {{$interface}}; then
+        ip -4 a s dev {{$interface}} | awk '/inet / {print $2}'
+      fi
     exit-status: 0
     stdout:
     - /[1-9]/
     timeout: 10000
+    {{if eq $interface "bond0.can0"}}
+    skip: true
+    {{else}}
     skip: false
+    {{end}}
 {{end}}


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

Adjusts a test to ignore `bond0.can0` as it is now optional.

## Issues and Related PRs

* Resolves CASMINST-4195
* Relates to CASMINST-4196
* Relates to #222 

## Testing

  * `wasp`

### Test description:

```
ncn-m001:~ # export GOSS_BASE=/opt/cray/tests/install/ncn/
ncn-m001:~ # export GOSS_FILE=/opt/cray/tests/install/ncn/tests/goss-interface-has-ip.yaml
ncn-m001:~ # goss --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
....

Total Duration: 0.013s
Count: 4, Failed: 0, Skipped: 0
ncn-m001:~ #
```

## Risks and Mitigations

Low


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
