### PR TITLE
CSM-shared-library changed

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -76,12 +76,12 @@ pipeline {
         stage('Publish: RPMs') {
             steps {
                 script {
-                    publishCsmRpms(component: getRepoName(), pattern: "dist/rpmbuild/RPMS/noarch/csm-testing*.rpm", os: 'sle-15sp2', arch: "noarch", isStable: isStable)
-                    publishCsmRpms(component: getRepoName(), pattern: "dist/rpmbuild/RPMS/noarch/csm-testing*.rpm", os: 'sle-15sp3', arch: "noarch", isStable: isStable)
-                    publishCsmRpms(component: getRepoName(), pattern: "dist/rpmbuild/RPMS/noarch/goss-servers*.rpm", os: 'sle-15sp2', arch: "noarch", isStable: isStable)
-                    publishCsmRpms(component: getRepoName(), pattern: "dist/rpmbuild/RPMS/noarch/goss-servers*.rpm", os: 'sle-15sp3',  arch: "noarch", isStable: isStable)
-                    publishCsmRpms(component: getRepoName(), pattern: "dist/rpmbuild/SRPMS/*.rpm", os: 'sle-15sp2', arch: "src", isStable: isStable)
-                    publishCsmRpms(component: getRepoName(), pattern: "dist/rpmbuild/SRPMS/*.rpm", os: 'sle-15sp3', arch: "src", isStable: isStable)
+                    publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/RPMS/noarch/${env.GIT_REPO_NAME}*.rpm", os: 'sle-15sp2', arch: "noarch", isStable: isStable)
+                    publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/RPMS/noarch/${env.GIT_REPO_NAME}*.rpm", os: 'sle-15sp3', arch: "noarch", isStable: isStable)
+                    publishCsmRpms(component: 'goss-servers', pattern: "dist/rpmbuild/RPMS/noarch/goss-servers*.rpm", os: 'sle-15sp2', arch: "noarch", isStable: isStable)
+                    publishCsmRpms(component: 'goss-servers', pattern: "dist/rpmbuild/RPMS/noarch/goss-servers*.rpm", os: 'sle-15sp3',  arch: "noarch", isStable: isStable)
+                    publishCsmRpms(component: env.GIT_REPO_NAME, pattern: "dist/rpmbuild/SRPMS/${env.GIT_REPO_NAME}*.rpm", os: 'sle-15sp2', arch: "src", isStable: isStable)
+                    publishCsmRpms(component: 'goss-servers', pattern: "dist/rpmbuild/SRPMS/goss-servers*.rpm", os: 'sle-15sp3', arch: "src", isStable: isStable)
                 }
             }
         }


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

`goss-servers` was not being published due to a recent change in csm-shared-library (https://github.com/Cray-HPE/csm-shared-library/pull/36) which requires the Component field to match the RPM name.
