### PR TITLE
Fix metadata for SLES15SP3

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,5 +1,6 @@
 @Library('csm-shared-library') _
 
+def sleVersion = '15.3'
 def promotionToken = ~"(master|main|release\\/.*)"
 def isStable = env.TAG_NAME != null || env.BRANCH_NAME ==~ promotionToken ? true : false
 pipeline {
@@ -9,6 +10,8 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: "10"))
+        disableConcurrentBuilds()
+        timeout(time: 20, unit: 'MINUTES')
         timestamps()
     }
 
@@ -16,22 +19,46 @@ pipeline {
         DESCRIPTION = "CSM automated testing"
         IS_STABLE = "${isStable}"
         BUILD_METADATA = getRpmRevision(isStable: isStable)
+        GIT_REPO_NAME = getRepoName()
     }
 
     stages {
         stage("Prepare") {
+            // Make RPM MetaData in our target environment (SLE).
+            agent {
+                docker {
+                    label 'docker'
+                    reuseNode true
+                    image "artifactory.algol60.net/csm-docker/stable/csm-docker-sle:${sleVersion}"
+                }
+            }
             steps {
+                runLibraryScript("addRpmMetaData.sh", "${env.GIT_REPO_NAME}.spec")
                 sh "make rpm_prepare"
             }
         }
 
         stage("Build RPM 1") {
+            agent {
+                docker {
+                    label 'docker'
+                    reuseNode true
+                    image "artifactory.algol60.net/csm-docker/stable/csm-docker-sle:${sleVersion}"
+                }
+            }
             steps {
                 sh "make build-csm-testing"
             }
         }
 
         stage("Build RPM 2") {
+            agent {
+                docker {
+                    label 'docker'
+                    reuseNode true
+                    image "artifactory.algol60.net/csm-docker/stable/csm-docker-sle:${sleVersion}"
+                }
+            }
             steps {
                 sh "make build-goss-servers"
             }


### PR DESCRIPTION
Right now csm-testing and goss-servers are missing Git information from their description and a value for distribution.

```
Name        : csm-testing
Version     : 1.14.21
Release     : 1
Architecture: noarch
Install Date: (not installed)
Group       : HPC
Size        : 815599
License     : HPE Software License Agreement
Signature   : RSA/SHA256, Fri 20 May 2022 09:52:01 PM UTC, Key ID d4dae1e39da39f44
Source RPM  : csm-testing-1.14.21-1.src.rpm
Build Date  : Fri 20 May 2022 09:50:18 PM UTC
Build Host  : csm-jenkins-metal-builder-9bth1t.us-central1-a.c.cloudbees-202004.internal
Relocations : (not relocatable)
Vendor      : HPE
Summary     : Goss tests to test out installation set-up
Description :
Tests to test the set-up during installation.
They test both the LiveCD and NCN environment.
Distribution: (none)
```
```
Name        : goss-servers
Version     : 1.14.21
Release     : 1
Architecture: noarch
Install Date: (not installed)
Group       : HPC
Size        : 9085
License     : HPE Software License Agreement
Signature   : RSA/SHA256, Fri 20 May 2022 09:52:39 PM UTC, Key ID d4dae1e39da39f44
Source RPM  : csm-testing-1.14.21-1.src.rpm
Build Date  : Fri 20 May 2022 09:50:18 PM UTC
Build Host  : csm-jenkins-metal-builder-9bth1t.us-central1-a.c.cloudbees-202004.internal
Relocations : (not relocatable)
Vendor      : HPE
Summary     : Goss Health Check Endpoint Service
Description :
Sets up a systemd service for running Goss health check servers
Distribution: (none)
```

With this PR the following information is amended to the Description, and th Distribution is set:
```
Description :
Git Repository: csm-testing
Git Branch: metadata-1.3
Git Commit Revision: 43727784
Git Commit Timestamp: Fri May 20 17:02:23 2022 -0500

Sets up a systemd service for running Goss health check servers
Distribution: SUSE Linux Enterprise Server 15 SP3
```
```
Description :
Git Repository: csm-testing
Git Branch: metadata-1.3
Git Commit Revision: 43727784
Git Commit Timestamp: Fri May 20 17:02:23 2022 -0500

Tests to test the set-up during installation.
They test both the LiveCD and NCN environment.
Distribution: SUSE Linux Enterprise Server 15 SP3
```