### PR TITLE
CASMINST-4226: Simplify & enable logging of LVM label tests

### DIFF
--- a/goss-testing/tests/ncn/goss-dedicated-drive-worker.yaml
+++ b/goss-testing/tests/ncn/goss-dedicated-drive-worker.yaml
@@ -21,28 +21,23 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  conrun_label_worker:
-    title: Worker Node CONRUN FS Label
-    meta:
-      desc: Validates the CONRUN FS Label is set up correctly on worker nodes.
-      sev: 0
-    # blkid will return non-zero if no block device has the CONRUN label
-    exec: blkid -L CONRUN
-    exit-status: 0
-  conlib_label_worker:
-    title: Worker Node CONLIB FS Label
-    meta:
-      desc: Validates the CONLIB FS Label is set up correctly on worker nodes.
-      sev: 0
-    # blkid will return non-zero if no block device has the CONLIB label
-    exec: blkid -L CONLIB
-    exit-status: 0
-  k8slet_label_worker:
-    title: Worker Node K8SLET FS Label
-    meta:
-      desc: Validates the K8SLET FS Label is set up correctly on worker nodes.
-      sev: 0
-    # blkid will return non-zero if no block device has the K8SLET label
-    exec: blkid -L K8SLET
-    exit-status: 0
+    {{range $fslabel := index .Vars "k8s_worker_fs_labels"}}
+        {{ $testlabel := $fslabel | toLower | printf "%s_label_worker" }}
+        {{$testlabel}}:
+            title: Worker Node {{$fslabel}} FS Label
+            meta:
+                desc: Validates the {{$fslabel}} FS label is set up correctly on worker nodes. If this test fails, inspect the '/var/log/cloud-init-output.log' to determine why the lvm creation failed.
+                sev: 0
+            # blkid will return non-zero if no block device has the $fslabel label and
+            # will print to stdout the device with that label (i.e. /dev/whatever)
+            exec: |-
+                "{{$logrun}}" -l "{{$testlabel}}" \
+                    blkid -L "{{$fslabel}}"
+            exit-status: 0
+            stdout:
+                - /^\/dev\//
+            timeout: 5000
+    {{end}}

--- a/goss-testing/tests/ncn/goss-etcdlvm-drive-master.yaml
+++ b/goss-testing/tests/ncn/goss-etcdlvm-drive-master.yaml
@@ -21,12 +21,23 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  etcdlvm_drive_master:
-    title: Validates the dedicated drive for ETCD is set up correctly on master nodes (ETCDLVM FS Label)
-    meta:
-      desc: If this test fails, inspect the '/var/log/cloud-init-output.log' to determine why the lvm creation failed.
-      sev: 0
-    exec: blkid -L ETCDLVM
-    # blkid will return non-zero if no block device has the ETCDLVM label
-    exit-status: 0
+    {{range $fslabel := index .Vars "k8s_master_fs_labels"}}
+        {{ $testlabel := $fslabel | toLower | printf "%s_label_master" }}
+        {{$testlabel}}:
+            title: Worker Node {{$fslabel}} FS Label
+            meta:
+                desc: Validates the {{$fslabel}} FS label is set up correctly on master nodes. If this test fails, inspect the '/var/log/cloud-init-output.log' to determine why the lvm creation failed.
+                sev: 0
+            # blkid will return non-zero if no block device has the $fslabel label and
+            # will print to stdout the device with that label (i.e. /dev/whatever)
+            exec: |-
+                "{{$logrun}}" -l "{{$testlabel}}" \
+                    blkid -L "{{$fslabel}}"
+            exit-status: 0
+            stdout:
+                - /^\/dev\//
+            timeout: 5000
+    {{end}}

--- a/goss-testing/tests/ncn/goss-lvm-drives-storage.yaml
+++ b/goss-testing/tests/ncn/goss-lvm-drives-storage.yaml
@@ -21,25 +21,23 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  cephetc_label_storage:
-    title: Validates the CEPHETC FS Label is set up correctly on storage nodes.
-    meta:
-      desc: If this test fails, inspect the '/var/log/cloud-init-output.log' to determine why the lvm creation failed.
-      sev: 0
-    exec: blkid -L CEPHETC
-    exit-status: 0
-  cephvar_label_storage:
-    title: Validates the CEPHVAR FS Label is set up correctly on storage nodes.
-    meta:
-      desc: If this test fails, inspect the '/var/log/cloud-init-output.log' to determine why the lvm creation failed.
-      sev: 0
-    exec: blkid -L CEPHVAR
-    exit-status: 0
-  contain_label_storage:
-    title: Validates the CONTAIN FS Label is set up correctly on storage nodes.
-    meta:
-      desc: If this test fails, inspect the '/var/log/cloud-init-output.log' to determine why the lvm creation failed.
-      sev: 0
-    exec: blkid -L CONTAIN
-    exit-status: 0
+    {{range $fslabel := index .Vars "storage_fs_labels"}}
+        {{ $testlabel := $fslabel | toLower | printf "%s_label_storage" }}
+        {{$testlabel}}:
+            title: Storage Node {{$fslabel}} FS Label
+            meta:
+                desc: Validates the {{$fslabel}} FS label is set up correctly on storage nodes. If this test fails, inspect the '/var/log/cloud-init-output.log' to determine why the lvm creation failed.
+                sev: 0
+            # blkid will return non-zero if no block device has the $fslabel label and
+            # will print to stdout the device with that label (i.e. /dev/whatever)
+            exec: |-
+                "{{$logrun}}" -l "{{$testlabel}}" \
+                    blkid -L "{{$fslabel}}"
+            exit-status: 0
+            stdout:
+                - /^\/dev\//
+            timeout: 5000
+    {{end}}

--- a/goss-testing/vars/variables-ncn.yaml
+++ b/goss-testing/vars/variables-ncn.yaml
@@ -141,3 +141,16 @@ staticsconf:
   - ""
 
 bond_member_mtu: 9000
+
+k8s_master_fs_labels:
+  - ETCDLVM
+
+k8s_worker_fs_labels:
+  - CONRUN
+  - CONLIB
+  - K8SLET
+
+storage_fs_labels:
+  - CEPHETC
+  - CEPHVAR
+  - CONTAIN


### PR DESCRIPTION
## Summary and Scope

Three different tests are used to validate that LVM labels exist on devices on master nodes, storage nodes, and worker nodes. However, the check being done is essentially the same, with different values being hard-coded into each test. This PR moves those values into the NCN variable file, simplifying each of the three tests in the process.

In addition, logging is enabled for the tests, and a check on the output of the command is added (rather than purely going by the exit code).

## Issues and Related PRs

None

## Testing

On hela I ran all 3 tests:

### goss-dedicated-drive-worker.yaml

```
ncn-w002:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars ./variables-ncn.yaml -g ./goss-dedicated-drive-worker.yaml v
......

Total Duration: 0.025s
Count: 6, Failed: 0, Skipped: 0
```

```
ncn-w002:/tmp/zz # cat /opt/cray/tests/install/logs/conlib_label_worker/20220313_183805_691198223_2609295.log
log_run argument(s): -l conlib_label_worker
Executable: 'blkid'
2 argument(s) to executable: '-L' 'CONLIB'

## 20220313_183805_701344946 ##                      executable starting ##
###########################################################################
/dev/sdc2
###########################################################################
## 20220313_183805_705791660 ##       executable completed (exit code=0) ##
```
```
ncn-w002:/tmp/zz # cat /opt/cray/tests/install/logs/conrun_label_worker/20220313_183805_690836632_2609293.log
log_run argument(s): -l conrun_label_worker
Executable: 'blkid'
2 argument(s) to executable: '-L' 'CONRUN'

## 20220313_183805_701031254 ##                      executable starting ##
###########################################################################
/dev/sdc1
###########################################################################
## 20220313_183805_705088897 ##       executable completed (exit code=0) ##
```
```
ncn-w002:/tmp/zz # cat /opt/cray/tests/install/logs/k8slet_label_worker/20220313_183805_690717071_2609292.log
log_run argument(s): -l k8slet_label_worker
Executable: 'blkid'
2 argument(s) to executable: '-L' 'K8SLET'

## 20220313_183805_700741156 ##                      executable starting ##
###########################################################################
/dev/sdc3
###########################################################################
## 20220313_183805_705478209 ##       executable completed (exit code=0) ##
```

### goss-etcdlvm-drive-master.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars ./variables-ncn.yaml -g ./goss-etcdlvm-drive-master.yaml v
..

Total Duration: 0.024s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/etcdlvm_label_master/20220313_183708_029542312_3268548.log
log_run argument(s): -l etcdlvm_label_master
Executable: 'blkid'
2 argument(s) to executable: '-L' 'ETCDLVM'

## 20220313_183708_039806752 ##                      executable starting ##
###########################################################################
/dev/sdc
###########################################################################
## 20220313_183708_044324657 ##       executable completed (exit code=0) ##
```

### goss-lvm-drives-storage.yaml

```
ncn-s002:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars ./variables-ncn.yaml -g ./goss-lvm-drives-storage.yaml v
......

Total Duration: 0.025s
Count: 6, Failed: 0, Skipped: 0
```

```
ncn-s002:/tmp/zz # cat /opt/cray/tests/install/logs/cephetc_label_storage/20220313_183902_389861918_27906.log
log_run argument(s): -l cephetc_label_storage
Executable: 'blkid'
2 argument(s) to executable: '-L' 'CEPHETC'

## 20220313_183902_399753843 ##                      executable starting ##
###########################################################################
/dev/mapper/metalvg0-CEPHETC
###########################################################################
## 20220313_183902_404292509 ##       executable completed (exit code=0) ##
```
```
ncn-s002:/tmp/zz # cat /opt/cray/tests/install/logs/cephvar_label_storage/20220313_183902_389960441_27907.log
log_run argument(s): -l cephvar_label_storage
Executable: 'blkid'
2 argument(s) to executable: '-L' 'CEPHVAR'

## 20220313_183902_400101939 ##                      executable starting ##
###########################################################################
/dev/mapper/metalvg0-CEPHVAR
###########################################################################
## 20220313_183902_404967292 ##       executable completed (exit code=0) ##
```
```
ncn-s002:/tmp/zz # cat /opt/cray/tests/install/logs/contain_label_storage/20220313_183902_389798780_27905.log
log_run argument(s): -l contain_label_storage
Executable: 'blkid'
2 argument(s) to executable: '-L' 'CONTAIN'

## 20220313_183902_400258780 ##                      executable starting ##
###########################################################################
/dev/mapper/metalvg0-CONTAIN
###########################################################################
## 20220313_183902_404925344 ##       executable completed (exit code=0) ##
ncn-s002:/tmp/zz #

```

## Risks and Mitigations

Low risk -- these are very simple tests.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

