### PR TITLE
CASMINST-4227: Enable logging for 4 postgres tests

### DIFF
--- a/goss-testing/tests/ncn/goss-k8s-postgres-backups.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-postgres-backups.yaml
@@ -21,15 +21,22 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
+{{ $logrun := $scripts | printf "%s/log_run.sh" }}
+{{ $postgresql_backups_check := $scripts | printf "%s/postgresql_backups_check.sh" }}
 command:
-  k8s_postgresql_backups_check:
-    title: Kubernetes Postgresql Check that Automated Backups are Working
-    meta:
-      desc: If this test fails, run the script "{{.Env.GOSS_BASE}}/scripts/postgresql_backups_check.sh -p" to see a printed description of the errors. Check that cron jobs are running and creating postgresql backups periodically with the command "kubectl get cronjob -A | grep postgresql". To see a last scheduled time, run the command "kubectl -n <namespace> get cronjob <cron_job_name> -o jsonpath='{.status}'".
-      sev: 0
-    exec: "{{.Env.GOSS_BASE}}/scripts/postgresql_backups_check.sh"
-    exit-status: 0
-    stdout:
-      - PASS
-    timeout: 600000
-    skip: false
+    {{ $testlabel := "k8s_postgresql_backups_check" }}
+    {{$testlabel}}:
+        title: Kubernetes Postgresql Check that Automated Backups are Working
+        meta:
+            desc: If this test fails, run the script "{{$postgresql_backups_check}} -p" to see a printed description of the errors. Check that cron jobs are running and creating postgresql backups periodically with the command "kubectl get cronjob -A | grep postgresql". To see a last scheduled time, run the command "kubectl -n <namespace> get cronjob <cron_job_name> -o jsonpath='{.status}'".
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$postgresql_backups_check}}"
+        exit-status: 0
+        stdout:
+            - PASS
+        timeout: 600000
+        skip: false

--- a/goss-testing/tests/ncn/goss-k8s-postgres-clusters-running.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-postgres-clusters-running.yaml
@@ -21,15 +21,21 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
+{{ $logrun := $scripts | printf "%s/log_run.sh" }}
 command:
-  k8s_postgres_clusters_running:
-    title: Kubernetes Postgres Check that All Clusters are in a Running State
-    meta:
-      desc: If this test fails, run the command 'kubectl get postgresql -A' to look at all postgres clusters and thier statuses. Refer to 'operations/kubernetes/Troubleshoot_Postgres_Database.md' in the CSM documentation for more information on diagnosing and fixing clusters not in a running state.
-      sev: 0
-    exec: "{{.Env.GOSS_BASE}}/scripts/postgres_clusters_running.sh"
-    exit-status: 0
-    stdout:
-      - PASS
-    timeout: 60000
-    skip: false
+    {{ $testlabel := "k8s_postgres_clusters_running" }}
+    {{$testlabel}}:
+        title: Kubernetes Postgres Check that All Clusters are in a Running State
+        meta:
+            desc: If this test fails, run the command 'kubectl get postgresql -A' to look at all postgres clusters and thier statuses. Refer to 'operations/kubernetes/Troubleshoot_Postgres_Database.md' in the CSM documentation for more information on diagnosing and fixing clusters not in a running state.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$scripts}}/postgres_clusters_running.sh"
+        exit-status: 0
+        stdout:
+            - PASS
+        timeout: 60000
+        skip: false

--- a/goss-testing/tests/ncn/goss-k8s-postgres-leader.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-postgres-leader.yaml
@@ -21,15 +21,22 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
+{{ $logrun := $scripts | printf "%s/log_run.sh" }}
+{{ $postgres_clusters_leader := $scripts | printf "%s/postgres_clusters_leader.sh" }}
 command:
-  k8s_postgres_clusters_have_leaders:
-    title: Kubernetes Postgres Clusters Have Leaders
-    meta:
-      desc: If this test fails, run the script "{{.Env.GOSS_BASE}}/scripts/postgres_clusters_leader.sh -p" to see printed descriptions of errors. Refer to 'operations/kubernetes/Troubleshoot_Postgres_Database.md' in the CSM documentation for more information on diagnosing and fixing postgres clusters without a leader.
-      sev: 0
-    exec: "{{.Env.GOSS_BASE}}/scripts/postgres_clusters_leader.sh"
-    exit-status: 0
-    stdout:
-    - "PASS"
-    timeout: 60000
-    skip: false
+    {{ $testlabel := "k8s_postgres_clusters_have_leaders" }}
+    {{$testlabel}}:
+        title: Kubernetes Postgres Clusters Have Leaders
+        meta:
+            desc: If this test fails, run the script "{{$postgres_clusters_leader}} -p" to see printed descriptions of errors. Refer to 'operations/kubernetes/Troubleshoot_Postgres_Database.md' in the CSM documentation for more information on diagnosing and fixing postgres clusters without a leader.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$postgres_clusters_leader}}"
+        exit-status: 0
+        stdout:
+            - "PASS"
+        timeout: 60000
+        skip: false

--- a/goss-testing/tests/ncn/goss-k8s-postgres-pods-running.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-postgres-pods-running.yaml
@@ -21,15 +21,22 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
+{{ $logrun := $scripts | printf "%s/log_run.sh" }}
+{{ $postgres_pods_running := $scripts | printf "%s/postgres_pods_running.sh" }}
 command:
-  k8s_postgres_pods_per_cluster:
-    title: Kubernetes Postgres Clusters have the  Correct Number of Pods 'Running'
-    meta:
-      desc: If this test fails, run the script "{{.Env.GOSS_BASE}}/scripts/postgres_pods_running.sh -p" to see a  printed description of errors. Refer to 'operations/kubernetes/Troubleshoot_Postgres_Database.md' in the CSM documentation for more information on diagnosing and fixing pods not in a running state. 
-      sev: 0
-    exec: "{{.Env.GOSS_BASE}}/scripts/postgres_pods_running.sh"
-    exit-status: 0
-    stdout:
-      - PASS
-    timeout: 60000
-    skip: false
+    {{ $testlabel := "k8s_postgres_pods_per_cluster" }}
+    {{$testlabel}}:
+        title: Kubernetes Postgres Clusters have the  Correct Number of Pods 'Running'
+        meta:
+            desc: If this test fails, run the script "{{$postgres_pods_running}} -p" to see a  printed description of errors. Refer to 'operations/kubernetes/Troubleshoot_Postgres_Database.md' in the CSM documentation for more information on diagnosing and fixing pods not in a running state.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$postgres_pods_running}}"
+        exit-status: 0
+        stdout:
+            - PASS
+        timeout: 60000
+        skip: false


### PR DESCRIPTION
## Summary and Scope

This PR enables logging for the following 4 postgres tests:
* goss-k8s-postgres-backups.yaml
* goss-k8s-postgres-clusters-running.yaml
* goss-k8s-postgres-leader.yaml
* goss-k8s-postgres-pods-running.yaml

No changes were made to the tests themselves.

## Issues and Related PRs

None

## Testing

I executed all 4 updated tests on hela.

### goss-k8s-postgres-backups.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss -g ./goss-k8s-postgres-backups.yaml v
..

Total Duration: 9.464s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/k8s_postgresql_backups_check/20220313_185829_878096271_3281397.log
log_run argument(s): -l k8s_postgresql_backups_check
Executable: '/opt/cray/tests/install/ncn/scripts/postgresql_backups_check.sh'
No arguments to executable

## 20220313_185829_888121697 ##                      executable starting ##
###########################################################################
PASS
###########################################################################
## 20220313_185839_332300588 ##       executable completed (exit code=0) ##
```

### goss-k8s-postgres-clusters-running.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss -g ./goss-k8s-postgres-clusters-running.yaml v
..

Total Duration: 0.148s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/k8s_postgres_clusters_running/20220313_185803_091696673_3281255.log
log_run argument(s): -l k8s_postgres_clusters_running
Executable: '/opt/cray/tests/install/ncn/scripts/postgres_clusters_running.sh'
No arguments to executable

## 20220313_185803_101483867 ##                      executable starting ##
###########################################################################
PASS
###########################################################################
## 20220313_185803_229844293 ##       executable completed (exit code=0) ##
```

### goss-k8s-postgres-leader.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss -g ./goss-k8s-postgres-leader.yaml v
..

Total Duration: 10.751s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/k8s_postgres_clusters_have_leaders/20220313_185845_916524237_3282083.log
log_run argument(s): -l k8s_postgres_clusters_have_leaders
Executable: '/opt/cray/tests/install/ncn/scripts/postgres_clusters_leader.sh'
No arguments to executable

## 20220313_185845_926681097 ##                      executable starting ##
###########################################################################
PASS
###########################################################################
## 20220313_185856_658351053 ##       executable completed (exit code=0) ##
```

### goss-k8s-postgres-pods-running.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss -g ./goss-k8s-postgres-pods-running.yaml v
..

Total Duration: 7.497s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/k8s_postgres_pods_per_cluster/20220313_185600_043801420_3278619.log
log_run argument(s): -l k8s_postgres_pods_per_cluster
Executable: '/opt/cray/tests/install/ncn/scripts/postgres_pods_running.sh'
No arguments to executable

## 20220313_185600_053173384 ##                      executable starting ##
###########################################################################
PASS
###########################################################################
## 20220313_185607_531225391 ##       executable completed (exit code=0) ##
```

## Risks and Mitigations

Low risk -- enabling logging of tests is fairly cookie-cutter.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

