### PR TITLE
CASMINST-4222: Enable logging for 5 tests

### DIFF
--- a/goss-testing/scripts/check_static_routes.sh
+++ b/goss-testing/scripts/check_static_routes.sh
@@ -86,22 +86,32 @@ function get_token() {
       break
     fi
   done
-  echo $TOKEN
+  if [[ $print_token -eq 1 ]]; then
+    echo $TOKEN
+  fi
+}
+
+function usage
+{
+  echo "usage: ${0}       # Only print 'PASS upon success"
+  echo "       ${0} -p    # Print all results and errors if found. Use for manual check."
+  echo "       ${0} -t    # Print all results and errors if found. Also print API token. Use for manual check."
+  exit 3
 }
 
 print_results=0
-while getopts ph options
+print_token=0
+while getopts hpt options
 do
     case "${options}" in 
+        h) usage
+           ;;
         p) print_results=1
            ;;
-        h) echo "usage: ${0}       # Only print 'PASS upon success"
-           echo "       ${0} -p    # Print all results and errors if found. Use for manual check."
-           exit 3
+        t) print_results=1
+           print_token=1
            ;;
-       \?) echo "usage: ${0}       # Only print 'PASS upon success"
-           echo "       ${0} -p    # Print all results and errors if found. Use for manual check."
-           exit 3
+       \?) usage
            ;;
     esac
 done

--- a/goss-testing/tests/ncn/goss-boot-parameter-check-no-wipe.yaml
+++ b/goss-testing/tests/ncn/goss-boot-parameter-check-no-wipe.yaml
@@ -21,13 +21,19 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
+{{ $logrun := $scripts | printf "%s/log_run.sh" }}
 command:
-  boot_parameter_check_no_wipe:
-    title: Check Boot Parameter is Set to Not Wipe the Disk (metal.no-wipe=1)
-    meta:
-      desc: If this test fails, run `csi handoff bss-update-param --set metal.no-wipe=1 --limit <SERVER_XNAME>` to set metal.no-wipe to 1. This test is not meant to be run if the PIT has not been rebooted into m001 or if metal.no-wipe has been set to 0 for a node image upgraded.
-      sev: 0
-    exec: "{{.Env.GOSS_BASE}}/scripts/check_no_wipe_flag.sh"
-    exit-status: 0
-    timeout: 30000
-    skip: false
+    {{ $testlabel := "boot_parameter_check_no_wipe" }}
+    {{$testlabel}}:
+        title: Check Boot Parameter is Set to Not Wipe the Disk (metal.no-wipe=1)
+        meta:
+            desc: If this test fails, run `csi handoff bss-update-param --set metal.no-wipe=1 --limit <SERVER_XNAME>` to set metal.no-wipe to 1. This test is not meant to be run if the PIT has not been rebooted into m001 or if metal.no-wipe has been set to 0 for a node image upgraded.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$scripts}}/check_no_wipe_flag.sh"
+        exit-status: 0
+        timeout: 30000
+        skip: false

--- a/goss-testing/tests/ncn/goss-cfs-state-reporter.yaml
+++ b/goss-testing/tests/ncn/goss-cfs-state-reporter.yaml
@@ -21,15 +21,22 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
+{{ $logrun := $scripts | printf "%s/log_run.sh" }}
+{{ $cfs_state_reporter_check := $scripts | printf "%s/python/cfs_state_reporter_check.py" }}
 command:
-  cfs_state_reporter_check:
-    title: cfs-state-reporter service ran successfully
-    meta:
-      desc: If this test fails, run {{.Env.GOSS_BASE}}/scripts/python/cfs_state_reporter_check.py on the target node for more information
-      sev: 0
-    exec: "{{.Env.GOSS_BASE}}/scripts/python/cfs_state_reporter_check.py"
-    exit-status: 0
-    stdout:
-      - PASS
-    timeout: 10000
-    skip: false
+    {{ $testlabel := "cfs_state_reporter_check" }}
+    {{$testlabel}}:
+        title: cfs-state-reporter service ran successfully
+        meta:
+            desc: If this test fails, run {{$cfs_state_reporter_check}} on the target node for more information
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$cfs_state_reporter_check}}"
+        exit-status: 0
+        stdout:
+            - PASS
+        timeout: 10000
+        skip: false

--- a/goss-testing/tests/ncn/goss-check-static-routes.yaml
+++ b/goss-testing/tests/ncn/goss-check-static-routes.yaml
@@ -21,15 +21,23 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
+{{ $logrun := $scripts | printf "%s/log_run.sh" }}
+{{ $check_static_routes := $scripts | printf "%s/check_static_routes.sh" }}
 command:
-  check_static_routes:
-    title: NCNs Have All Required Static Routes 
-    meta:
-      desc: Validates all NCNs have the required static routes to support booting nodes. If this test fails, run the script "{{.Env.GOSS_BASE}}/scripts/check_static_routes.sh -p" to see a printed description of the errors.
-      sev: 0
-    exec: "{{.Env.GOSS_BASE}}/scripts/check_static_routes.sh"
-    stdout:
-      - "!FAIL"
-    exit-status: 0
-    timeout: 5000
-    skip: false
+    {{ $testlabel := "check_static_routes" }}
+    {{$testlabel}}:
+        title: NCNs Have All Required Static Routes 
+        meta:
+            desc: Validates all NCNs have the required static routes to support booting nodes. If this test fails, run the script "{{$check_static_routes}} -p" to see a printed description of the errors.
+            sev: 0
+        exec: |-
+            # Because we are logging, run the script with -p flag to get more detailed output
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$check_static_routes}}" -p
+        stdout:
+            - "!FAIL"
+        exit-status: 0
+        timeout: 5000
+        skip: false

--- a/goss-testing/tests/ncn/goss-k8s-etcd-cluster-balance.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-etcd-cluster-balance.yaml
@@ -21,15 +21,23 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
+{{ $logrun := $scripts | printf "%s/log_run.sh" }}
+{{ $etcd_cluster_balance := $scripts | printf "%s/etcd_cluster_balance.sh" }}
 command:
-  k8s_etcd_cluster_balance:
-    title: All Etcd Pods in a Cluster are Running on a Different Worker Node
-    meta:
-      desc: If this test fails, run the script "{{.Env.GOSS_BASE}}/scripts/etcd_cluster_balance.sh -p" to see a printed description of the errors. Refer to 'operations/kubernetes/Rebalance_Healthy_etcd_Clusters.md' in the CSM documentation for instructions on fixing unbalanced clusters.
-      sev: 0
-    exec: "{{.Env.GOSS_BASE}}/scripts/etcd_cluster_balance.sh"
-    exit-status: 0
-    stdout:
-      - PASS
-    timeout: 20000
-    skip: false
+    {{ $testlabel := "k8s_etcd_cluster_balance" }}
+    {{$testlabel}}:
+        title: All Etcd Pods in a Cluster are Running on a Different Worker Node
+        meta:
+            desc: If this test fails, run the script "{{$etcd_cluster_balance}} -p" to see a printed description of the errors. Refer to 'operations/kubernetes/Rebalance_Healthy_etcd_Clusters.md' in the CSM documentation for instructions on fixing unbalanced clusters.
+            sev: 0
+        exec: |-
+            # Since we are logging, call with the -p flag
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$etcd_cluster_balance}}" -p
+        exit-status: 0
+        stdout:
+            - PASS
+        timeout: 20000
+        skip: false

--- a/goss-testing/tests/ncn/goss-k8s-etcd-database-health.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-etcd-database-health.yaml
@@ -21,15 +21,21 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
+{{ $logrun := $scripts | printf "%s/log_run.sh" }}
 command:
-  etcd_database_health:
-    title: Etcd Database Health
-    meta:
-      desc: Checks the health of the etcd service databases.
-      sev: 0
-    exec: {{.Env.GOSS_BASE}}/scripts/etcd_database_health.sh
-    stdout:
-      - "!FAIL"
-    exit-status: 0
-    timeout: 20000
-    skip: false
+    {{ $testlabel := "etcd_database_health" }}
+    {{$testlabel}}:
+        title: Etcd Database Health
+        meta:
+            desc: Checks the health of the etcd service databases.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$scripts}}/etcd_database_health.sh"
+        stdout:
+            - "!FAIL"
+        exit-status: 0
+        timeout: 20000
+        skip: false


### PR DESCRIPTION
## Summary and Scope

Debugging goss test failures is a big pain point. Logging alleviates this significantly.

The logging feature has already merged and no problems have been found with it (the mismatched quote typo went in with the same PR, but was a commit unrelated to the logging). This ticket just enables logging for 5 additional tests.
* goss-boot-parameter-check-no-wipe
* goss-cfs-state-reporter
* goss-check-static-routes
* goss-k8s-etcd-cluster-balance
* goss-k8s-etcd-database-health

The script for the check-static-routes test was also modified so that it does not print out the API token by default, as I felt this was something customers may not want being written into a test log file. Instead I made that available if the test script is manually run using a new flag.

## Issues and Related PRs

Similar to https://github.com/Cray-HPE/csm-testing/pull/223

## Testing

On hela I ran all 5 tests both with and without the changes in place. The boot-parameter test was already failing on hela, and the others were passing. None of that changed with the logging changes in place -- the only difference is that the logs with the test output were now available:

### goss-boot-parameter-check-no-wipe

```
ncn-m001:~ # GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/tests/goss-boot-parameter-check-no-wipe.yaml v
F

Failures/Skipped:

Title: Check Boot Parameter is Set to Not Wipe the Disk (metal.no-wipe=1)
Meta:
    desc: If this test fails, run `csi handoff bss-update-param --set metal.no-wipe=1 --limit <SERVER_XNAME>` to set metal.no-wipe to 1. This test is not meant to be run if the PIT has not been rebooted into m001 or if metal.no-wipe has been set to 0 for a node image upgraded.
    sev: 0
Command: boot_parameter_check_no_wipe: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0

Total Duration: 0.254s
Count: 1, Failed: 1, Skipped: 0
```

```
ncn-m001:~ #  cat /opt/cray/tests/install/logs/boot_parameter_check_no_wipe/20220311_174744_095516779_1290504.log
log_run argument(s): -l boot_parameter_check_no_wipe
Executable: '/opt/cray/tests/install/ncn/scripts/check_no_wipe_flag.sh'
No arguments to executable

## 20220311_174744_104975914 ##                      executable starting ##
###########################################################################
Note that before the PIT node has been rebooted into ncn-m001,
metal.no-wipe status may not available which will cause this test to fail.
x3000c0s1b0n0 - metal.no-wipe=0
 --- FAILED --- metal.no-wipe status is not 1. (note: node_status = upgrade/rebuild, then metal.no-wipe=0 is valid)
###########################################################################
## 20220311_174744_347271574 ##       executable completed (exit code=1) ##
```

### goss-cfs-state-reporter

```
ncn-m001:~ # GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/tests/goss-cfs-state-reporter.yaml v..

Total Duration: 0.100s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-m001:~ #  cat /opt/cray/tests/install/logs/cfs_state_reporter_check/20220311_174717_368280317_1290214.log
log_run argument(s): -l cfs_state_reporter_check
Executable: '/opt/cray/tests/install/ncn/scripts/python/cfs_state_reporter_check.py'
No arguments to executable

## 20220311_174717_378026345 ##                      executable starting ##
###########################################################################
Test log file: /opt/cray/tests/cfs_state_reporter_check.log

cfs_state_reporter_check: INFO     Running command: /usr/bin/systemctl --all --no-pager show cfs-state-reporter
cfs_state_reporter_check: INFO     Command completed with return code 0
cfs_state_reporter_check: INFO     ExecMainStartTimestamp = Thu 2022-03-10 12:54:17 UTC
cfs_state_reporter_check: INFO     ExecMainExitTimestamp = Thu 2022-03-10 12:57:54 UTC
cfs_state_reporter_check: INFO     ExecMainStatus = 0
cfs_state_reporter_check: INFO     LoadState = loaded
cfs_state_reporter_check: INFO     ActiveState = inactive
cfs_state_reporter_check: INFO     SubState = dead
cfs_state_reporter_check: INFO     Result = success

cfs_state_reporter_check: INFO     PASS: Validation of cfs-state-reporter service succeeded
###########################################################################
## 20220311_174717_479603604 ##       executable completed (exit code=0) ##
```

### goss-check-static-routes

```
ncn-m001:~ # GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/tests/goss-check-static-routes.yaml v
..

Total Duration: 2.666s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-m001:~ #  cat /opt/cray/tests/install/logs/check_static_routes/20220311_175525_439745987_1295581.log
log_run argument(s): -l check_static_routes
Executable: '/opt/cray/tests/install/ncn/scripts/check_static_routes.sh'
1 argument(s) to executable: '-p'

## 20220311_175525_449248002 ##                      executable starting ##
###########################################################################
INFO: NMN gateway is 10.252.0.1
INFO: HMN gateway is 10.254.0.1
INFO: NMNLB CIDR is 10.92.100.0/24 - route found = true
INFO: NMNLB CIDR is 10.106.0.0/22 - route found = true
INFO: HMNLB CIDR is 10.94.100.0/24 - route found = true
INFO: HMNLB CIDR is 10.107.0.0/22 - route found = true
INFO: MTL CIDR is 10.1.0.0/16 - route found = true
PASS
###########################################################################
## 20220311_175528_096638453 ##       executable completed (exit code=0) ##
```

### goss-k8s-etcd-cluster-balance

```
ncn-m001:~ # GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-etcd-cluster-balance.yaml v
..

Total Duration: 7.267s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-m001:~ #  cat /opt/cray/tests/install/logs/k8s_etcd_cluster_balance/20220311_182352_596181241_1313831.log
log_run argument(s): -l k8s_etcd_cluster_balance
Executable: '/opt/cray/tests/install/ncn/scripts/etcd_cluster_balance.sh'
1 argument(s) to executable: '-p'

## 20220311_182352_605661375 ##                      executable starting ##
###########################################################################
PASS
###########################################################################
## 20220311_182359_863269658 ##       executable completed (exit code=0) ##
```

### goss-k8s-etcd-database-health

```
ncn-m001:~ # GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-etcd-database-health.yaml v
..

Total Duration: 7.665s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-m001:~ #  cat /opt/cray/tests/install/logs/etcd_database_health/20220311_182411_930975914_1315099.log
log_run argument(s): -l etcd_database_health
Executable: '/opt/cray/tests/install/ncn/scripts/etcd_database_health.sh'
No arguments to executable

## 20220311_182411_940244425 ##                      executable starting ##
###########################################################################
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
###########################################################################
## 20220311_182419_532006580 ##       executable completed (exit code=0) ##
```

## Risks and Mitigations

Low risk -- test logging feature has been tested previously by me and Jacob with no issues found. Enabling logging to existing tests is pretty cookie-cutter.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [N/A] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

