### PR TITLE
CASMINST-4413 make ssh connections faster for clock skew test

### DIFF
--- a/goss-testing/tests/ncn/goss-check-clock-skew.yaml
+++ b/goss-testing/tests/ncn/goss-check-clock-skew.yaml
@@ -30,7 +30,7 @@ command:
     {{$testlabel}}:
         title: Check clock skew on k8s and storage nodes
         meta:
-            desc: If this test fails, run {{$check_clock_skew}} for more detail on which nodes have clock skew, and then inspect those node(s) to determine why NTP sync may be failing. Start by running 'systemctl status chronyd.service' on those nodes, as well looking for any chrony related messages in /var/log/messages"
+            desc: If this test fails, see https://cray-hpe.github.io/docs-csm/en-12/operations/node_management/configure_ntp_on_ncns/#fix-broken-configs for steps to remediate clock skew."
             sev: 0
         exec: |-
             "{{$logrun}}" -l "{{$testlabel}}" \


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

Adds SSH options to allow re-use of the connection, allowing for faster checks of time.


## Issues and Related PRs

* Resolves CASMINST-4413 for 1.2
* 
## Testing

### Tested on:

  * `#redbull`
  * `#surtur`

### Test description:

Ran the script with `time` and verified it worked.  It usually clocked in around 1.3 seconds, which is fine for allowing 1 second of drift.

## Risks and Mitigations

Low


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

