### PR TITLE
CASMINST-4457: Refine storage test

### DIFF
--- a/goss-testing/automated/ncn-storage-checks
+++ b/goss-testing/automated/ncn-storage-checks
@@ -27,91 +27,31 @@
 
 export GOSS_LOG_BASE_DIR=/opt/cray/tests/install/logs
 
-# Temporary file to store command output
-NCN_STORAGE_CHECKS_TMPFILE=/tmp/.ncn-storage-checks.tmp.$$.$RANDOM
-
 source "$GOSS_BASE/automated/run-ncn-tests.sh"
 
 echo $'\e[1;33m'Storage Node Automated Tests$'\e[0m'
 echo $'\e[1;33m'----------------------------$'\e[0m'
 
-# find the storage node names and query the server endpoint
-for FAKELOOP in 1 
-do
-    if ! command -v ceph &> /dev/null
-    then
-        echo "ceph command not found"
-    else
-        echo "ceph command found"
-        if ! ceph status -f json-pretty > ${NCN_STORAGE_CHECKS_TMPFILE} 2>&1
-        then
-            echo "Command failed: ceph status -f json-pretty"
-        elif ! mons=$(jq -r '.quorum_names[]' ${NCN_STORAGE_CHECKS_TMPFILE})
-        then
-            echo "Unexpected format from command: ceph status -f json-pretty"
-        else
-            # Make sure we got at least one NCN name
-            ncns=( $mons )
-            if [[ ${#ncns[@]} -gt 0 ]]
-            then
-                echo "Obtained storage node name list from: ceph status"
-                break
-            fi
-            echo "Unable to find node names in output of ceph status -f json-pretty"
-        fi
-    fi
+# Find the storage node names
+if [ -f "/etc/dnsmasq.d/statics.conf" ]; then
+	storage_nodes=$(grep -oE 'ncn-s[0-9]{3}' /etc/dnsmasq.d/statics.conf | sort -u)
+else
+	storage_nodes=$(grep -oE 'ncn-s[0-9]{3}' /etc/hosts | sort -u)
+fi
 
-    if ! command -v kubectl &> /dev/null
-    then
-        echo "kubectl command not found"
-    else
-        echo "kubectl command found"
-        if ! kubectl get cm ceph-csi-config -o json > ${NCN_STORAGE_CHECKS_TMPFILE} 2>&1
-        then
-            echo "Command failed: kubectl get cm ceph-csi-config -o json"
-        elif ! jq -r '.data[]' ${NCN_STORAGE_CHECKS_TMPFILE} > ${NCN_STORAGE_CHECKS_TMPFILE}.2 2>&1
-        then
-            echo "Unexpected format from command: kubectl get cm ceph-csi-config -o json"
-        elif ! jq -r '.[].monitors[]' ${NCN_STORAGE_CHECKS_TMPFILE}.2 > ${NCN_STORAGE_CHECKS_TMPFILE} 2>&1
-        then
-            echo "Unexpected 'data' field format in output of command: kubectl get cm ceph-csi-config -o json"
-        else
-            # Make sure we got at least one NCN name
-            ncns=( $mons )
-            if [[ ${#ncns[@]} -gt 0 ]]
-            then
-                echo "Obtained storage node name list from: kubectl get cm ceph-csi-config"
-                break
-            fi
-            echo "Unable to find node names in output of kubectl get cm ceph-csi-config -o json"
-        fi
-    fi
-    
-    echo "Using default list of storage NCNs"
-    mons="ncn-s001 ncn-s002 ncn-s003"
-done
-echo -n "List of storage NCNs: "
-echo $mons
+echo "List of storage NCNs: $storage_nodes"
 
-# Remove the temporary file(s), if they exist
-rm -f ${NCN_STORAGE_CHECKS_TMPFILE} ${NCN_STORAGE_CHECKS_TMPFILE}.2 >& /dev/null
+if [[ -z $storage_nodes ]]; then
+	echo "ERROR: No storage nodes found"
+	exit 1
+elif ! echo $storage_nodes | grep -q ncn-s001 ; then
+	# It is important that we ran on ncn-s001, since some of the tests only run from that node
+	echo "ERROR: ncn-s001 not listed among the storage nodes"
+fi
 
-(( counter=0 ))
-
-for node in $mons; do
-    nodename=$(echo $node|cut -d":" -f1)
-    echo "$counter: Checking $nodename"
-    if [[ $(nc -z -w 10 $node 22) ]] || [[ $counter -lt 3 ]]
-    then
-        run_ncn_tests "$nodename" "8997" "ncn-storage-tests"
-        exit $?
-    elif [[ $counter -ge 3 ]]
-    then
-        break
-    else
-        (( counter+1 ))
-    fi
+for node in $nodes ; do
+	run_ncn_tests "$nodename" "8997" "ncn-storage-tests"
 done
 
-echo "Unable to perform test due to missing command or unable to access ceph monitor nodes"
-exit 1
+# We always exit 0 -- this does not indicate that the tests passed.
+exit 0

--- a/goss-testing/suites/ncn-storage-tests.yaml
+++ b/goss-testing/suites/ncn-storage-tests.yaml
@@ -21,8 +21,16 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# This suite is run during CSM installs before CSM services have been deployed
 
+#
+# This suite is run during CSM installs before CSM services have been deployed
+#
+
+{{ $thisnode := .Vars.thisnode }}
 gossfile:
-  ../tests/goss-ceph-csi-storage-node-requirements.yaml: {}
-  ../tests/goss-ceph-storage-services.yaml: {}
+    ../tests/goss-ceph-csi-storage-node-requirements.yaml: {}
+    # This takes a while to run and does not need to be run on all of the
+    # storage nodes, so we only run it on ncn-s001
+    {{if eq $thisnode "ncn-s001"}}
+        ../tests/goss-ceph-storage-services.yaml: {}
+    {{end}}

--- a/goss-testing/tests/ncn/goss-ceph-csi-storage-node-requirements.yaml
+++ b/goss-testing/tests/ncn/goss-ceph-csi-storage-node-requirements.yaml
@@ -31,14 +31,24 @@ package:
             sev: 0
         installed: true
 file:
-    {{range $ceph_file := index .Vars "ceph_files"}}
-        {{$ceph_file}}:
-            title: {{$ceph_file}} file
-            meta:
-                desc: "Check that {{$ceph_file}} file exists"
-                sev: 0
-            exists: true
-            filetype: file
+    /usr/bin/ceph:
+        title: /usr/bin/ceph file
+        meta:
+            desc: "Check that /usr/bin/ceph file exists"
+            sev: 0
+        exists: true
+        filetype: file
+    # The rest of these files only are checked on ncn-s001
+    {{if eq $thisnode "ncn-s001"}}
+        {{range $ceph_file := index .Vars "ceph_files"}}
+            {{$ceph_file}}:
+                title: {{$ceph_file}} file
+                meta:
+                    desc: "Check that {{$ceph_file}} file exists"
+                    sev: 0
+                exists: true
+                filetype: file
+        {{end}}
     {{end}}
 command:
     {{ $testlabel := "ceph_installed" }}

--- a/goss-testing/tests/ncn/goss-ceph-storage-services.yaml
+++ b/goss-testing/tests/ncn/goss-ceph-storage-services.yaml
@@ -21,15 +21,21 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# Variable set: ceph_services
-command:
-  ceph_services_status:
-    title: Ceph Services are healthy
-    meta:
-      desc: Validates that Ceph services are running.  For more detailed output, navigate to '/opt/cray/tests/install/ncn/scripts' directory  and run ceph-service-status.sh -A true -v true or ceph-service-status.sh for additional options
-      sev: 0
-    exec: "{{.Env.GOSS_BASE}}/scripts/ceph-service-status.sh -A true"
-    exit-status: 0
-    timeout: 1000000
-    skip: false
 
+{{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
+{{ $logrun := $scripts | printf "%s/log_run.sh" }}
+{{ $ceph_service_status := $scripts | printf "%s/ceph-service-status.sh" }}
+command:
+    {{ $testlabel := "ceph_services_status" }}
+    {{$testlabel}}:
+        title: Ceph services are healthy
+        meta:
+            desc: Validates that Ceph services are running. For more detailed output, run '{{$ceph_service_status}} -A true -v true', or use the '-h' flag additional options
+            sev: 0
+        exec: |-
+            # We are logging, so call script with verbose option
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$ceph_service_status}}" -A true -v true
+        exit-status: 0
+        timeout: 1000000
+        skip: false

--- a/goss-testing/vars/variables-ncn.yaml
+++ b/goss-testing/vars/variables-ncn.yaml
@@ -113,7 +113,6 @@ k8s_worker_mounts:
   - /run/containerd
 
 ceph_files:
-  - /usr/bin/ceph
   - /etc/cray/ceph/ceph_k8s_initialized
   - /etc/cray/ceph/csi_initialized
 


### PR DESCRIPTION
## Summary and Scope

This PR contains 3 changes:
1. The pre-CSM deploy storage test previously used an unorthodox way to try and find a list of storage nodes, ran on the first one it found that worked, and then exited. However, some of its tests make sense to run on all of the storage nodes. Therefore, the `ncn-storage-tests` script was changed so that it used a more standard way to get the list of storage nodes (that is, it uses the same method the other automated test scripts do), and it runs the tests on all storage nodes. 
2. This will not significantly increase the runtime of the tests, as the only long-running test in the suite is modified so that it only runs on ncn-s001 (which is appropriate, since it runs with an option that checks all of the nodes anyway). 
3. While I was working on that test, I also modified it to run in verbose mode and to log its output.

## Issues and Related PRs

This is part of several PRs for CASMINST-4457. I broke them into different commits and PRs in order to simplify the review process.

## Testing

The testing for this PR needs to be done during an install, since it involves tests run from the PIT node. I plan to do that during my install on mug. But in the meantime I wanted to open this up for reviews.

THIS SHOULD NOT MERGE until I finish my testing.

## Risks and Mitigations

Medium risk. The changes to the automated test script are fairly large. On the other hand, they made it significantly simpler. After testing, I do not think there is a lot of risk.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

The version number will be added by another PR in the set.
I will check off the testing box above once that is done.