### PR TITLE
CASMINST-4229: Enable logging for 4 upgrade preflight tests

### DIFF
--- a/goss-testing/tests/common/goss-command-available.yaml
+++ b/goss-testing/tests/common/goss-command-available.yaml
@@ -21,15 +21,34 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  {{range $command := index .Vars "commands"}}
-  command_{{$command}}:
-    title: Command '{{$command}}' Available
-    meta:
-      desc: Validates that '{{$command}}' is available on the local system.
-      sev: 0
-    exec: {{$command}}
-    exit-status: 0
-    timeout: 10000
-    skip: false
-{{end}}
+    {{range $index, $command := index .Vars "commands"}}
+        # Split the command path into a list, take the last field (the command base name), and convert it to lowercase
+        {{ $command_base_name := splitList "/" $command | last | toLower }}
+
+        # If there are any non-alphanumeric characters, convert them to underscores, and then strip away any
+        # leading or trailing underscores
+        {{ if regexMatch "[^a-z0-9]" $command_base_name }}
+            {{ $command_base_name = regexReplaceAll "[^a-z0-9]" $command_base_name "_" | trimAll "_" }}
+
+            # If there are any strings of one or more consecutive underscores, replace them with a single underscore
+            {{ if contains "__" $command_base_name }}
+                {{ $command_base_name = regexReplaceAll "_{2,}" $command_base_name "_" }}
+            {{end}}
+
+        {{end}}
+
+        {{ $testlabel := $command_base_name | printf "command_available_%d_%s" $index }}
+        {{$testlabel}}:
+            title: Command '{{$command}}' Available
+            meta:
+                desc: Validates that '{{$command}}' is available and executes successfully on the local system.
+                sev: 0
+            exec: |-
+                "{{$logrun}}" -l "{{$testlabel}}" {{$command}}
+            exit-status: 0
+            timeout: 10000
+            skip: false
+    {{end}}

--- a/goss-testing/tests/ncn/goss-k8s-cray-cli-configured.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-cray-cli-configured.yaml
@@ -21,13 +21,18 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  k8s_cray_cli_configured:
-    title: Validate that the cray cli is configured
-    meta:
-      desc: If this test fails, follow instructions in the admin guide for how to initially configure the cray cli.
-      sev: 0
-    exec: "cray artifacts buckets list"
-    exit-status: 0
-    timeout: 10000
-    skip: false
+    {{ $testlabel := "k8s_cray_cli_configured" }}
+    {{$testlabel}}:
+        title: Validate that the cray CLI is configured
+        meta:
+            desc: If this test fails, follow instructions in the admin guide for how to initially configure the cray CLI.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                cray artifacts buckets list
+        exit-status: 0
+        timeout: 10000
+        skip: false

--- a/goss-testing/tests/ncn/goss-k8s-ipxe-pod-running.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-ipxe-pod-running.yaml
@@ -21,13 +21,21 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $kubectl := .Vars.kubectl }}
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  k8s_service_ipxe_running:
-    title: Kubernetes Service 'cray-ipxe' Is Running
-    meta:
-      desc: If this test fails, look at the state of the ipxe pod (kubectl get po -n services | grep cray-ipxe) to investigate.
-      sev: 0
-    exec: kubectl get pods -n services -l 'app.kubernetes.io/name=cray-ipxe' | awk '{ print $3 }' | grep Running
-    exit-status: 0
-    timeout: 10000
-    skip: false
+    {{ $testlabel := "k8s_service_ipxe_running" }}
+    {{$testlabel}}:
+        title: Kubernetes Service 'cray-ipxe' Is Running
+        meta:
+            desc: If this test fails, look at the state of the ipxe pod (kubectl get po -n services | grep cray-ipxe) to investigate.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$kubectl}}" get pods -n services -l 'app.kubernetes.io/name=cray-ipxe' |
+                awk '{ print $3 }' |
+                grep Running
+        exit-status: 0
+        timeout: 10000
+        skip: false

--- a/goss-testing/tests/ncn/goss-k8s-kea-pod-running.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-kea-pod-running.yaml
@@ -21,13 +21,21 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $kubectl := .Vars.kubectl }}
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  k8s_service_kea_running:
-    title: Kubernetes Service 'cray-dhcp-kea' Is Running
-    meta:
-      desc: If this test fails, look at the state of the dhcp-kea pod (kubectl get po -n services | grep cray-dhcp-kea) to investigate.
-      sev: 0
-    exec: kubectl get pods -n services -l 'app.kubernetes.io/name=cray-dhcp-kea' | awk '{ print $3 }' | grep Running
-    exit-status: 0
-    timeout: 10000
-    skip: false
+    {{ $testlabel := "k8s_service_kea_running" }}
+    {{$testlabel}}:
+        title: Kubernetes Service 'cray-dhcp-kea' Is Running
+        meta:
+            desc: If this test fails, look at the state of the dhcp-kea pod (kubectl get po -n services | grep cray-dhcp-kea) to investigate.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$kubectl}}" get pods -n services -l 'app.kubernetes.io/name=cray-dhcp-kea' |
+                awk '{ print $3 }' |
+                grep Running
+        exit-status: 0
+        timeout: 10000
+        skip: false


### PR DESCRIPTION
## Summary and Scope

This PR adds logging to the following tests:
* goss-command-available.yaml
* goss-k8s-cray-cli-configured.yaml
* goss-k8s-ipxe-pod-running.yaml
* goss-k8s-kea-pod-running.yaml

The tests themselves are unchanged.

## Issues and Related PRs

None

## Testing

I ran the updated tests on hela.

### goss-command-available.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars ./variables-ncn.yaml -g ./goss-command-available.yaml v
..

Total Duration: 1.238s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/command_available_*/*
log_run argument(s): -l command_available_0_kubectl_version_client
Executable: 'kubectl'
2 argument(s) to executable: 'version' '--client'

## 20220313_201947_323360375 ##                      executable starting ##
###########################################################################
Client Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.13", GitCommit:"2444b3347a2c45eb965b182fb836e1f51dc61b70", GitTreeState:"clean", BuildDate:"2021-11-17T13:05:33Z", GoVersion:"go1.15.15", Compiler:"gc", Platform:"linux/amd64"}
###########################################################################
## 20220313_201947_398176638 ##       executable completed (exit code=0) ##
log_run argument(s): -l command_available_1_cray_version
Executable: 'cray'
1 argument(s) to executable: '--version'

## 20220313_201947_323976488 ##                      executable starting ##
###########################################################################
cray, version 0.46.0

###########################################################################
## 20220313_201948_532819758 ##       executable completed (exit code=0) ##
```

### goss-k8s-cray-cli-configured.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars ./variables-ncn.yaml -g ./goss-k8s-cray-cli-configured.yaml v
.

Total Duration: 1.658s
Count: 1, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/k8s_cray_cli_configured/20220313_201837_492846225_3327083.log
log_run argument(s): -l k8s_cray_cli_configured
Executable: 'cray'
3 argument(s) to executable: 'artifacts' 'buckets' 'list'

## 20220313_201837_502295392 ##                      executable starting ##
###########################################################################
results = [ "admin-tools", "alc", "badger", "benji-backups", "boot-images", "config-data", "etcd-backup", "fw-update", "ims", "install-artifacts", "ncn-images", "ncn-utils", "nmd", "postgres-backup", "prs", "sat", "sds", "sls", "sma", "ssd", "ssi", "ssm", "vbis", "velero", "wlm",]

###########################################################################
## 20220313_201839_141233241 ##       executable completed (exit code=0) ##
```

### goss-k8s-ipxe-pod-running.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars ./variables-ncn.yaml -g ./goss-k8s-ipxe-pod-running.yaml v
.

Total Duration: 0.154s
Count: 1, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/k8s_service_ipxe_running/20220313_201852_958219631_3327294.log
log_run argument(s): -l k8s_service_ipxe_running
Executable: '/usr/bin/kubectl'
6 argument(s) to executable: 'get' 'pods' '-n' 'services' '-l' 'app.kubernetes.io/name=cray-ipxe'

## 20220313_201852_967276410 ##                      executable starting ##
###########################################################################
NAME                         READY   STATUS    RESTARTS   AGE
cray-ipxe-8587996f97-xgzzc   2/2     Running   1          3d6h
###########################################################################
## 20220313_201853_105185788 ##       executable completed (exit code=0) ##
```

### goss-k8s-kea-pod-running.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars ./variables-ncn.yaml -g ./goss-k8s-kea-pod-running.yaml v
.

Total Duration: 0.176s
Count: 1, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/k8s_service_kea_running/20220313_201900_846234455_3327389.log
log_run argument(s): -l k8s_service_kea_running
Executable: '/usr/bin/kubectl'
6 argument(s) to executable: 'get' 'pods' '-n' 'services' '-l' 'app.kubernetes.io/name=cray-dhcp-kea'

## 20220313_201900_855562206 ##                      executable starting ##
###########################################################################
NAME                            READY   STATUS    RESTARTS   AGE
cray-dhcp-kea-dbf9c4787-rk6fp   3/3     Running   0          3d7h
###########################################################################
## 20220313_201901_011463236 ##       executable completed (exit code=0) ##
```

## Risks and Mitigations

Low risk. Adding logging is cookie-cutter.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

