### PR TITLE
CASMINST-4176 retry skew check three times to reduce false positives

### DIFF
--- a/goss-testing/scripts/check_clock_skew.sh
+++ b/goss-testing/scripts/check_clock_skew.sh
@@ -50,6 +50,11 @@ for node in $nodes; do
   pdsh_node_args="$pdsh_node_args -w $node"
 done
 
+for try in {1..3}; do
+echo "Checking clock skew...attempt $try of 3..."
+# short delay between tries
+sleep 2
+
 node_times=$(pdsh $pdsh_node_args 'date -u "+%s"' 2>/dev/null)
 node_times_array=( $node_times )
 array_length=${#node_times_array[@]}
@@ -76,5 +81,5 @@ while [[ "$cnt" -lt "$array_length" ]]; do
     exit_code=1
   fi
 done
-
+done
 exit $exit_code


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

Wraps the existing check in a loop that tries three times.

## Issues and Related PRs

* Resolves CASMINST-4176

## Testing

- `redbull`
- `fanta`

### Test description:

```
ncn-m001:~/jsalmela # ./!$
./test
Checking clock skew...attempt 1 of 3...
Epoch seconds by node (allowing 1 seconds of drift):
ncn-s001: 1646746048
ncn-s002: 1646746048
ncn-s003: 1646746048
ncn-s004: 1646746048
ncn-m001: 1646746048
ncn-m002: 1646746048
ncn-m003: 1646746048
ncn-w001: 1646746048
ncn-w002: 1646746049
ncn-w004: 1646746049
ncn-w003: 1646746049

Checking clock skew...attempt 2 of 3...
Epoch seconds by node (allowing 1 seconds of drift):
ncn-s001: 1646746059
ncn-s003: 1646746059
ncn-s002: 1646746059
ncn-s004: 1646746059
ncn-m001: 1646746059
ncn-m002: 1646746059
ncn-m003: 1646746059
ncn-w001: 1646746059
ncn-w002: 1646746060
ncn-w004: 1646746060
ncn-w003: 1646746060

Checking clock skew...attempt 3 of 3...
Epoch seconds by node (allowing 1 seconds of drift):
ncn-s002: 1646746070
ncn-s001: 1646746070
ncn-s003: 1646746070
ncn-s004: 1646746070
ncn-m001: 1646746070
ncn-m002: 1646746070
ncn-m003: 1646746070
ncn-w001: 1646746070
ncn-w002: 1646746071
ncn-w004: 1646746071
ncn-w003: 1646746071

ncn-m001:~/jsalmela # echo $?
0
ncn-m001:~/jsalmela #
```

## Risks and Mitigations

Low.  This just loops existing code three times with a small delay.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
