### PR TITLE
Fixing ceph service check

### DIFF
--- a/goss-testing/scripts/ceph-service-status.sh
+++ b/goss-testing/scripts/ceph-service-status.sh
@@ -105,10 +105,10 @@ function check_service(){
       fi
       if [[ -n "$osd_id" ]] || [[ -n "$osd" ]]
       then
-        read -r -d "\n" service_unit status epoch < <(pdsh -N -w "$host" podman ps --format json 2>&1 |grep -v "Permanently added"|jq --arg osd "osd.$osd_id" -r '.[]|select(.Names[]|contains($osd))|.Names[], .State, .StartedAt')
+        read -r -d "\n" service_unit status epoch < <(pdsh -N -w "$host" podman ps --format json 2>&1 |grep -v "Permanently added"|jq --arg osd "osd-$osd_id" -r '.[]|select(.Names[]|contains($osd))|.Names[], .State, .StartedAt')
         (( tests++ ))
         #shellcheck disable=SC2076
-        if [[ "$service_unit" =~ "$FSID_STR-osd.$osd_id" ]]
+        if [[ "$service_unit" =~ "$FSID_STR-osd-$osd_id" ]]
         then
           (( passed++ ))
         fi


### PR DESCRIPTION
## Summary and Scope

The new version of podman/ceph changes the syntax of how they refer to osds.
went from osd.# to osd-#

## Issues and Related PRs

* Resolves CASMTRIAGE-3686

## Testing

### Tested on:

  * surtur

### Test description:

Debugged the script in place on surtur

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

