### PR TITLE
CASMPET-5737: Add in nexus free space check

### DIFF
--- a/goss-testing/suites/ncn-upgrade-preflight-tests.yaml
+++ b/goss-testing/suites/ncn-upgrade-preflight-tests.yaml
@@ -38,3 +38,4 @@ gossfile:
   ../tests/goss-postgresql-syncfailed.yaml: {}
   ../tests/goss-ip-dns-check.yaml: {}
   ../tests/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml: {}
+  ../tests/goss-k8s-nexus-space.yaml: {}

--- a/goss-testing/tests/ncn/goss-k8s-nexus-space.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-nexus-space.yaml
@@ -27,7 +27,7 @@ command:
     meta:
       desc: If this test fails, look at the the amount of free space in `nexus-data` PVC and refer to operations/package_repository_management/nexus-space-cleanup.md in the docs-csm repository.
       sev: 0
-    exec: freeSpace=$(kubectl exec -n nexus deploy/nexus -c nexus -- df -P /nexus-data | grep '/nexus-data' | awk '{print ($4/1024/1024);}');if [[ $freeSpace < 200 ]];then return 0; fi
+    exec: freeSpace=$(kubectl exec -n nexus deploy/nexus -c nexus -- df -P /nexus-data | grep '/nexus-data' | awk '{print ($4/1024/1024);}');if [[ $freeSpace < 150 ]];then return 0; fi
     exit-status: 0
     timeout: 20000
     skip: false

--- a/goss-testing/tests/ncn/goss-k8s-nexus-space.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-nexus-space.yaml
@@ -27,7 +27,7 @@ command:
     meta:
       desc: If this test fails, look at the the amount of free space in `nexus-data` PVC and refer to operations/package_repository_management/Nexus_Space_Cleanup.md in the docs-csm repository.
       sev: 0
-    exec: freeSpace=$(kubectl exec -n nexus deploy/nexus -c nexus -- df -P /nexus-data | grep '/nexus-data' | awk '{print ($4/1024/1024);}');if (( $(echo $freeSpace | awk '{print ($1 < 150)}') ));then return 0; fi
+    exec: freeSpace=$(kubectl exec -n nexus deploy/nexus -c nexus -- df -P /nexus-data | grep '/nexus-data' | awk '{printf "%.0f", ($4/1024/1024);}');if (( $freeSpace < 150 ));then return 0; fi
     exit-status: 0
     timeout: 20000
     skip: false

--- a/goss-testing/tests/ncn/goss-k8s-nexus-space.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-nexus-space.yaml
@@ -27,7 +27,7 @@ command:
     meta:
       desc: If this test fails, look at the the amount of free space in `nexus-data` PVC and refer to operations/package_repository_management/Nexus_Space_Cleanup.md in the docs-csm repository.
       sev: 0
-    exec: freeSpace=$(kubectl exec -n nexus deploy/nexus -c nexus -- df -P /nexus-data | grep '/nexus-data' | awk '{print ($4/1024/1024);}');if (( $(echo $freeSpace | awk '{print ($1 < 950)}') ));then return 0; fi
+    exec: freeSpace=$(kubectl exec -n nexus deploy/nexus -c nexus -- df -P /nexus-data | grep '/nexus-data' | awk '{print ($4/1024/1024);}');if (( $(echo $freeSpace | awk '{print ($1 < 150)}') ));then return 0; fi
     exit-status: 0
     timeout: 20000
     skip: false

--- a/goss-testing/tests/ncn/goss-k8s-nexus-space.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-nexus-space.yaml
@@ -25,7 +25,7 @@ command:
   k8s_nexus_free_space:
     title: Kubernetes Service 'nexus' Has Enough Free Space
     meta:
-      desc: If this test fails, look at the the amount of free space in `nexus-data` PVC and refer to operations/package_repository_management/nexus-space-cleanup.md in the docs-csm repository.
+      desc: If this test fails, look at the the amount of free space in `nexus-data` PVC and refer to operations/package_repository_management/Nexus_Space_Cleanup.md in the docs-csm repository.
       sev: 0
     exec: freeSpace=$(kubectl exec -n nexus deploy/nexus -c nexus -- df -P /nexus-data | grep '/nexus-data' | awk '{print ($4/1024/1024);}');if [[ $freeSpace < 150 ]];then return 0; fi
     exit-status: 0

--- a/goss-testing/tests/ncn/goss-k8s-nexus-space.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-nexus-space.yaml
@@ -27,7 +27,7 @@ command:
     meta:
       desc: If this test fails, look at the the amount of free space in `nexus-data` PVC and refer to operations/package_repository_management/Nexus_Space_Cleanup.md in the docs-csm repository.
       sev: 0
-    exec: freeSpace=$(kubectl exec -n nexus deploy/nexus -c nexus -- df -P /nexus-data | grep '/nexus-data' | awk '{print ($4/1024/1024);}');if [[ $freeSpace < 150 ]];then return 0; fi
+    exec: freeSpace=$(kubectl exec -n nexus deploy/nexus -c nexus -- df -P /nexus-data | grep '/nexus-data' | awk '{print ($4/1024/1024);}');if (( $(echo $freeSpace | awk '{print ($1 < 950)}') ));then return 0; fi
     exit-status: 0
     timeout: 20000
     skip: false

--- a/goss-testing/tests/ncn/goss-k8s-nexus-space.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-nexus-space.yaml
@@ -1,0 +1,33 @@
+#
+# MIT License
+#
+# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+command:
+  k8s_nexus_free_space:
+    title: Kubernetes Service 'nexus' Has Enough Free Space
+    meta:
+      desc: If this test fails, look at the the amount of free space in `nexus-data` PVC and refer to operations/package_repository_management/nexus-space-cleanup.md in the docs-csm repository.
+      sev: 0
+    exec: freeSpace=$(kubectl exec -n nexus deploy/nexus -c nexus -- df -P /nexus-data | grep '/nexus-data' | awk '{print ($4/1024/1024);}');if [[ $freeSpace < 200 ]];then return 0; fi
+    exit-status: 0
+    timeout: 20000
+    skip: false


### PR DESCRIPTION
## Summary and Scope

This adds in a goss test for a check that there will be enough free space for in the nexus-data pvc for an upgrade. The current size requirements is 150 GiB, this is an estimate and may change with more data found.

## Issues and Related PRs

* Works on [CASMPET-5737](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5737)
* Future work required by [CASMPET-5737](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5737)
* Documentation changes required in [CASMPET-5737](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5737)


## Testing

### Tested on:

  *  mug

### Test description:

Tested by running the goss test on mug and changing the amount of free space required.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y

## Risks and Mitigations

No


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

