### PR TITLE
CASMISNT-4365 Add retry text to ceph csi k8s requirements check

### DIFF
--- a/goss-testing/tests/common/goss-ceph-csi-k8s-requirements.yaml
+++ b/goss-testing/tests/common/goss-ceph-csi-k8s-requirements.yaml
@@ -38,7 +38,7 @@ command:
         {{$testlabel}}:
             title: "Kubernetes configmap {{$configmap}}"
             meta:
-                desc: "Check that Kubernetes configmap {{$configmap}} exists"
+                desc: "Check that Kubernetes configmap {{$configmap}} exists. For failures please wait 5 minutes to ensure cloud-init has finished and run again"
                 sev: 0
             exec: |-
                 "{{$logrun}}" -l "{{$testlabel}}" \
@@ -51,7 +51,7 @@ command:
         {{$testlabel}}:
             title: "Kubernetes secret {{$secret}}"
             meta:
-                desc: "Check that Kubernetes secret {{$secret}} exists"
+                desc: "Check that Kubernetes secret {{$secret}} exists. For failures please wait 5 minutes to ensure cloud-init has finished and run again"
                 sev: 0
             exec: |-
                 "{{$logrun}}" -l "{{$testlabel}}" \


### PR DESCRIPTION
## Summary and Scope

Adding text for the ceph csi k8s requirements check to wait 5 mins and try again as cloud-init may not have finished

## Issues and Related PRs

* Resolves CASMINST-4365

## Testing

### Tested on:

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

