### PR TITLE
CASMINST-4195 adjust ip test to use regex and check for PASS

### DIFF
--- a/goss-testing/tests/common/goss-interface-has-ip.yaml
+++ b/goss-testing/tests/common/goss-interface-has-ip.yaml
@@ -29,18 +29,15 @@ command:
     meta:
       desc: Validates that interface '{{$interface}}' has an IP address
       sev: 0
-    # For bond0.can0, if it does not exist, we do not fail. Echo a fake IP so the test passes
     exec: |-
-      if ip link show dev {{$interface}}; then
-        ip -4 a s dev {{$interface}} | awk '/inet / {print $2}'
+      if ip link show dev "{{$interface}}"; then
+          ip -4 a s dev "{{$interface}}" | awk '/inet / {print $2}' | grep -E -o "([0-9]{1,3}[\.]){3}[0-9]{1,3}" && echo PASS
+      elif [[ "{{$interface}}" == "bond0.can0" ]]; then
+          echo PASS
       fi
     exit-status: 0
     stdout:
-    - /[1-9]/
+    - PASS
     timeout: 10000
-    {{if eq $interface "bond0.can0"}}
-    skip: true
-    {{else}}
     skip: false
-    {{end}}
 {{end}}


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

Adjusts the bond IP test to use regex for detecting an IP and then echoing PASS to STDOUT.

## Issues and Related PRs

CASMINST-4195

## Testing

  * `hela`

### Test description:

`/opt/cray/tests/install/ncn/automated/ncn-healthcheck`

## Risks and Mitigations

Low.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
