### PR TITLE
CASMINST-4228: Enable logging for 4 storage tests

### DIFF
--- a/goss-testing/tests/common/goss-ceph-csi-k8s-requirements.yaml
+++ b/goss-testing/tests/common/goss-ceph-csi-k8s-requirements.yaml
@@ -21,33 +21,41 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{ $kubectl := index .Vars "kubectl" }}
+
+{{ $kubectl := .Vars.kubectl }}
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 file:
     {{$kubectl}}:
         title: "{{$kubectl}} command"
         meta:
-            desc: "Check that {{$kubectl}} command exists"
+            desc: "Check that kubectl command exists"
             sev: 0
         exists: true
         filetype: file
 command:
     {{range $configmap := index .Vars "k8s_ceph_csi_configmaps"}}
-    k8s_cm_{{$configmap}}:
-        title: "Kubernetes configmap {{$configmap}}"
-        meta:
-            desc: "Check that Kubernetes configmap {{$configmap}} exists"
-            sev: 0
-        exec: "{{$kubectl}} get configmap {{$configmap}}"
-        exit-status: 0
-        timeout: 10000
+        {{ $testlabel := $configmap | printf "k8s_cm_%s" }}
+        {{$testlabel}}:
+            title: "Kubernetes configmap {{$configmap}}"
+            meta:
+                desc: "Check that Kubernetes configmap {{$configmap}} exists"
+                sev: 0
+            exec: |-
+                "{{$logrun}}" -l "{{$testlabel}}" \
+                    "{{$kubectl}}" get configmap "{{$configmap}}"
+            exit-status: 0
+            timeout: 10000
     {{end}}
     {{range $secret := index .Vars "k8s_ceph_csi_secrets"}}
-    k8s_secret_{{$secret}}:
-        title: "Kubernetes secret {{$secret}}"
-        meta:
-            desc: "Check that Kubernetes secret {{$secret}} exists"
-            sev: 0
-        exec: "{{$kubectl}} get secret {{$secret}}"
-        exit-status: 0
-        timeout: 10000
+        {{ $testlabel := $secret | printf "k8s_secret_%s" }}
+        {{$testlabel}}:
+            title: "Kubernetes secret {{$secret}}"
+            meta:
+                desc: "Check that Kubernetes secret {{$secret}} exists"
+                sev: 0
+            exec: |-
+                "{{$logrun}}" -l "{{$testlabel}}" \
+                    "{{$kubectl}}" get secret "{{$secret}}"
+            exit-status: 0
+            timeout: 10000
     {{end}}

--- a/goss-testing/tests/ncn/goss-ceph-storage-config-files.yaml
+++ b/goss-testing/tests/ncn/goss-ceph-storage-config-files.yaml
@@ -21,14 +21,19 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  ceph_storage_config_files:
-    title: Validates the ceph config files are in place.
-    meta:
-      desc: If this test fails, verify install/upgrade steps were completed properly without errors.
-      sev: 0
-    exec: "ls /etc/ceph"
-    stdout:
-    - ceph.client.admin.keyring
-    - ceph.conf
-    exit-status: 0
+    {{ $testlabel := "ceph_storage_config_files" }}
+    {{$testlabel}}:
+        title: Validates the ceph config files are in place.
+        meta:
+            desc: If this test fails, verify install/upgrade steps were completed properly without errors.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                ls -al /etc/ceph
+        stdout:
+            - ceph.client.admin.keyring
+            - ceph.conf
+        exit-status: 0

--- a/goss-testing/tests/ncn/goss-ceph-storage-images.yaml
+++ b/goss-testing/tests/ncn/goss-ceph-storage-images.yaml
@@ -21,17 +21,22 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  ceph_storage_images:
-    title: Validates the ceph storage images have been loaded into podman
-    meta:
-      desc: If this test fails, run "/srv/cray/scripts/common/pre-load-images.sh" on the failed node.
-      sev: 0
-    exec: "podman images"
-    stdout:
-    - registry.local/ceph/ceph
-    - registry.local/ceph/ceph-grafana
-    - registry.local/quay.io/prometheus/prometheus
-    - registry.local/quay.io/prometheus/alertmanager
-    - registry.local/quay.io/prometheus/node-exporter
-    exit-status: 0
+    {{ $testlabel := "ceph_storage_images" }}
+    {{$testlabel}}:
+        title: Validates the ceph storage images have been loaded into podman
+        meta:
+            desc: If this test fails, run "/srv/cray/scripts/common/pre-load-images.sh" on the failed node.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                podman images
+        stdout:
+            - registry.local/ceph/ceph
+            - registry.local/ceph/ceph-grafana
+            - registry.local/quay.io/prometheus/prometheus
+            - registry.local/quay.io/prometheus/alertmanager
+            - registry.local/quay.io/prometheus/node-exporter
+        exit-status: 0

--- a/goss-testing/tests/ncn/goss-rgw-health.yaml
+++ b/goss-testing/tests/ncn/goss-rgw-health.yaml
@@ -21,13 +21,20 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
+{{ $logrun := $scripts | printf "%s/log_run.sh" }}
+{{ $rgw_health_check := $scripts | printf "%s/rgw_health_check.sh" }}
 command:
-  verify_rgw_health:
-    title: Verify rgw is healthy
-    meta:
-      desc: Check that rgw-vip and all storage nodes are up. Check rgw endpoint health by uploading and downloading a file from a bucket. For more detailed output, run 'GOSS_BASE={{.Env.GOSS_BASE}} {{.Env.GOSS_BASE}}/scripts/rgw_health_check.sh'
-      sev: 0
-    exec: "{{.Env.GOSS_BASE}}/scripts/rgw_health_check.sh"
-    exit-status: 0
-    timeout: 180000
-    skip: false
+    {{ $testlabel := "verify_rgw_health" }}
+    {{$testlabel}}:
+        title: Verify rgw is healthy
+        meta:
+            desc: Check that rgw-vip and all storage nodes are up. Check rgw endpoint health by uploading and downloading a file from a bucket. For more detailed output, run 'GOSS_BASE={{.Env.GOSS_BASE}} {{$rgw_health_check}}'
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$rgw_health_check}}"
+        exit-status: 0
+        timeout: 180000
+        skip: false


### PR DESCRIPTION
## Summary and Scope

This PR enables logging for the following 4 storage tests:
* goss-ceph-csi-k8s-requirements.yaml
* goss-ceph-storage-config-files.yaml
* goss-ceph-storage-images.yaml
* goss-rgw-health.yaml

The tests themselves were not altered.

## Issues and Related PRs

None

## Testing

I ran the updated tests on hela:

### goss-ceph-csi-k8s-requirements.yaml

```
ncn-s001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars ./variables-ncn.yaml -g ./goss-ceph-csi-k8s-requirements.yaml v
..........

Total Duration: 0.274s
Count: 10, Failed: 0, Skipped: 0
```

```
ncn-s001:/tmp/zz # cat /opt/cray/tests/install/logs/k8s_cm_*/* /opt/cray/tests/install/logs/k8s_secret_csi*/*
log_run argument(s): -l k8s_cm_ceph-csi-config
Executable: '/usr/bin/kubectl'
3 argument(s) to executable: 'get' 'configmap' 'ceph-csi-config'

## 20220313_191550_502476760 ##                      executable starting ##
###########################################################################
NAME              DATA   AGE
ceph-csi-config   1      5d6h
###########################################################################
## 20220313_191550_748151783 ##       executable completed (exit code=0) ##
log_run argument(s): -l k8s_cm_cephfs-csi-sc
Executable: '/usr/bin/kubectl'
3 argument(s) to executable: 'get' 'configmap' 'cephfs-csi-sc'

## 20220313_191550_501612807 ##                      executable starting ##
###########################################################################
NAME            DATA   AGE
cephfs-csi-sc   1      5d6h
###########################################################################
## 20220313_191550_755418192 ##       executable completed (exit code=0) ##
log_run argument(s): -l k8s_cm_kube-csi-sc
Executable: '/usr/bin/kubectl'
3 argument(s) to executable: 'get' 'configmap' 'kube-csi-sc'

## 20220313_191550_504057602 ##                      executable starting ##
###########################################################################
NAME          DATA   AGE
kube-csi-sc   1      5d6h
###########################################################################
## 20220313_191550_750360480 ##       executable completed (exit code=0) ##
log_run argument(s): -l k8s_cm_sma-csi-sc
Executable: '/usr/bin/kubectl'
3 argument(s) to executable: 'get' 'configmap' 'sma-csi-sc'

## 20220313_191550_502732554 ##                      executable starting ##
###########################################################################
NAME         DATA   AGE
sma-csi-sc   1      5d6h
###########################################################################
## 20220313_191550_753331091 ##       executable completed (exit code=0) ##
log_run argument(s): -l k8s_cm_sts-rados-config
Executable: '/usr/bin/kubectl'
3 argument(s) to executable: 'get' 'configmap' 'sts-rados-config'

## 20220313_191550_501667038 ##                      executable starting ##
###########################################################################
NAME               DATA   AGE
sts-rados-config   1      5d6h
###########################################################################
## 20220313_191550_754396336 ##       executable completed (exit code=0) ##
log_run argument(s): -l k8s_secret_csi-cephfs-secret
Executable: '/usr/bin/kubectl'
3 argument(s) to executable: 'get' 'secret' 'csi-cephfs-secret'

## 20220313_191550_500570234 ##                      executable starting ##
###########################################################################
NAME                TYPE     DATA   AGE
csi-cephfs-secret   Opaque   4      5d6h
###########################################################################
## 20220313_191550_751386223 ##       executable completed (exit code=0) ##
log_run argument(s): -l k8s_secret_csi-kube-secret
Executable: '/usr/bin/kubectl'
3 argument(s) to executable: 'get' 'secret' 'csi-kube-secret'

## 20220313_191550_502907429 ##                      executable starting ##
###########################################################################
NAME              TYPE     DATA   AGE
csi-kube-secret   Opaque   2      5d6h
###########################################################################
## 20220313_191550_748579296 ##       executable completed (exit code=0) ##
log_run argument(s): -l k8s_secret_csi-sma-secret
Executable: '/usr/bin/kubectl'
3 argument(s) to executable: 'get' 'secret' 'csi-sma-secret'

## 20220313_191550_504026515 ##                      executable starting ##
###########################################################################
NAME             TYPE     DATA   AGE
csi-sma-secret   Opaque   2      5d6h
###########################################################################
## 20220313_191550_753654891 ##       executable completed (exit code=0) ##
```

### goss-ceph-storage-config-files.yaml

```
ncn-s001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars ./variables-ncn.yaml -g ./goss-ceph-storage-config-files.yaml v
..

Total Duration: 0.025s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-s001:/tmp/zz # cat /opt/cray/tests/install/logs/ceph_storage_config_files/20220313_191538_574569445_23619.log
log_run argument(s): -l ceph_storage_config_files
Executable: 'ls'
2 argument(s) to executable: '-al' '/etc/ceph'

## 20220313_191538_584895539 ##                      executable starting ##
###########################################################################
total 52
drwxr-xr-x 3 root root  4096 Mar  9 17:24 .
drwxr-xr-x 1 root root  4096 Mar  9 17:49 ..
-rw------- 1 root root    63 Mar  8 12:03 ceph.client.admin.keyring
-rw------- 1 root root   148 Mar  9 17:24 ceph.client.ro.keyring
-rw-r--r-- 1 root root   259 Mar  8 12:03 ceph.conf
-rw-r--r-- 1 root root   259 Mar  8 12:03 ceph_conf_min
-rw-r--r-- 1 root root   595 Mar  8 12:03 ceph.pub
drwx------ 2 root root 16384 Mar  8 11:43 lost+found
-rw-r--r-- 1 root root  6411 Mar  8 12:03 rgw.pem
###########################################################################
## 20220313_191538_590260971 ##       executable completed (exit code=0) ##
```

### goss-ceph-storage-images.yaml

```
ncn-s001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars ./variables-ncn.yaml -g ./goss-ceph-storage-images.yaml v
..

Total Duration: 0.135s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-s001:/tmp/zz # cat /opt/cray/tests/install/logs/ceph_storage_images/20220313_191618_110493152_24755.log
log_run argument(s): -l ceph_storage_images
Executable: 'podman'
1 argument(s) to executable: 'images'

## 20220313_191618_119792761 ##                      executable starting ##
###########################################################################
REPOSITORY                                                                  TAG       IMAGE ID      CREATED        SIZE
registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph  v15.2.15  183b3c85e378  6 days ago     1.4 GB
registry.local/baseos/busybox                                               1         b238987be87d  2 months ago   1.46 MB
registry.local/quay.io/prometheus/node-exporter                             v1.2.2    1d2ca0d48a6b  7 months ago   22.6 MB
registry.local/prometheus/node-exporter                                     v1.2.2    1d2ca0d48a6b  7 months ago   22.6 MB
<none>                                                                      <none>    0fafea149859  7 months ago   22.6 MB
registry.local/ceph/ceph                                                    v15.2.12  c717e215da21  10 months ago  1.05 GB
registry.local/ceph/ceph-grafana                                            6.7.4     ae5c36c3d3cd  10 months ago  496 MB
registry.local/ceph/ceph                                                    v15.2.8   5553b0cb212c  15 months ago  965 MB
registry.local/quay.io/prometheus/alertmanager                              v0.21.0   30aabfb0f939  21 months ago  56.9 MB
<none>                                                                      <none>    c876f5897d7b  21 months ago  56.9 MB
registry.local/prometheus/alertmanager                                      v0.21.0   30aabfb0f939  21 months ago  56.9 MB
registry.local/ceph/ceph-grafana                                            6.6.2     a0dce381714a  21 months ago  519 MB
registry.local/quay.io/prometheus/prometheus                                v2.18.1   5abb731661eb  22 months ago  141 MB
registry.local/prometheus/prometheus                                        v2.18.1   5abb731661eb  22 months ago  141 MB
<none>                                                                      <none>    de242295e225  22 months ago  141 MB
<none>                                                                      <none>    0881eb8f169f  2 years ago    53.5 MB
registry.local/prometheus/alertmanager                                      v0.20.0   92adfa57f0f9  2 years ago    53.5 MB
registry.local/quay.io/prometheus/alertmanager                              v0.20.0   92adfa57f0f9  2 years ago    53.5 MB
registry.local/quay.io/prometheus/node-exporter                             v0.18.1   e5a616e4b9cf  2 years ago    24.3 MB
###########################################################################
## 20220313_191618_236490831 ##       executable completed (exit code=0) ##
```

### goss-rgw-health.yaml

```
ncn-s001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars ./variables-ncn.yaml -g ./goss-rgw-health.yaml v
.

Total Duration: 6.972s
Count: 1, Failed: 0, Skipped: 0
```

```
ncn-s001:/tmp/zz # cat /opt/cray/tests/install/logs/verify_rgw_health/20220313_191600_421998668_24047.log
log_run argument(s): -l verify_rgw_health
Executable: '/opt/cray/tests/install/ncn/scripts/rgw_health_check.sh'
No arguments to executable

## 20220313_191600_432128046 ##                      executable starting ##
###########################################################################
---Test that rgw-vip and storage nodes are reachable---
Passed: rgw-vip and storage nodes are responding.

---Test ability to upload and download a file from bucket---
-Created a test bucket.
-File successfully uploaded to bucket.
-Succesfully downloaded file.
-File successfully deleted from bucket.
-Test bucket succesfully deleted.
Passed: successfully uploaded and downloaded a file from bucket.
###########################################################################
## 20220313_191607_384175773 ##       executable completed (exit code=0) ##
```

## Risks and Mitigations

Low risk. Enabling logging on an existing test is cookie-cutter.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

