### PR TITLE
CASMINST-4235: Enable logging for 5 tests

### DIFF
--- a/goss-testing/tests/ncn/goss-k8s-console-services.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-console-services.yaml
@@ -21,13 +21,19 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
+{{ $logrun := $scripts | printf "%s/log_run.sh" }}
 command:
-  k8s_service_console_running:
-    title: Kubernetes Pods 'cray-console-operator', 'cray-console-node', and 'cray-console-data' Are Running
-    meta:
-      desc: If this test fails, look at the state of the console pods (kubectl get po -n services | grep console) to investigate.
-      sev: 0
-    exec: "{{.Env.GOSS_BASE}}/scripts/python/console_verify_services.py"
-    exit-status: 0
-    timeout: 60000
-    skip: false
+    {{ $testlabel := "k8s_service_console_running" }}
+    {{$testlabel}}:
+        title: Kubernetes Pods 'cray-console-operator', 'cray-console-node', and 'cray-console-data' Are Running
+        meta:
+            desc: If this test fails, look at the state of the console pods (kubectl get po -n services | grep console) to investigate.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$scripts}}/python/console_verify_services.py"
+        exit-status: 0
+        timeout: 60000
+        skip: false

--- a/goss-testing/tests/ncn/goss-k8s-etcd-members.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-etcd-members.yaml
@@ -21,15 +21,28 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
+{{ $cacert := "/etc/kubernetes/pki/etcd/ca.crt" }}
+# cakey sounds delicious
+{{ $cakey := "/etc/kubernetes/pki/etcd/ca.key" }}
 command:
-  k8s_etcd_members:
-    title: Validate the kubernetes etcd cluster has three active members
-    meta:
-      desc: If this test fails, inspect the output from 'etcdctl --cacert=/etc/kubernetes/pki/etcd/ca.crt --cert=/etc/kubernetes/pki/etcd/ca.crt --key=/etc/kubernetes/pki/etcd/ca.key --endpoints=localhost:2379 member list' to determine which node is not a member of the cluster.
-      sev: 0
-    exec: "etcdctl --cacert=/etc/kubernetes/pki/etcd/ca.crt --cert=/etc/kubernetes/pki/etcd/ca.crt --key=/etc/kubernetes/pki/etcd/ca.key --endpoints=localhost:2379 member list | grep started | wc -l"
-    exit-status: 0
-    stdout:
-      - "3"
-    timeout: 5000
-    skip: false
+    {{ $testlabel := "k8s_etcd_members" }}
+    {{$testlabel}}:
+        title: Validate the kubernetes etcd cluster has three active members
+        meta:
+            desc: If this test fails, inspect the output from 'etcdctl --cacert={{$cacert}} --cert={{$cacert}} --key={{$cakey}} --endpoints=localhost:2379 member list' to determine which node is not a member of the cluster.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                etcdctl --cacert={{$cacert}} \
+                    --cert={{$cacert}} \
+                    --key={{$cakey}} \
+                    --endpoints=localhost:2379 member list |
+                grep started |
+                wc -l
+        exit-status: 0
+        stdout:
+            - /^3$/
+        timeout: 5000
+        skip: false

--- a/goss-testing/tests/ncn/goss-k8s-etcd-service.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-etcd-service.yaml
@@ -35,22 +35,32 @@ file:
     title: etcd ca.crt file exists
     meta:
       desc: This file should be created when the master is initialized or joins the Kubernetes cluster.
+      sev: 0
     exists: true
   /etc/kubernetes/pki/apiserver-etcd-client.crt:
     title: etcd client crt file exists
     meta:
       desc: This file should be created when the master is initialized or joins the Kubernetes cluster.
+      sev: 0
     exists: true
   /etc/kubernetes/pki/apiserver-etcd-client.key:
     title: etcd client key file exists
     meta:
       desc: This file should be created when the master is initialized or joins the Kubernetes cluster.
+      sev: 0
     exists: true
-
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  k8s_etcd_endpoint_health:
-    title: Validate the Kubernetes etcd on this node is healthy.
-    meta:
-      desc: Checks that Kubernetes' etcd instance on this node must be healthy.
-    exec: "ETCDCTL_API=3 etcdctl endpoint health --cacert=/etc/kubernetes/pki/etcd/ca.crt --cert=/etc/kubernetes/pki/apiserver-etcd-client.crt --key=/etc/kubernetes/pki/apiserver-etcd-client.key"
-    exit-status: 0
+    {{ $testlabel := "k8s_etcd_endpoint_health" }}
+    {{$testlabel}}:
+        title: Validate the Kubernetes etcd on this node is healthy.
+        meta:
+            desc: Checks that Kubernetes' etcd instance on this node must be healthy.
+            sev: 0
+        exec: |-
+            ETCDCTL_API=3 "{{$logrun}}" -l "{{$testlabel}}" \
+                etcdctl endpoint health \
+                    --cacert=/etc/kubernetes/pki/etcd/ca.crt \
+                    --cert=/etc/kubernetes/pki/apiserver-etcd-client.crt \
+                    --key=/etc/kubernetes/pki/apiserver-etcd-client.key
+        exit-status: 0

--- a/goss-testing/tests/ncn/goss-k8s-nexus-can-pull.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-nexus-can-pull.yaml
@@ -21,13 +21,18 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  k8s_nexus_can_pull:
-    title: Validate nexus (registry.local) can pull images
-    meta:
-      desc: If this test fails, look at the state of the nexus pods (kubectl get po -n nexus) to determine why the test was unable to pull a docker image.
-      sev: 0
-    exec: "crictl pull registry.local/k8s.gcr.io/pause:3.2"
-    exit-status: 0
-    timeout: 5000
-    skip: false
+    {{ $testlabel := "k8s_nexus_can_pull" }}
+    {{$testlabel}}:
+        title: Validate nexus (registry.local) can pull images
+        meta:
+            desc: If this test fails, look at the state of the nexus pods (kubectl get po -n nexus) to determine why the test was unable to pull a docker image.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                crictl pull registry.local/k8s.gcr.io/pause:3.2
+        exit-status: 0
+        timeout: 5000
+        skip: false

--- a/goss-testing/tests/ncn/goss-k8s-sealed-secret-key.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-sealed-secret-key.yaml
@@ -21,13 +21,17 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $kubectl := .Vars.kubectl }}
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  k8s_sealed_secrets_key_exists:
-    title: Sealed Secrets Key Exists
-    meta:
-      desc: Validates the sealed secrets key exists in Kubernetes.
-      sev: 0
-    exec: 'kubectl get secret -n kube-system sealed-secrets-key'
-    stdout:
-      - 'sealed-secrets-key'
-    exit-status: 0
+    {{ $testlabel := "k8s_sealed_secrets_key_exists" }}
+    {{$testlabel}}:
+        title: Sealed Secrets Key Exists
+        meta:
+            desc: Validates the sealed secrets key exists in Kubernetes.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$kubectl}}" get secret -n kube-system sealed-secrets-key
+        exit-status: 0


### PR DESCRIPTION
## Summary and Scope

This PR adds logging to the following tests:
* goss-k8s-console-services.yaml
* goss-k8s-etcd-members.yaml
* goss-k8s-etcd-service.yaml
* goss-k8s-nexus-can-pull.yaml
* goss-k8s-sealed-secret-key.yaml

The tests themselves are unchanged.

## Issues and Related PRs

None

## Testing

I ran the updated tests on hela.

### goss-k8s-console-services.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml -g ./goss-k8s-console-services.yaml v
.

Total Duration: 3.836s
Count: 1, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/k8s_service_console_running/20220314_013341_049839698_3503740.log
log_run argument(s): -l k8s_service_console_running
Executable: '/opt/cray/tests/install/ncn/scripts/python/console_verify_services.py'
No arguments to executable

## 20220314_013341_058595418 ##                      executable starting ##
###########################################################################
/opt/cray/tests/install/ncn/scripts/python/console_verify_services.py: INFO     Beginning verification that all console services are running
/opt/cray/tests/install/ncn/scripts/python/console_verify_services.py: INFO     Verification of console services succeeded
###########################################################################
## 20220314_013344_876419765 ##       executable completed (exit code=0) ##
```

### goss-k8s-etcd-members.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml -g ./goss-k8s-etcd-members.yaml v
..

Total Duration: 0.058s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/k8s_etcd_members/20220314_013351_122243733_3503853.log
log_run argument(s): -l k8s_etcd_members
Executable: 'etcdctl'
6 argument(s) to executable: '--cacert=/etc/kubernetes/pki/etcd/ca.crt' '--cert=/etc/kubernetes/pki/etcd/ca.crt' '--key=/etc/kubernetes/pki/etcd/ca.key' '--endpoints=localhost:2379' 'member' 'list'

## 20220314_013351_131149621 ##                      executable starting ##
###########################################################################
27c09c5c7f1e26e7, started, ncn-m003, https://10.252.1.11:2380, https://10.252.1.11:2379,https://127.0.0.1:2379, false
ec4fd4eb47570618, started, ncn-m002, https://10.252.1.12:2380, https://10.252.1.12:2379,https://127.0.0.1:2379, false
f28e73c107a800e8, started, ncn-m001, https://10.252.1.13:2380, https://10.252.1.13:2379,https://127.0.0.1:2379, false
###########################################################################
## 20220314_013351_169777051 ##       executable completed (exit code=0) ##
```

### goss-k8s-etcd-service.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml -g ./goss-k8s-etcd-service.yaml v
......

Total Duration: 0.059s
Count: 6, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/k8s_etcd_endpoint_health/20220314_013357_388191478_3503899.log
log_run argument(s): -l k8s_etcd_endpoint_health
Executable: 'etcdctl'
5 argument(s) to executable: 'endpoint' 'health' '--cacert=/etc/kubernetes/pki/etcd/ca.crt' '--cert=/etc/kubernetes/pki/apiserver-etcd-client.crt' '--key=/etc/kubernetes/pki/apiserver-etcd-client.key'

## 20220314_013357_397852769 ##                      executable starting ##
###########################################################################
127.0.0.1:2379 is healthy: successfully committed proposal: took = 14.619333ms
###########################################################################
## 20220314_013357_438289486 ##       executable completed (exit code=0) ##
```

### goss-k8s-nexus-can-pull.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml -g ./goss-k8s-nexus-can-pull.yaml v
.

Total Duration: 0.071s
Count: 1, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/k8s_nexus_can_pull/20220314_013404_324682966_3504078.log
log_run argument(s): -l k8s_nexus_can_pull
Executable: 'crictl'
2 argument(s) to executable: 'pull' 'registry.local/k8s.gcr.io/pause:3.2'

## 20220314_013404_334431158 ##                      executable starting ##
###########################################################################
Image is up to date for sha256:80d28bedfe5dec59da9ebf8e6260224ac9008ab5c11dbbe16ee3ba3e4439ac2c
###########################################################################
## 20220314_013404_386483042 ##       executable completed (exit code=0) ##
```

### goss-k8s-sealed-secret-key.yaml

```
ncn-m001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml -g ./goss-k8s-sealed-secret-key.yaml v
.

Total Duration: 0.131s
Count: 1, Failed: 0, Skipped: 0
```

```
ncn-m001:/tmp/zz # cat /opt/cray/tests/install/logs/k8s_sealed_secrets_key_exists/20220314_013411_214013787_3504154.log
log_run argument(s): -l k8s_sealed_secrets_key_exists
Executable: '/usr/bin/kubectl'
5 argument(s) to executable: 'get' 'secret' '-n' 'kube-system' 'sealed-secrets-key'

## 20220314_013411_223232557 ##                      executable starting ##
###########################################################################
NAME                 TYPE                DATA   AGE
sealed-secrets-key   kubernetes.io/tls   2      5d12h
###########################################################################
## 20220314_013411_336057941 ##       executable completed (exit code=0) ##
```

## Risks and Mitigations

Low risk. Adding logging is cookie-cutter.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

