### PR TITLE
CASMINST-4234: Enable logging for 4 tests

### DIFF
--- a/goss-testing/tests/common/goss-network-interfaces.yaml
+++ b/goss-testing/tests/common/goss-network-interfaces.yaml
@@ -22,17 +22,20 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Variable set: network_interfaces
+
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-{{range $interface := index .Vars "network_interfaces"}}
-  {{if ne $interface "bond0.can0"}}
-  interface_{{$interface}}:
-    title: Interface '{{$interface}}' Has VLAN
-    meta:
-      desc: Ensures VLAN was created for network interface '{{$interface}}'.
-      sev: 0
-    exec: 'ip link show dev {{$interface}}'
-    exit-status: 0
-    timeout: 10000
-    skip: false
-  {{end}}
-{{end}}
+    {{range $interface := index .Vars "network_interfaces"}}
+        {{ $testlabel := $interface | printf "interface_%s" }}
+        {{$testlabel}}:
+            title: Interface '{{$interface}}' Has VLAN
+            meta:
+                desc: Ensures VLAN was created for network interface '{{$interface}}'.
+                sev: 0
+            exec: |-
+                "{{$logrun}}" -l "{{$testlabel}}" \
+                    ip link show dev "{{$interface}}"
+            exit-status: 0
+            timeout: 10000
+            skip: false
+    {{end}}

--- a/goss-testing/tests/ncn/goss-spire-healthcheck.yaml
+++ b/goss-testing/tests/ncn/goss-spire-healthcheck.yaml
@@ -21,13 +21,18 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  spire-healthcheck:
-    title: Spire Health Check
-    meta:
-      desc: Validates that the spire healthcheck runs successfully. If this fails, run `kubectl rollout restart -n spire daemonset request-ncn-join-token` to fix the issue.
-      sev: 0
-    exec: "spire-agent healthcheck -socketPath /root/spire/agent.sock"
-    exit-status: 0
-    timeout: 5000
-    skip: false
+    {{ $testlabel := "spire-healthcheck" }}
+    {{$testlabel}}:
+        title: Spire Health Check
+        meta:
+            desc: Validates that the spire healthcheck runs successfully. If this fails, run `kubectl rollout restart -n spire daemonset request-ncn-join-token` to fix the issue.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                spire-agent healthcheck -socketPath /root/spire/agent.sock
+        exit-status: 0
+        timeout: 5000
+        skip: false

--- a/goss-testing/tests/ncn/goss-spire-verify-api-fetch-jwt.yaml
+++ b/goss-testing/tests/ncn/goss-spire-verify-api-fetch-jwt.yaml
@@ -21,13 +21,19 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  spire_verify_api_fetch_jwt:
-    title: Verify spire api fetch of jwt
-    meta:
-      desc: Verify spire api fetch of jwt.
-      sev: 0
-    exec: /usr/bin/heartbeat-spire-agent api fetch jwt -socketPath /root/spire/agent.sock -audience goss-test >/dev/null
-    exit-status: 0
-    timeout: 5000
-    skip: false
+    {{ $testlabel := "spire_verify_api_fetch_jwt" }}
+    {{$testlabel}}:
+        title: Verify spire api fetch of jwt
+        meta:
+            desc: Verify spire api fetch of jwt.
+            sev: 0
+        # We do not want to log stdout from this command, so we call log_run with --no-stdout
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" --no-stdout \
+                /usr/bin/heartbeat-spire-agent api fetch jwt -socketPath /root/spire/agent.sock -audience goss-test >/dev/null
+        exit-status: 0
+        timeout: 5000
+        skip: false

--- a/goss-testing/tests/ncn/goss-spire-verify-pods.yaml
+++ b/goss-testing/tests/ncn/goss-spire-verify-pods.yaml
@@ -21,17 +21,23 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $kubectl := .Vars.kubectl }}
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  k8s_verify_spire_pods:
-    title: Spire Pods
-    meta:
-      desc: Kubernetes spire namespace pods are running.
-      sev: 0
-    exec: "kubectl get po -n spire"
-    stdout:
-    - /^request-ncn-join-token.*Running/
-    - /^spire-agent.*Running/
-    - /^spire-jwks.*Running/
-    - /^spire-postgres.*Running/
-    - /^spire-server.*Running/
-    exit-status: 0
+    {{ $testlabel := "k8s_verify_spire_pods" }}
+    {{$testlabel}}:
+        title: Spire Pods
+        meta:
+            desc: Kubernetes spire namespace pods are running.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$kubectl}}" get po -n spire -o custom-columns=:.metadata.name,:status.phase --no-headers
+        stdout:
+            - /^request-ncn-join-token-.*Running/
+            - /^spire-agent-.*Running/
+            - /^spire-jwks-.*Running/
+            - /^spire-postgres-.*Running/
+            - /^spire-server-.*Running/
+        exit-status: 0


### PR DESCRIPTION
## Summary and Scope

This PR adds logging to the following tests:
* goss-network-interfaces.yaml
* goss-spire-healthcheck.yaml
* goss-spire-verify-api-fetch-jwt.yaml
* goss-spire-verify-pods.yaml

The tests themselves are unchanged.

## Issues and Related PRs

None

## Testing

I ran the updated tests on hela.

### goss-network-interfaces.yaml

```
ncn-w002:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml -g ./goss-network-interfaces.yaml v
....

Total Duration: 0.028s
Count: 4, Failed: 0, Skipped: 0
```

```
ncn-w002:/tmp/zz # cat /opt/cray/tests/install/logs/interface_*/20220314_012242_01*.log
log_run argument(s): -l interface_bond0.can0
Executable: 'ip'
4 argument(s) to executable: 'link' 'show' 'dev' 'bond0.can0'

## 20220314_012242_020758817 ##                      executable starting ##
###########################################################################
7: bond0.can0@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether 14:02:ec:d9:78:c8 brd ff:ff:ff:ff:ff:ff
###########################################################################
## 20220314_012242_025889671 ##       executable completed (exit code=0) ##
log_run argument(s): -l interface_bond0.cmn0
Executable: 'ip'
4 argument(s) to executable: 'link' 'show' 'dev' 'bond0.cmn0'

## 20220314_012242_021741599 ##                      executable starting ##
###########################################################################
8: bond0.cmn0@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether 14:02:ec:d9:78:c8 brd ff:ff:ff:ff:ff:ff
###########################################################################
## 20220314_012242_027605993 ##       executable completed (exit code=0) ##
log_run argument(s): -l interface_bond0.hmn0
Executable: 'ip'
4 argument(s) to executable: 'link' 'show' 'dev' 'bond0.hmn0'

## 20220314_012242_021879044 ##                      executable starting ##
###########################################################################
9: bond0.hmn0@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether 14:02:ec:d9:78:c8 brd ff:ff:ff:ff:ff:ff
###########################################################################
## 20220314_012242_028240640 ##       executable completed (exit code=0) ##
log_run argument(s): -l interface_bond0.nmn0
Executable: 'ip'
4 argument(s) to executable: 'link' 'show' 'dev' 'bond0.nmn0'

## 20220314_012242_021740227 ##                      executable starting ##
###########################################################################
10: bond0.nmn0@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether 14:02:ec:d9:78:c8 brd ff:ff:ff:ff:ff:ff
###########################################################################
## 20220314_012242_027168352 ##       executable completed (exit code=0) ##
```

### goss-spire-healthcheck.yaml

```
ncn-w002:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml -g ./goss-spire-healthcheck.yaml v
.

Total Duration: 0.219s
Count: 1, Failed: 0, Skipped: 0
```

```
ncn-w002:/tmp/zz # cat /opt/cray/tests/install/logs/spire-healthcheck/20220314_012249_429655503_513537.log
log_run argument(s): -l spire-healthcheck
Executable: 'spire-agent'
3 argument(s) to executable: 'healthcheck' '-socketPath' '/root/spire/agent.sock'

## 20220314_012249_438913508 ##                      executable starting ##
###########################################################################
Agent is healthy.
###########################################################################
## 20220314_012249_639130168 ##       executable completed (exit code=0) ##
```

### goss-spire-verify-api-fetch-jwt.yaml

```
ncn-w002:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml -g ./goss-spire-verify-api-fetch-jwt.yaml v
.

Total Duration: 0.402s
Count: 1, Failed: 0, Skipped: 0
```

```
ncn-w002:/tmp/zz # cat /opt/cray/tests/install/logs/spire_verify_api_fetch_jwt/20220314_012255_240413006_514118.log
log_run argument(s): -l spire_verify_api_fetch_jwt --no-stdout
Executable: '/usr/bin/heartbeat-spire-agent'
7 argument(s) to executable: 'api' 'fetch' 'jwt' '-socketPath' '/root/spire/agent.sock' '-audience' 'goss-test'
stdout from executable will be suppressed in log by --no-stdout

## 20220314_012255_251316051 ##                      executable starting ##
###########################################################################
###########################################################################
## 20220314_012255_632715129 ##       executable completed (exit code=0) ##
```

### goss-spire-verify-pods.yaml

```
ncn-w002:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml -g ./goss-spire-verify-pods.yaml v
..

Total Duration: 0.305s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-w002:/tmp/zz # cat /opt/cray/tests/install/logs/k8s_verify_spire_pods/20220314_012303_070521195_515039.log
log_run argument(s): -l k8s_verify_spire_pods
Executable: '/usr/bin/kubectl'
7 argument(s) to executable: 'get' 'po' '-n' 'spire' '-o' 'custom-columns=:.metadata.name,:status.phase' '--no-headers'

## 20220314_012303_080280430 ##                      executable starting ##
###########################################################################
request-ncn-join-token-7nm65                  Running
request-ncn-join-token-d4wrt                  Running
request-ncn-join-token-g2qrf                  Running
request-ncn-join-token-nz92j                  Running
request-ncn-join-token-tfs2t                  Running
request-ncn-join-token-w4ccj                  Running
request-ncn-join-token-wx98t                  Running
spire-agent-525v5                             Running
spire-agent-g8wt6                             Running
spire-agent-m8znj                             Running
spire-agent-r7sx4                             Running
spire-create-pooler-schema-2-g7qg6            Succeeded
spire-jwks-6c97b5694f-6m4x9                   Running
spire-jwks-6c97b5694f-b6689                   Running
spire-jwks-6c97b5694f-j872t                   Running
spire-postgres-0                              Running
spire-postgres-1                              Running
spire-postgres-2                              Running
spire-postgres-pooler-ddc58cd-4ms52           Running
spire-postgres-pooler-ddc58cd-shkv5           Running
spire-postgres-pooler-ddc58cd-xn4wd           Running
spire-postgresql-db-backup-1646968200-ftwbl   Succeeded
spire-postgresql-db-backup-1647054600-ndjxv   Succeeded
spire-postgresql-db-backup-1647141000-kst7b   Succeeded
spire-server-0                                Running
spire-server-1                                Running
spire-server-2                                Running
spire-update-bss-2-brdr5                      Succeeded
###########################################################################
## 20220314_012303_365880328 ##       executable completed (exit code=0) ##
```

## Risks and Mitigations

Low risk. Adding logging is cookie-cutter.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

