### PR TITLE
CASMINST-4232: Enable logging for 5 tests

### DIFF
--- a/goss-testing/tests/ncn/goss-cray-service-etcd-health-check.yaml
+++ b/goss-testing/tests/ncn/goss-cray-service-etcd-health-check.yaml
@@ -21,13 +21,20 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
+{{ $logrun := $scripts | printf "%s/log_run.sh" }}
+{{ $etcd_health_check := $scripts | printf "%s/etcd_health_check.sh" }}
 command:
-  verify_etcd_health:
-    title: Verify cray etcd is healthy
-    meta:
-      desc: Check the correct number of etcd nodes are running per cluster, check endpoint health, and check that no alarms are set. Upon failure, run '{{.Env.GOSS_BASE}}/scripts/etcd_health_check.sh' for more details.
-      sev: 0
-    exec: "{{.Env.GOSS_BASE}}/scripts/etcd_health_check.sh"
-    exit-status: 0
-    timeout: 180000
-    skip: false
+    {{ $testlabel := "verify_etcd_health" }}
+    {{$testlabel}}:
+        title: Verify cray etcd is healthy
+        meta:
+            desc: Check the correct number of etcd nodes are running per cluster, check endpoint health, and check that no alarms are set. Upon failure, run '{{$etcd_health_check}}' for more details.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$etcd_health_check}}"
+        exit-status: 0
+        timeout: 180000
+        skip: false

--- a/goss-testing/tests/ncn/goss-k8s-certmanager-certs-ready.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-certmanager-certs-ready.yaml
@@ -21,13 +21,21 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $kubectl := .Vars.kubectl }}
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  k8s_certmgr_certificates:
-    title: Kubernetes Cert-manager Certificates Ready
-    meta:
-      desc: Validates All Cert-manager Certificates are Ready
-      sev: 0
-    exec: "kubectl get certificate -A -o json | jq '.items[].status.conditions[] | select(.type==\"Ready\") | select(.status==\"False\")' | wc -l"
-    stdout:
-    - "/^0$/"
-    exit-status: 0
+    {{ $testlabel := "k8s_certmgr_certificates" }}
+    {{$testlabel}}:
+        title: Kubernetes Cert-manager Certificates Ready
+        meta:
+            desc: Validates All Cert-manager Certificates are Ready
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$kubectl}}" get certificate -A -o json |
+                jq '.items[].status.conditions[] | select(.type=="Ready") | select(.status=="False")' |
+                wc -l
+        stdout:
+            - "/^0$/"
+        exit-status: 0

--- a/goss-testing/tests/ncn/goss-k8s-certmanager-issuers-ready.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-certmanager-issuers-ready.yaml
@@ -21,13 +21,21 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $kubectl := .Vars.kubectl }}
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  k8s_certmgr_issuers:
-    title: Kubernetes Cert-manager Issuers Ready
-    meta:
-      desc: Validates All Cert-manager Issuers are Ready
-      sev: 0
-    exec: "kubectl get issuer -A -o json | jq '.items[].status.conditions[] | select(.type==\"Ready\") | select(.status==\"False\")' | wc -l"
-    stdout:
-    - "/^0$/"
-    exit-status: 0
+    {{ $testlabel := "k8s_certmgr_issuers" }}
+    {{$testlabel}}:
+        title: Kubernetes Cert-manager Issuers Ready
+        meta:
+            desc: Validates All Cert-manager Issuers are Ready
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$kubectl}}" get issuer -A -o json |
+                jq '.items[].status.conditions[] | select(.type=="Ready") | select(.status=="False")' |
+                wc -l
+        stdout:
+            - "/^0$/"
+        exit-status: 0

--- a/goss-testing/tests/ncn/goss-k8s-istio-pod-containers-running.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-istio-pod-containers-running.yaml
@@ -21,15 +21,22 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $kubectl := .Vars.kubectl }}
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  k8s-istio-pod-containers-running:
-    title: Validate istio-ingressgateway pod containers are Running
-    meta:
-      desc: Validates that all istio-ingressgateway pod containers are running. If this test fails, run "kubectl get pods -n istio-system -o wide  | awk '$1 ~ "istio-ingressgateway" && $3 == "Running" && split($2,count,"/") && (count[1] != count[2])'" to see a list of failing pods to investigate.
-      sev: 0
-    exec: kubectl get pods -n istio-system | awk '$1 ~ "istio-ingressgateway" && $3 == "Running" && split($2,count,"/") { if (count[1] != count[2])  print "FAIL"; else print "PASS" }'
-    exit-status: 0
-    stdout:
-    - "!FAIL"
-    timeout: 5000
-    skip: false
+    {{ $testlabel := "k8s-istio-pod-containers-running" }}
+    {{$testlabel}}:
+        title: Validate istio-ingressgateway pod containers are Running
+        meta:
+            desc: Validates that all istio-ingressgateway pod containers are running. If this test fails, run "kubectl get pods -n istio-system -o wide  | awk '$1 ~ "istio-ingressgateway" && $3 == "Running" && split($2,count,"/") && (count[1] != count[2])'" to see a list of failing pods to investigate.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$kubectl}}" get pods -n istio-system |
+                awk '$1 ~ "istio-ingressgateway" && $3 == "Running" && split($2,count,"/") { if (count[1] != count[2])  print "FAIL"; else print "PASS" }'
+        exit-status: 0
+        stdout:
+            - "!FAIL"
+        timeout: 5000
+        skip: false

--- a/goss-testing/tests/ncn/goss-k8s-istio-pods-running.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-istio-pods-running.yaml
@@ -21,15 +21,22 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $kubectl := .Vars.kubectl }}
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  k8s-istio-pods-running:
-    title: Validate istio-ingressgateway pods are Running
-    meta:
-      desc: Validates that istio-ingressgateway pods are running. If this test fails, run "kubectl get pods -n istio-system -o wide | awk '$1 ~ "istio-ingressgateway" && $3 != "Running"'" to see a list of failing pods to investigate.
-      sev: 0
-    exec: kubectl get pods -n istio-system | awk '$1 ~ "istio-ingressgateway" { if ($3 != "Running") print "FAIL"; else print "PASS" }'
-    exit-status: 0
-    stdout:
-    - "!FAIL"
-    timeout: 5000
-    skip: false
+    {{ $testlabel := "k8s-istio-pods-running" }}
+    {{$testlabel}}:
+        title: Validate istio-ingressgateway pods are Running
+        meta:
+            desc: Validates that istio-ingressgateway pods are running. If this test fails, run "kubectl get pods -n istio-system -o wide | awk '$1 ~ "istio-ingressgateway" && $3 != "Running"'" to see a list of failing pods to investigate.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$kubectl}}" get pods -n istio-system |
+                awk '$1 ~ "istio-ingressgateway" { if ($3 != "Running") print "FAIL"; else print "PASS" }'
+        exit-status: 0
+        stdout:
+            - "!FAIL"
+        timeout: 5000
+        skip: false


### PR DESCRIPTION
## Summary and Scope

This PR adds logging to the following tests:
* goss-cray-service-etcd-health-check.yaml
* goss-k8s-certmanager-certs-ready.yaml
* goss-k8s-certmanager-issuers-ready.yaml
* goss-k8s-istio-pod-containers-running.yaml
* goss-k8s-istio-pods-running.yaml

The tests themselves are unchanged.

## Issues and Related PRs

None

## Testing

I ran the updated tests on hela.

### goss-cray-service-etcd-health-check.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml -g ./goss-cray-service-etcd-health-check.yaml v
.

Total Duration: 18.223s
Count: 1, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/etcd_database_health/20220311_182411_930975914_1315099.log
log_run argument(s): -l etcd_database_health
Executable: '/opt/cray/tests/install/ncn/scripts/etcd_database_health.sh'
No arguments to executable

## 20220311_182411_940244425 ##                      executable starting ##
###########################################################################
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
PASS:  OK foo fooCheck 1
###########################################################################
## 20220311_182419_532006580 ##       executable completed (exit code=0) ##
```

### goss-k8s-certmanager-certs-ready.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml -g ./goss-k8s-certmanager-certs-ready.yaml v
..

Total Duration: 0.169s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/k8s_certmgr_certificates/20220314_005356_285165094_3480762.log
log_run argument(s): -l k8s_certmgr_certificates
Executable: '/usr/bin/kubectl'
5 argument(s) to executable: 'get' 'certificate' '-A' '-o' 'json'

## 20220314_005356_295007130 ##                      executable starting ##
###########################################################################
{
    "apiVersion": "v1",
    "items": [
        {
            "apiVersion": "cert-manager.io/v1alpha3",
            "kind": "Certificate",
            "metadata": {
```
...
```
    ],
    "kind": "List",
    "metadata": {
        "resourceVersion": "",
        "selfLink": ""
    }
}
###########################################################################
## 20220314_005356_441877329 ##       executable completed (exit code=0) ##
```

### goss-k8s-certmanager-issuers-ready.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml -g ./goss-k8s-certmanager-issuers-ready.yaml v
..

Total Duration: 0.223s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/k8s_certmgr_issuers/20220314_005408_064239154_3481054.log
log_run argument(s): -l k8s_certmgr_issuers
Executable: '/usr/bin/kubectl'
5 argument(s) to executable: 'get' 'issuer' '-A' '-o' 'json'

## 20220314_005408_073184315 ##                      executable starting ##
###########################################################################
{
    "apiVersion": "v1",
    "items": [
        {
            "apiVersion": "cert-manager.io/v1alpha3",
            "kind": "Issuer",
```
...
```
    "kind": "List",
    "metadata": {
        "resourceVersion": "",
        "selfLink": ""
    }
}
###########################################################################
## 20220314_005408_276543042 ##       executable completed (exit code=0) ##

```

### goss-k8s-istio-pod-containers-running.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml -g ./goss-k8s-istio-pod-containers-running.yaml v
..

Total Duration: 0.161s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/k8s-istio-pod-containers-running/20220314_005417_655131084_3481131.log
log_run argument(s): -l k8s-istio-pod-containers-running
Executable: '/usr/bin/kubectl'
4 argument(s) to executable: 'get' 'pods' '-n' 'istio-system'

## 20220314_005417_665451037 ##                      executable starting ##
###########################################################################
NAME                                                   READY   STATUS    RESTARTS   AGE
istio-ingressgateway-6467b544f8-546d8                  1/1     Running   0          3d11h
istio-ingressgateway-6467b544f8-hklxg                  1/1     Running   0          3d11h
istio-ingressgateway-6467b544f8-hqrwn                  1/1     Running   0          3d11h
istio-ingressgateway-customer-admin-6895d6d84f-9wc8k   1/1     Running   0          3d11h
istio-ingressgateway-customer-admin-6895d6d84f-kmblm   1/1     Running   0          3d11h
istio-ingressgateway-customer-admin-6895d6d84f-q9rnm   1/1     Running   0          3d11h
istio-ingressgateway-customer-user-6f7d84fc87-c6w7h    1/1     Running   0          3d11h
istio-ingressgateway-customer-user-6f7d84fc87-pc4bk    1/1     Running   0          3d11h
istio-ingressgateway-customer-user-6f7d84fc87-t8kbg    1/1     Running   0          3d11h
istio-ingressgateway-hmn-6bcc447f6f-lbmcs              1/1     Running   0          3d11h
istio-ingressgateway-hmn-6bcc447f6f-nt6j4              1/1     Running   0          3d11h
istio-ingressgateway-hmn-6bcc447f6f-xqk62              1/1     Running   0          3d11h
istiod-fdd865dc5-fwg6q                                 1/1     Running   0          3d11h
kiali-794557f9d9-zvqk9                                 1/1     Running   0          3d11h
###########################################################################
## 20220314_005417_804891907 ##       executable completed (exit code=0) ##
```

### goss-k8s-istio-pods-running.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml -g ./goss-k8s-istio-pods-running.yaml v
..

Total Duration: 0.158s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/k8s-istio-pods-running/20220314_005425_941536103_3481227.log
log_run argument(s): -l k8s-istio-pods-running
Executable: '/usr/bin/kubectl'
4 argument(s) to executable: 'get' 'pods' '-n' 'istio-system'

## 20220314_005425_951021468 ##                      executable starting ##
###########################################################################
NAME                                                   READY   STATUS    RESTARTS   AGE
istio-ingressgateway-6467b544f8-546d8                  1/1     Running   0          3d11h
istio-ingressgateway-6467b544f8-hklxg                  1/1     Running   0          3d11h
istio-ingressgateway-6467b544f8-hqrwn                  1/1     Running   0          3d11h
istio-ingressgateway-customer-admin-6895d6d84f-9wc8k   1/1     Running   0          3d11h
istio-ingressgateway-customer-admin-6895d6d84f-kmblm   1/1     Running   0          3d11h
istio-ingressgateway-customer-admin-6895d6d84f-q9rnm   1/1     Running   0          3d11h
istio-ingressgateway-customer-user-6f7d84fc87-c6w7h    1/1     Running   0          3d11h
istio-ingressgateway-customer-user-6f7d84fc87-pc4bk    1/1     Running   0          3d11h
istio-ingressgateway-customer-user-6f7d84fc87-t8kbg    1/1     Running   0          3d11h
istio-ingressgateway-hmn-6bcc447f6f-lbmcs              1/1     Running   0          3d11h
istio-ingressgateway-hmn-6bcc447f6f-nt6j4              1/1     Running   0          3d11h
istio-ingressgateway-hmn-6bcc447f6f-xqk62              1/1     Running   0          3d11h
istiod-fdd865dc5-fwg6q                                 1/1     Running   0          3d11h
kiali-794557f9d9-zvqk9                                 1/1     Running   0          3d11h
###########################################################################
## 20220314_005426_089000475 ##       executable completed (exit code=0) ##
```

## Risks and Mitigations

Low risk. Adding logging is cookie-cutter.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
