### PR TITLE
Move loadbalancer test to suite after pit reboot

### DIFF
--- a/goss-testing/suites/ncn-afterpitreboot-kubernetes-tests-worker.yaml
+++ b/goss-testing/suites/ncn-afterpitreboot-kubernetes-tests-worker.yaml
@@ -22,5 +22,6 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 gossfile:
- ../tests/goss-k8s-trustedcerts-configmaps-exist.yaml: {}
- ../tests/goss-k8s-vault-cluster-health.yaml: {}
+  ../tests/goss-k8s-trustedcerts-configmaps-exist.yaml: {}
+  ../tests/goss-k8s-vault-cluster-health.yaml: {}
+  ../tests/goss-k8s-all-loadbalancers-have-external-ips.yaml: {}

--- a/goss-testing/suites/ncn-kubernetes-tests-master.yaml
+++ b/goss-testing/suites/ncn-kubernetes-tests-master.yaml
@@ -27,7 +27,6 @@ gossfile:
   ../tests/goss-k8s-pods-ips-in-nmn-pool.yaml: {}
   ../tests/goss-ceph-csi-k8s-requirements.yaml: {}
   ../tests/goss-k8s-verify-cluster.yaml: {}
-  ../tests/goss-k8s-all-loadbalancers-have-external-ips.yaml: {}
   ../tests/goss-k8s-certmanager-certs-ready.yaml: {}
   ../tests/goss-k8s-certmanager-issuers-ready.yaml: {}
   ../tests/goss-etcdlvm-drive-master.yaml: {}

--- a/goss-testing/suites/ncn-kubernetes-tests-worker.yaml
+++ b/goss-testing/suites/ncn-kubernetes-tests-worker.yaml
@@ -28,7 +28,6 @@ gossfile:
   ../tests/goss-k8s-pods-ips-in-nmn-pool.yaml: {}
   ../tests/goss-ceph-csi-k8s-requirements.yaml: {}
   ../tests/goss-k8s-verify-cluster.yaml: {}
-  ../tests/goss-k8s-all-loadbalancers-have-external-ips.yaml: {}
   ../tests/goss-k8s-certmanager-certs-ready.yaml: {}
   ../tests/goss-k8s-certmanager-issuers-ready.yaml: {}
   ../tests/goss-unbound-dns-entries.yaml: {}


### PR DESCRIPTION
## Summary and Scope

Call load balancer test after pit is rebooted, and services are fully deployed.

## Issues and Related PRs

* Resolves [CASMINST-4250](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4250)

## Testing

N/A -- no change to test, just moving to different suite

### Tested on:

N/A

### Test description:

N/A

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable