### PR TITLE
CASMINST-4233: Enable logging for 4 more tests

### DIFF
--- a/goss-testing/tests/ncn/goss-k8s-monitoring-url.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-monitoring-url.yaml
@@ -21,13 +21,20 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
+{{ $logrun := $scripts | printf "%s/log_run.sh" }}
+{{ $monitoring_check := $scripts | printf "%s/monitoring_check.sh" }}
 command:
-  goss-k8s-monitoring-url:
-    title: Check that all Kubernetes Monitoring URLs are Redirecting and Responding
-    meta:
-      desc: Checks whether monitoring URLs are accessible. If the test fails, the expected HTTP status was not returned. Check the System Management Health information in the Operations section. For more detailed output, run 'GOSS_BASE={{.Env.GOSS_BASE}} {{.Env.GOSS_BASE}}/scripts/monitoring_check.sh'
-      sev: 0
-    exec: "{{.Env.GOSS_BASE}}/scripts/monitoring_check.sh"
-    exit-status: 0
-    timeout: 20000
-    skip: false
+    {{ $testlabel := "goss-k8s-monitoring-url" }}
+    {{$testlabel}}:
+        title: Check that all Kubernetes Monitoring URLs are Redirecting and Responding
+        meta:
+            desc: Checks whether monitoring URLs are accessible. If the test fails, the expected HTTP status was not returned. Check the System Management Health information in the Operations section. For more detailed output, run 'GOSS_BASE={{.Env.GOSS_BASE}} {{$monitoring_check}}'
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$monitoring_check}}"
+        exit-status: 0
+        timeout: 20000
+        skip: false

--- a/goss-testing/tests/ncn/goss-k8s-storageclass.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-storageclass.yaml
@@ -21,15 +21,21 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $kubectl := .Vars.kubectl }}
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  k8s_storageclasses:
-    title: Kubernetes StorageClasses
-    meta:
-      desc: Validates Kubernetes has correct StorageClasses.
-      sev: 0
-    exec: "kubectl get storageclass"
-    stdout:
-    - ceph-cephfs-external
-    - k8s-block-replicated
-    - sma-block-replicated
-    exit-status: 0
+    {{ $testlabel := "k8s_storageclasses" }}
+    {{$testlabel}}:
+        title: Kubernetes StorageClasses
+        meta:
+            desc: Validates Kubernetes has correct StorageClasses.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$kubectl}}" get storageclass
+        stdout:
+            - ceph-cephfs-external
+            - k8s-block-replicated
+            - sma-block-replicated
+        exit-status: 0

--- a/goss-testing/tests/ncn/goss-k8s-trustedcerts-configmaps-exist.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-trustedcerts-configmaps-exist.yaml
@@ -21,11 +21,17 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
+{{ $logrun := $scripts | printf "%s/log_run.sh" }}
 command:
-  k8s_trustedcerts_configmaps_exist:
-    title: Kubernetes Ensure Configmaps Containing CA Certs Exist
-    meta:
-      desc: Kubernetes Ensure Configmaps Containing CA Certs Exist
-      sev: 0
-    exec: "{{.Env.GOSS_BASE}}/scripts/tco_configmaps_exist.sh pki-operator shasta-platform-1-3-compat"
-    exit-status: 0
+    {{ $testlabel := "k8s_trustedcerts_configmaps_exist" }}
+    {{$testlabel}}:
+        title: Kubernetes Ensure Configmaps Containing CA Certs Exist
+        meta:
+            desc: Kubernetes Ensure Configmaps Containing CA Certs Exist
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$scripts}}/tco_configmaps_exist.sh" pki-operator shasta-platform-1-3-compat
+        exit-status: 0

--- a/goss-testing/tests/ncn/goss-k8s-verify-cluster.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-verify-cluster.yaml
@@ -21,19 +21,25 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $kubectl := .Vars.kubectl }}
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  k8s_verify_cluster:
-    title: Kubernetes Pods
-    meta:
-      desc: Kubernetes kube-system namespace pods are running.
-      sev: 0
-    exec: "kubectl get po -n kube-system"
-    stdout:
-    - /^kube-apiserver.*Running/
-    - /^kube-controller-manager.*Running/
-    - /^kube-multus-ds.*Running/
-    - /^kube-proxy.*Running/
-    - /^kube-scheduler.*Running/
-    - /^weave-net.*Running/
-    - /^coredns.*Running/
-    exit-status: 0
+    {{ $testlabel := "k8s_verify_cluster" }}
+    {{$testlabel}}:
+        title: Kubernetes Pods
+        meta:
+            desc: Kubernetes kube-system namespace pods are running.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$kubectl}}" get po -n kube-system -o custom-columns=:.metadata.name,:status.phase --no-headers
+        stdout:
+            - /^coredns-.*Running/
+            - /^kube-apiserver-.*Running/
+            - /^kube-controller-manager-.*Running/
+            - /^kube-multus-ds-.*Running/
+            - /^kube-proxy-.*Running/
+            - /^kube-scheduler-.*Running/
+            - /^weave-net-.*Running/
+        exit-status: 0


### PR DESCRIPTION
## Summary and Scope

This PR adds logging to the following tests:
* goss-k8s-monitoring-url.yaml
* goss-k8s-storageclass.yaml
* goss-k8s-trustedcerts-configmaps-exist.yaml
* goss-k8s-verify-cluster.yaml

The tests themselves are unchanged.

## Issues and Related PRs

None

## Testing

I ran the updated tests on hela.

### goss-k8s-monitoring-url.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml -g ./goss-k8s-monitoring-url.yaml v
.

Total Duration: 0.731s
Count: 1, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/goss-k8s-monitoring-url/20220314_010752_002495453_3488775.log
log_run argument(s): -l goss-k8s-monitoring-url
Executable: '/opt/cray/tests/install/ncn/scripts/monitoring_check.sh'
No arguments to executable

## 20220314_010752_010791190 ##                      executable starting ##
###########################################################################
PASS
###########################################################################
## 20220314_010752_724139884 ##       executable completed (exit code=0) ##
```

### goss-k8s-storageclass.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml -g ./goss-k8s-storageclass.yaml v
..

Total Duration: 0.129s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/k8s_storageclasses/20220314_010800_359804207_3488944.log
log_run argument(s): -l k8s_storageclasses
Executable: '/usr/bin/kubectl'
2 argument(s) to executable: 'get' 'storageclass'

## 20220314_010800_369320678 ##                      executable starting ##
###########################################################################
NAME                             PROVISIONER           RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
ceph-cephfs-external             cephfs.csi.ceph.com   Delete          Immediate           true                   5d11h
k8s-block-replicated (default)   rbd.csi.ceph.com      Delete          Immediate           true                   5d11h
sma-block-replicated             rbd.csi.ceph.com      Delete          Immediate           true                   5d11h
###########################################################################
## 20220314_010800_479062620 ##       executable completed (exit code=0) ##
```

### goss-k8s-trustedcerts-configmaps-exist.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml -g ./goss-k8s-trustedcerts-configmaps-exist.yaml v
.

Total Duration: 0.479s
Count: 1, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/k8s_trustedcerts_configmaps_exist/20220314_010807_673303969_3489136.loglog_run argument(s): -l k8s_trustedcerts_configmaps_exist
Executable: '/opt/cray/tests/install/ncn/scripts/tco_configmaps_exist.sh'
2 argument(s) to executable: 'pki-operator' 'shasta-platform-1-3-compat'

## 20220314_010807_682641029 ##                      executable starting ##
###########################################################################
###########################################################################
## 20220314_010808_143672554 ##       executable completed (exit code=0) ##
```

### goss-k8s-verify-cluster.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml -g ./goss-k8s-verify-cluster.yaml v
..

Total Duration: 0.280s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/k8s_verify_cluster/20220314_010816_032457207_3489468.log
log_run argument(s): -l k8s_verify_cluster
Executable: '/usr/bin/kubectl'
7 argument(s) to executable: 'get' 'po' '-n' 'kube-system' '-o' 'custom-columns=:.metadata.name,:status.phase' '--no-headers'

## 20220314_010816_041732721 ##                      executable starting ##
###########################################################################
coredns-76ccd59f5c-2p2xp           Running
coredns-76ccd59f5c-vxpl9           Running
kube-apiserver-ncn-m001            Running
kube-apiserver-ncn-m002            Running
kube-apiserver-ncn-m003            Running
kube-controller-manager-ncn-m001   Running
kube-controller-manager-ncn-m002   Running
kube-controller-manager-ncn-m003   Running
kube-etcdbackup-1647219600-wkmxf   Succeeded
kube-multus-ds-amd64-2nhxj         Running
kube-multus-ds-amd64-2qxs6         Running
kube-multus-ds-amd64-c8dfx         Running
kube-multus-ds-amd64-f5zbb         Running
kube-multus-ds-amd64-vx2p5         Running
kube-multus-ds-amd64-zbtrq         Running
kube-multus-ds-amd64-zh78d         Running
kube-proxy-7mgqk                   Running
kube-proxy-8s6nr                   Running
kube-proxy-jk4qb                   Running
kube-proxy-m9g52                   Running
kube-proxy-n5hhg                   Running
kube-proxy-nq77j                   Running
kube-proxy-wrnm9                   Running
kube-scheduler-ncn-m001            Running
kube-scheduler-ncn-m002            Running
kube-scheduler-ncn-m003            Running
metrics-server-7d959657d6-dwmdx    Running
node-problem-detector-5gqnd        Running
node-problem-detector-9nkfs        Running
node-problem-detector-djg28        Running
node-problem-detector-khcf7        Running
node-problem-detector-qwjtw        Running
node-problem-detector-tmtj5        Running
node-problem-detector-wwcqb        Running
sealed-secrets-bd8695cb-62pzk      Running
weave-net-8m68g                    Running
weave-net-9lq76                    Running
weave-net-nl6ml                    Running
weave-net-pgs27                    Running
weave-net-tv978                    Running
weave-net-xghwp                    Running
weave-net-xx49h                    Running
###########################################################################
## 20220314_010816_302988470 ##       executable completed (exit code=0) ##
```

## Risks and Mitigations

Low risk. Adding logging is cookie-cutter.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

