### PR TITLE
CASMINST-4265: Add goss-switch-bgp-neighbor-aruba-or-mellanox.yaml to ncn-upgrade-preflight-tests.yaml suite

### DIFF
--- a/goss-testing/suites/ncn-upgrade-preflight-tests.yaml
+++ b/goss-testing/suites/ncn-upgrade-preflight-tests.yaml
@@ -38,3 +38,4 @@ gossfile:
   ../tests/goss-k8s-tftp-pods-running.yaml: {}
   ../tests/goss-postgresql-syncfailed.yaml: {}
   ../tests/goss-ip-dns-check.yaml: {}
+  ../tests/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml: {}


### PR DESCRIPTION
## Summary and Scope

This adds the goss-switch-bgp-neighbor-aruba-or-mellanox.yaml test to ncn-upgrade-preflight-tests.yaml suite.  This allows us to check the BGP peering sessions before we attempt to boot nodes.

## Issues and Related PRs

* Resolves CASMINST-4265

## Testing

### Tested on:

  * `drax`

### Test description:

I manually added this test to the ncn-upgrade-preflight-tests.yaml suite and ran the suite as it is done in prerequisites.sh.   I verified that the test ran and checked the logs for the test in /opt/cray/tests/install/logs/bgp_neighbors_established.

```
GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/suites/ncn-upgrade-preflight-tests.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
```

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

