### PR TITLE
CASMINST-4529: Remove unmatched quote; minor linting; make docs link release-agnostic

### DIFF
--- a/goss-testing/scripts/check_clock_skew.sh
+++ b/goss-testing/scripts/check_clock_skew.sh
@@ -35,8 +35,8 @@ export PDSH_SSH_ARGS_APPEND="-o ControlMaster=auto -o ControlPath=~/.ssh/sockets
 nodes=$(cloud-init query ds | jq -r ".meta_data[].host_records[] | select(.aliases[]? | contains(\"ncn\")) | .aliases[]"  2>/dev/null | sort | uniq | grep -v '\.' | grep -v 'mgmt')
 
 for node in $nodes; do
-    # setup the initial ssh connection to each node so it can be re-used below for a faster test
-    #shellcheck disable=SC2086
+  # set up the initial ssh connection to each node so it can be re-used below for a faster test
+  #shellcheck disable=SC2086
   ssh $PDSH_SSH_ARGS_APPEND "$node" 'sleep 180' &
 done
 

--- a/goss-testing/tests/ncn/goss-check-clock-skew.yaml
+++ b/goss-testing/tests/ncn/goss-check-clock-skew.yaml
@@ -30,7 +30,7 @@ command:
     {{$testlabel}}:
         title: Check clock skew on k8s and storage nodes
         meta:
-            desc: If this test fails, see https://cray-hpe.github.io/docs-csm/en-12/operations/node_management/configure_ntp_on_ncns/#fix-broken-configs for steps to remediate clock skew."
+            desc: If this test fails, see "operations/node_management/Configure_NTP_on_NCNs.md#fix-broken-configs" in the CSM release documentation for steps to remediate clock skew.
             sev: 0
         exec: |-
             "{{$logrun}}" -l "{{$testlabel}}" \


### PR DESCRIPTION
## Summary and Scope

This minor linting PR is included in the master branch PR for CASMINST-4413 (https://github.com/Cray-HPE/csm-testing/pull/289), but did not make it into the 1.2 PR for that ticket. So this PR is to pull in these minor fixes.

None of them are code changes. Just linting of comments, indentation, and description text.

## Issues and Related PRs

* CASMINST-4413
* https://github.com/Cray-HPE/csm-testing/pull/289

## Testing

N/A

## Risks and Mitigations

Negligible.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

