### PR TITLE
CASMINST-4091: fix mismatched quote in ncn-healthcheck

### DIFF
--- a/goss-testing/automated/ncn-healthcheck
+++ b/goss-testing/automated/ncn-healthcheck
@@ -35,4 +35,4 @@ fi
 
 "$GOSS_BASE/automated/ncn-healthcheck-storage"
 "$GOSS_BASE/automated/ncn-healthcheck-master"
-"$GOSS_BASE/automated/ncn-healthcheck-worker'
+"$GOSS_BASE/automated/ncn-healthcheck-worker"


### PR DESCRIPTION
## Summary and Scope

This fixes the mismatched quote introduced in the ncn-healthcheck script by my first 1.2 PR for CASMINST-4091.

## Issues and Related PRs

https://github.com/Cray-HPE/csm-testing/pull/220

## Testing

I tested the updated script on wasp and verified that it runs properly.

## Risks and Mitigations

Very low risk -- one character changed.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [N/A] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

