### PR TITLE
CASMINST-4236: Enable logging for ceph-csi-storage-node-requirements,…

### DIFF
--- a/goss-testing/tests/ncn/goss-ceph-csi-storage-node-requirements.yaml
+++ b/goss-testing/tests/ncn/goss-ceph-csi-storage-node-requirements.yaml
@@ -21,6 +21,8 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 package:
     ceph-common:
         title: ceph-common package
@@ -30,20 +32,23 @@ package:
         installed: true
 file:
     {{range $ceph_file := index .Vars "ceph_files"}}
-    {{$ceph_file}}:
-        title: {{$ceph_file}} file
-        meta:
-            desc: "Check that {{$ceph_file}} file exists"
-            sev: 0
-        exists: true
-        filetype: file
+        {{$ceph_file}}:
+            title: {{$ceph_file}} file
+            meta:
+                desc: "Check that {{$ceph_file}} file exists"
+                sev: 0
+            exists: true
+            filetype: file
     {{end}}
 command:
-    ceph_installed:
+    {{ $testlabel := "ceph_installed" }}
+    {{$testlabel}}:
         title: ceph -s
         meta:
             desc: Check that ceph -s successfully executes
             sev: 0
-        exec: "/usr/bin/ceph -s"
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                /usr/bin/ceph -s
         exit-status: 0
         timeout: 10000

--- a/goss-testing/tests/ncn/goss-storage-spire-healthcheck.yaml
+++ b/goss-testing/tests/ncn/goss-storage-spire-healthcheck.yaml
@@ -21,13 +21,18 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  spire-healthcheck:
-    title: Spire Health Check
-    meta:
-      desc: Validates that the spire healthcheck runs successfully. If this fails, run `/opt/cray/platform-utils/spire/fix-spire-on-storage.sh` on ncn-m001 to fix the issue.
-      sev: 0
-    exec: "spire-agent healthcheck -socketPath /root/spire/agent.sock"
-    exit-status: 0
-    timeout: 5000
-    skip: false
+    {{ $testlabel := "spire-healthcheck" }}
+    {{$testlabel}}:
+        title: Spire Health Check
+        meta:
+            desc: Validates that the spire healthcheck runs successfully. If this fails, run `/opt/cray/platform-utils/spire/fix-spire-on-storage.sh` on ncn-m001 to fix the issue.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                spire-agent healthcheck -socketPath /root/spire/agent.sock
+        exit-status: 0
+        timeout: 5000
+        skip: false


### PR DESCRIPTION
## Summary and Scope

This PR adds logging to the following tests:
* goss-ceph-csi-storage-node-requirements.yaml
* goss-storage-spire-healthcheck.yaml

The tests themselves are unchanged.

## Issues and Related PRs

None

## Testing

I ran the updated ceph-csi test on wasp and the updated spire test on hela (since wasp was not far enough along for that one).

### goss-ceph-csi-storage-node-requirements.yaml

```
ncn-s001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml -g ./goss-ceph-csi-storage-node-requirements.yaml v
..

Total Duration: 0.762s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-s001:/tmp/zz # cat /opt/cray/tests/install/logs/ceph_installed/20220314_014907_098346334_43708.log
log_run argument(s): -l ceph_installed
Executable: '/usr/bin/ceph'
1 argument(s) to executable: '-s'

## 20220314_014907_107296915 ##                      executable starting ##
###########################################################################
  cluster:
    id:     503633ce-a0ac-11ec-b2ae-b8599ff91d22
    health: HEALTH_OK

  services:
    mon: 3 daemons, quorum ncn-s001,ncn-s003,ncn-s002 (age 3d)
    mgr: ncn-s001.kesryl(active, since 2d), standbys: ncn-s002.ytpnef, ncn-s003.aijtpz
    mds: cephfs:1 {0=cephfs.ncn-s001.ycxqeu=up:active} 1 up:standby-replay 1 up:standby
    osd: 24 osds: 24 up (since 3d), 24 in (since 3d)
    rgw: 3 daemons active (site1.zone1.ncn-s001.kblvfs, site1.zone1.ncn-s002.smgest, site1.zone1.ncn-s003.drowab)

  task status:

  data:
    pools:   14 pools, 1105 pgs
    objects: 5.77k objects, 16 GiB
    usage:   56 GiB used, 42 TiB / 42 TiB avail
    pgs:     1105 active+clean

  io:
    client:   852 B/s rd, 42 KiB/s wr, 1 op/s rd, 3 op/s wr

###########################################################################
## 20220314_014907_852304422 ##       executable completed (exit code=0) ##
```

### goss-storage-spire-healthcheck.yaml

```
ncn-s001:/tmp/zz # GOSS_BASE=/opt/cray/tests/install/ncn goss --vars /opt/cray/tests/install/ncn/vars/variables-ncn.yaml -g ./goss-storage-spire-healthcheck.yaml v
.

Total Duration: 0.215s
Count: 1, Failed: 0, Skipped: 0
```

```
ncn-s001:/tmp/zz # cat /opt/cray/tests/install/logs/spire-healthcheck/20220314_015214_813151553_31758.log
log_run argument(s): -l spire-healthcheck
Executable: 'spire-agent'
3 argument(s) to executable: 'healthcheck' '-socketPath' '/root/spire/agent.sock'

## 20220314_015214_822789580 ##                      executable starting ##
###########################################################################
Agent is healthy.
###########################################################################
## 20220314_015215_019127401 ##       executable completed (exit code=0) ##
```

## Risks and Mitigations

Low risk. Adding logging is cookie-cutter.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

