### PR TITLE
CASMINST-5025: Create more shared functions for automated scripts; prove methods for determing NCN lists

### DIFF
--- a/csm-testing.spec
+++ b/csm-testing.spec
@@ -58,12 +58,17 @@ install -d -m 755 %{buildroot}%{ncn}/vars
 install -m 755 goss-testing/automated/*         %{buildroot}%{livecd}/automated
 install -m 755 goss-testing/tests/livecd/*.yaml %{buildroot}%{livecd}/tests
 install -m 755 goss-testing/tests/common/*.yaml %{buildroot}%{livecd}/tests
-install -m 755 goss-testing/vars/*.yaml         %{buildroot}%{livecd}/vars
 install -m 755 build-testing/*                  %{buildroot}%{livecd}/build-testing
 install -m 755 goss-testing/automated/*         %{buildroot}%{ncn}/automated
 install -m 755 goss-testing/tests/ncn/*.yaml    %{buildroot}%{ncn}/tests
 install -m 755 goss-testing/tests/common/*.yaml %{buildroot}%{ncn}/tests
-install -m 755 goss-testing/vars/*.yaml         %{buildroot}%{ncn}/vars
+# Install variables files
+install -m 755 goss-testing/vars/vars-packages.yaml         %{buildroot}%{livecd}/vars
+install -T -m 755 goss-testing/vars/variables-common.yaml %{buildroot}%{livecd}/vars/variables-livecd.yaml
+cat goss-testing/vars/variables-livecd.yaml >> %{buildroot}%{livecd}/vars/variables-livecd.yaml
+install -T -m 755 goss-testing/vars/variables-common.yaml %{buildroot}%{ncn}/vars/variables-ncn.yaml
+cat goss-testing/vars/variables-ncn.yaml >> %{buildroot}%{ncn}/vars/variables-ncn.yaml
+install -m 755 goss-testing/vars/vars-packages.yaml         %{buildroot}%{ncn}/vars
 # Install script files
 install -d -m 755 %{buildroot}%{livecd}/scripts
 install -d -m 755 %{buildroot}%{livecd}/scripts/python

--- a/goss-testing/automated/livecd-preflight-checks
+++ b/goss-testing/automated/livecd-preflight-checks
@@ -29,16 +29,11 @@ set -e
 
 # GOSS_BASE should already be set on the PIT node, but just in case we
 # will set it here
-[[ -z $GOSS_BASE ]] && export GOSS_BASE="/opt/cray/tests/install/livecd"
+[[ -z ${GOSS_BASE} ]] && export GOSS_BASE="/opt/cray/tests/install/livecd"
 
 export GOSS_LOG_BASE_DIR=/opt/cray/tests/install/logs
 
-# Print an error message and exit
-function err_exit
-{
-    echo "ERROR: $*"
-    exit 1
-}
+source "${GOSS_BASE}/automated/run-ncn-tests.sh"
 
 # Validates that a file exists and is a regular file
 function file_exists
@@ -47,52 +42,32 @@ function file_exists
     [[ -f "$1" ]] || err_exit "File exists but is not a regular file: $1"
 }
 
-export GOSS_FILE="$GOSS_BASE/suites/livecd-preflight-tests.yaml"
-vars_file="$GOSS_BASE/vars/variables-livecd.yaml"
-dnsmasq_statics=/etc/dnsmasq.d/statics.conf
+export GOSS_FILE="${GOSS_BASE}/suites/livecd-preflight-tests.yaml"
 
-file_exists "$GOSS_FILE"
-file_exists "$vars_file"
-file_exists "$dnsmasq_statics"
+file_exists "${GOSS_FILE}"
 
-nodes=$(grep -ohE 'ncn-[msw]([0-9]{3})' "$dnsmasq_statics" | awk '!a[$0]++')
-tmpvars=/tmp/goss-variables-$(date +%s)-temp.yaml
-
-# Add node names from statics.conf to temp variables file.
-# We expect there to be at least 9 nodes (3 each of masters,
-# storage, and workers).
-num_nodes=$(echo $nodes | wc -w)
-if [[ $num_nodes -ge 9 ]];then
-  echo "nodes:" >> $tmpvars
-  for node in $nodes; do
-    echo "  - $node" >> $tmpvars    
-  done
-  echo "" >> $tmpvars
-elif [[ $num_nodes -eq 0 ]]; then
-  err_exit "Node names could not be found in $dnsmasq_statics file!"
-else
-  err_exit "Only $num_nodes node name(s) found in $dnsmasq_statics file!"
-fi
-cat $vars_file >> $tmpvars
+# The create_tmpvars_file function is defined in run-ncn-tests.sh
+# It creates the temporary variables file and saves the path to it in the ${tmpvars} variable
+create_tmpvars_file || exit 1
 
 echo $'\e[1;33m'Running LiveCD preflight checks \(may take a few minutes to complete\)...$'\e[0m'
 
 # Run the LiveCD preflight Goss test suite
-export GOSS_VARS=$tmpvars
+export GOSS_VARS=${tmpvars}
 set +e
 results=$(/usr/bin/goss validate -f json)
 set -e
 
-if ! `echo $results | jq -e > /dev/null 2>&1`; then
+if ! `echo ${results} | jq -e > /dev/null 2>&1`; then
   err_exit $'\e[1;31m'Output not valid JSON$'\e[0m'
 fi
 
-echo $results | jq -c '.results | sort_by(.result) | .[]' | while read -r test; do
-  result=$(echo $test | jq -r '.result')
+echo ${results} | jq -c '.results | sort_by(.result) | .[]' | while read -r test; do
+  result=$(echo ${test} | jq -r '.result')
 
-  if [ -z $result ]; then
+  if [[ -z ${result} ]]; then
     continue
-  elif [ $result == 0 ]; then
+  elif [[ ${result} == 0 ]]; then
     result=PASS
     echo $'\e[1;32m'
   else
@@ -100,35 +75,35 @@ echo $results | jq -c '.results | sort_by(.result) | .[]' | while read -r test; 
     echo $'\e[1;31m'
   fi
 
-  title=$(echo $test | jq -r '.title')
-  description=$(echo $test | jq -r '.meta.desc')
-  severity=$(echo $test | jq -r '.meta.sev')
-  summary=$(echo $test | jq -r '."summary-line"')
-  time=$(echo $test | jq -r '.duration')
-  time=$(echo "scale=8; $time/1000000000" | bc | awk '{printf "%.8f\n", $0}')
+  title=$(echo ${test} | jq -r '.title')
+  description=$(echo ${test} | jq -r '.meta.desc')
+  severity=$(echo ${test} | jq -r '.meta.sev')
+  summary=$(echo ${test} | jq -r '."summary-line"')
+  time=$(echo ${test} | jq -r '.duration')
+  time=$(echo "scale=8; ${time}/1000000000" | bc | awk '{printf "%.8f\n", $0}')
 
-  echo "Result: $result"
-  echo "Test Name: $title"
-  echo "Description: $description"
-  echo "Severity: $severity"
-  echo "Test Summary: $summary"
-  echo "Execution Time: $time seconds"
+  echo "Result: ${result}"
+  echo "Test Name: ${title}"
+  echo "Description: ${description}"
+  echo "Severity: ${severity}"
+  echo "Test Summary: ${summary}"
+  echo "Execution Time: ${time} seconds"
   echo "Node: ncn-m001"
 done
 
 echo $'\e[0m'
 
-total=$(echo $results | jq -r '.summary."test-count"')
-failed=$(echo $results | jq -r '.summary."failed-count"')
-time=$(echo $results | jq -r '.summary."total-duration"')
-time=$(echo "scale=4; $time/1000000000" | bc | awk '{printf "%.4f\n", $0}')
+total=$(echo ${results} | jq -r '.summary."test-count"')
+failed=$(echo ${results} | jq -r '.summary."failed-count"')
+time=$(echo ${results} | jq -r '.summary."total-duration"')
+time=$(echo "scale=4; ${time}/1000000000" | bc | awk '{printf "%.4f\n", $0}')
 
-echo "Total Tests: $total, Total Passed: $((total-failed)), Total Failed: $failed, Total Execution Time: $time seconds"
+echo "Total Tests: ${total}, Total Passed: $((total-failed)), Total Failed: ${failed}, Total Execution Time: ${time} seconds"
 echo
 
-if [[ $total -eq 0 ]]; then
+if [[ ${total} -eq 0 ]]; then
     err_exit "No tests were run!"
-elif [[ $failed -ne 0 ]]; then
+elif [[ ${failed} -ne 0 ]]; then
     err_exit "Not all tests passed"
 fi
 echo "All tests passed!"

--- a/goss-testing/automated/livecd-provisioning-checks
+++ b/goss-testing/automated/livecd-provisioning-checks
@@ -24,46 +24,35 @@
 
 # GOSS_BASE should already be set on the PIT node, but just in case we
 # will set it here
-[[ -z $GOSS_BASE ]] && export GOSS_BASE="/opt/cray/tests/install/livecd"
+[[ -z ${GOSS_BASE} ]] && export GOSS_BASE="/opt/cray/tests/install/livecd"
 
 export GOSS_LOG_BASE_DIR=/opt/cray/tests/install/logs
 
-export GOSS_FILE="$GOSS_BASE/suites/livecd-provisioning-tests.yaml"
-vars_file="$GOSS_BASE/vars/variables-livecd.yaml"
+source "${GOSS_BASE}/automated/run-ncn-tests.sh"
 
-nodes=$(cat /etc/dnsmasq.d/statics.conf | grep -ohE 'ncn-[msw]([0-9]{3})' | awk '!a[$0]++')
-tmpvars=/tmp/goss-variables-$(date +%s)-temp.yaml
+export GOSS_FILE="${GOSS_BASE}/suites/livecd-provisioning-tests.yaml"
 
-# add node names from statics.conf to temp variables file
-if [ `echo $nodes | wc -w` -ne 0 ];then
-  echo "nodes:" >> $tmpvars
-  for node in $nodes; do
-    echo "  - $node" >> $tmpvars
-    echo "" >> $tmpvars
-  done
-else
-  echo "Node names could not be found in statics.conf file! Exiting now."
-  exit 1
-fi
-cat $vars_file >> $tmpvars
+# The create_tmpvars_file function is defined in run-ncn-tests.sh
+# It creates the temporary variables file and saves the path to it in the ${tmpvars} variable
+create_tmpvars_file || exit 1
 
 echo $'\e[1;33m'Running LiveCD provisioning checks \(may take a few minutes to complete\)...$'\e[0m'
 
 # Run the LiveCD provisioning Goss test suite
-export GOSS_VARS=$tmpvars
+export GOSS_VARS=${tmpvars}
 results=$(/usr/bin/goss validate -f json)
 
-if ! `echo $results | jq -e > /dev/null 2>&1`; then
+if ! `echo ${results} | jq -e > /dev/null 2>&1`; then
   echo $'\e[1;31m'ERROR: Output not valid JSON$'\e[0m'
   exit 1
 fi
 
-echo $results | jq -c '.results | sort_by(.result) | .[]' | while read -r test; do
-  result=$(echo $test | jq -r '.result')
+echo ${results} | jq -c '.results | sort_by(.result) | .[]' | while read -r test; do
+  result=$(echo ${test} | jq -r '.result')
 
-  if [ -z $result ]; then
+  if [ -z ${result} ]; then
     continue
-  elif [ $result == 0 ]; then
+  elif [ ${result} == 0 ]; then
     result=PASS
     echo $'\e[1;32m'
   else
@@ -71,29 +60,29 @@ echo $results | jq -c '.results | sort_by(.result) | .[]' | while read -r test; 
     echo $'\e[1;31m'
   fi
 
-  title=$(echo $test | jq -r '.title')
-  description=$(echo $test | jq -r '.meta.desc')
-  severity=$(echo $test | jq -r '.meta.sev')
-  summary=$(echo $test | jq -r '."summary-line"')
-  time=$(echo $test | jq -r '.duration')
-  time=$(echo "scale=8; $time/1000000000" | bc | awk '{printf "%.8f\n", $0}')
+  title=$(echo ${test} | jq -r '.title')
+  description=$(echo ${test} | jq -r '.meta.desc')
+  severity=$(echo ${test} | jq -r '.meta.sev')
+  summary=$(echo ${test} | jq -r '."summary-line"')
+  time=$(echo ${test} | jq -r '.duration')
+  time=$(echo "scale=8; ${time}/1000000000" | bc | awk '{printf "%.8f\n", $0}')
 
-  echo "Result: $result"
-  echo "Test Name: $title"
-  echo "Description: $description"
-  echo "Severity: $severity"
-  echo "Test Summary: $summary"
-  echo "Execution Time: $time seconds"
+  echo "Result: ${result}"
+  echo "Test Name: ${title}"
+  echo "Description: ${description}"
+  echo "Severity: ${severity}"
+  echo "Test Summary: ${summary}"
+  echo "Execution Time: ${time} seconds"
   echo "Node: ncn-m001"
 done
 
 echo $'\e[0m'
 
-total=$(echo $results | jq -r '.summary."test-count"')
-failed=$(echo $results | jq -r '.summary."failed-count"')
-time=$(echo $results | jq -r '.summary."total-duration"')
-time=$(echo "scale=4; $time/1000000000" | bc | awk '{printf "%.4f\n", $0}')
+total=$(echo ${results} | jq -r '.summary."test-count"')
+failed=$(echo ${results} | jq -r '.summary."failed-count"')
+time=$(echo ${results} | jq -r '.summary."total-duration"')
+time=$(echo "scale=4; ${time}/1000000000" | bc | awk '{printf "%.4f\n", $0}')
 
-echo "Total Tests: $total, Total Passed: $((total-failed)), Total Failed: $failed, Total Execution Time: $time seconds"
+echo "Total Tests: ${total}, Total Passed: $((total-failed)), Total Failed: ${failed}, Total Execution Time: ${time} seconds"
 
 exit

--- a/goss-testing/automated/ncn-healthcheck
+++ b/goss-testing/automated/ncn-healthcheck
@@ -23,16 +23,16 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 # GOSS_BASE isn't set by default on the NCNs, just on LiveCD
-[[ -z $GOSS_BASE ]] && export GOSS_BASE="/opt/cray/tests/install/ncn"
+[[ -z ${GOSS_BASE} ]] && export GOSS_BASE="/opt/cray/tests/install/ncn"
 
 export GOSS_LOG_BASE_DIR=/opt/cray/tests/install/logs
 
-if [[ -z "$SW_ADMIN_PASSWORD" ]]; then
+if [[ -z ${SW_ADMIN_PASSWORD} ]]; then
   echo "ERROR Management switch admin password must be provided via the SW_ADMIN_PASSWORD enviroment varaible"
   echo "Example: export SW_ADMIN_PASSWORD='changeme'"
   exit 1
 fi
 
-"$GOSS_BASE/automated/ncn-healthcheck-storage"
-"$GOSS_BASE/automated/ncn-healthcheck-master"
-"$GOSS_BASE/automated/ncn-healthcheck-worker"
+"${GOSS_BASE}/automated/ncn-healthcheck-storage"
+"${GOSS_BASE}/automated/ncn-healthcheck-master"
+"${GOSS_BASE}/automated/ncn-healthcheck-worker"

--- a/goss-testing/automated/ncn-healthcheck-master
+++ b/goss-testing/automated/ncn-healthcheck-master
@@ -23,24 +23,28 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 # GOSS_BASE isn't set by default on the NCNs, just on LiveCD
-[[ -z $GOSS_BASE ]] && export GOSS_BASE="/opt/cray/tests/install/ncn"
+[[ -z ${GOSS_BASE} ]] && export GOSS_BASE="/opt/cray/tests/install/ncn"
 
 export GOSS_LOG_BASE_DIR=/opt/cray/tests/install/logs
 
-source "$GOSS_BASE/automated/run-ncn-tests.sh"
+source "${GOSS_BASE}/automated/run-ncn-tests.sh"
 
 echo $'\e[1;33m'NCN Run-Time Checks$'\e[0m'
 echo $'\e[1;33m'-------------------$'\e[0m'
 
-# find the ncn node names and query the server endpoint
-if [ -f "/etc/dnsmasq.d/statics.conf" ]; then
-  cat /etc/dnsmasq.d/statics.conf | grep -ohE "ncn-[m]([0-9]{3})" | grep -v ncn-m001 | awk '!a[$0]++' | \
-    while read node ; do run_ncn_tests "$node" "8994" "ncn-healthcheck-master" ; done
-else
-  cat /etc/hosts | grep -ohE "ncn-[m]([0-9]{3})" | awk '!a[$0]++' | while read node ; do \
-    run_ncn_tests "$node" "8994" "ncn-healthcheck-master" ; \
-    run_ncn_tests "$node" "9004" "ncn-afterpitreboot-healthcheck-master" ; \
-    done
-fi
+# Find the NCN node names and query the server endpoint
+# The get_ncns function is defined in run-ncn-tests.sh
+nodes=$(get_ncns --master --exclude-pit) || exit 1
+
+# The get_ncns function should always give NCNs if its return code was 0, but better safe than sorry
+[[ -n ${nodes} ]] || err_exit "No master NCNs found"
+
+# Query the server endpoint
+for node in ${nodes} ; do
+	run_ncn_tests "${node}" "8994" "ncn-healthcheck-master"
+	if ! is_pit_node ; then
+		run_ncn_tests "${node}" "9004" "ncn-afterpitreboot-healthcheck-master"
+	fi
+done
 
 exit

--- a/goss-testing/automated/ncn-healthcheck-storage
+++ b/goss-testing/automated/ncn-healthcheck-storage
@@ -23,24 +23,28 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 # GOSS_BASE isn't set by default on the NCNs, just on LiveCD
-[[ -z $GOSS_BASE ]] && export GOSS_BASE="/opt/cray/tests/install/ncn"
+[[ -z ${GOSS_BASE} ]] && export GOSS_BASE="/opt/cray/tests/install/ncn"
 
 export GOSS_LOG_BASE_DIR=/opt/cray/tests/install/logs
 
-source "$GOSS_BASE/automated/run-ncn-tests.sh"
+source "${GOSS_BASE}/automated/run-ncn-tests.sh"
 
 echo $'\e[1;33m'NCN Run-Time Checks$'\e[0m'
 echo $'\e[1;33m'-------------------$'\e[0m'
 
-# find the ncn node names and query the server endpoint
-if [ -f "/etc/dnsmasq.d/statics.conf" ]; then
-  cat /etc/dnsmasq.d/statics.conf | grep -ohE "ncn-[s]([0-9]{3})" | grep -v ncn-m001 | awk '!a[$0]++' | \
-    while read node ; do run_ncn_tests "$node" "9001" "ncn-healthcheck-storage" ; done
-else
-  cat /etc/hosts | grep -ohE "ncn-[s]([0-9]{3})" | awk '!a[$0]++' | while read node ; do \
-    run_ncn_tests "$node" "9001" "ncn-healthcheck-storage" ; \
-    run_ncn_tests "$node" "9006" "ncn-afterpitreboot-healthcheck-storage" ; \
-    done
-fi
+# Find the NCN node names and query the server endpoint
+# The get_ncns function is defined in run-ncn-tests.sh
+nodes=$(get_ncns --storage) || exit 1
+
+# The get_ncns function should always give NCNs if its return code was 0, but better safe than sorry
+[[ -n ${nodes} ]] || err_exit "No storage NCNs found"
+
+# Query the server endpoint
+for node in ${nodes} ; do
+	run_ncn_tests "${node}" "9001" "ncn-healthcheck-storage"
+	if ! is_pit_node ; then
+		run_ncn_tests "${node}" "9006" "ncn-afterpitreboot-healthcheck-storage"
+	fi
+done
 
 exit

--- a/goss-testing/automated/ncn-healthcheck-worker
+++ b/goss-testing/automated/ncn-healthcheck-worker
@@ -23,34 +23,33 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 # GOSS_BASE isn't set by default on the NCNs, just on LiveCD
-[[ -z $GOSS_BASE ]] && export GOSS_BASE="/opt/cray/tests/install/ncn"
+[[ -z ${GOSS_BASE} ]] && export GOSS_BASE="/opt/cray/tests/install/ncn"
 
 export GOSS_LOG_BASE_DIR=/opt/cray/tests/install/logs
 
-vars_file="$GOSS_BASE/vars/variables-ncn.yaml"
+vars_file="${GOSS_BASE}/vars/variables-ncn.yaml"
 
-source "$GOSS_BASE/automated/run-ncn-tests.sh"
+source "${GOSS_BASE}/automated/run-ncn-tests.sh"
 
 echo $'\e[1;33m'NCN Run-Time Checks$'\e[0m'
 echo $'\e[1;33m'-------------------$'\e[0m'
 
-# find the ncn node names and query the server endpoint
-if [ -f "/etc/dnsmasq.d/statics.conf" ]; then
-	cat /etc/dnsmasq.d/statics.conf | 
-	grep -ohE "ncn-[w]([0-9]{3})" | 
-	grep -v ncn-m001 | 
-	awk '!a[$0]++' |
-	while read node ; do
-		run_ncn_tests "$node" "9000" "ncn-healthcheck-worker"
-	done
-else
-	cat /etc/hosts | 
-	grep -ohE "ncn-[w]([0-9]{3})" | 
-	awk '!a[$0]++' | 
-	while read node ; do
-		run_ncn_tests "$node" "9000" "ncn-healthcheck-worker"
-		run_ncn_tests "$node" "9005" "ncn-afterpitreboot-healthcheck-worker"
-    done
+# The get_ncns function is defined in run-ncn-tests.sh
+if nodes=$(get_ncns --workers); then
+
+	# The get_ncns function should always give NCNs if its return code was 0, but better safe than sorry
+	if [[ -z ${nodes} ]]; then
+		print_error "No worker NCNs found"
+	else
+		# Query the server endpoints
+		for node in ${nodes} ; do
+			run_ncn_tests "${node}" "9000" "ncn-healthcheck-worker"
+			if ! is_pit_node ; then
+				run_ncn_tests "${node}" "9005" "ncn-afterpitreboot-healthcheck-worker"
+			fi
+		done
+	fi
+
 fi
 
 # Specify the switch passwords and call the switch BGP neighbors tests.
@@ -58,15 +57,19 @@ fi
 # executing on as the BGP status tests check all switches in
 # the cluster.
 # If explicit Aruba or Mellanox switch passwords were not provided, then go with SW_ADMIN_PASSWORD
-if [[ -z "$SW_ADMIN_PASSWORD" ]]; then
+if [[ -z ${SW_ADMIN_PASSWORD} ]]; then
 	echo "ERROR Management switch admin password must be provided via the SW_ADMIN_PASSWORD enviroment varaible"
 	echo "Example: export SW_ADMIN_PASSWORD='changeme'"
 	exit 1
 fi
 
+# The create_tmpvars_file function is defined in run-ncn-tests.sh
+# It creates the temporary variables file and saves the path to it in the ${tmpvars} variable
+create_tmpvars_file "${vars_file}" || exit 1
+
 echo $'\n\e[1;33m'---------------$'\e[0m'
 echo $'\e[1;33m'Switch BGP Neighbors$'\e[0m'
 echo "Test Name: goss-switch-bgp-neighbor-aruba-or-mellanox.yaml"
 echo "Description: Validates connection to the BGP neighbors of a switch. Check Admin Guide \"Check BGP Status and Reset Sessions\" for more details on how to fix this issue."
-goss -g "$GOSS_BASE/tests/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml" --vars "$vars_file" validate --format documentation
+goss -g "${GOSS_BASE}/tests/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml" --vars "${tmpvars}" validate --format documentation
 exit $?

--- a/goss-testing/automated/ncn-kubernetes-checks
+++ b/goss-testing/automated/ncn-kubernetes-checks
@@ -23,59 +23,27 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 # GOSS_BASE isn't set by default on the NCNs, just on LiveCD
-[[ -z $GOSS_BASE ]] && export GOSS_BASE=/opt/cray/tests/install/ncn
+[[ -z ${GOSS_BASE} ]] && export GOSS_BASE=/opt/cray/tests/install/ncn
 
 export GOSS_LOG_BASE_DIR=/opt/cray/tests/install/logs
 
-export GOSS_VARS=/tmp/goss-variables-$(date +%s)-temp.yaml
+source "${GOSS_BASE}/automated/run-ncn-tests.sh"
 
-source "$GOSS_BASE/automated/run-ncn-tests.sh"
-
-# files needed to run from livecd
+# file needed to run from livecd
 kube_creds=/root/.kube/config
-pit_file=/etc/pit-release
 
-if [ -f $pit_file ]; then
-  # running on a pit node
-  cat "$GOSS_BASE/vars/variables-livecd.yaml" > $GOSS_VARS
-else
-  # running on an NCN
-  cat "$GOSS_BASE/vars/variables-ncn.yaml" > $GOSS_VARS
-fi
-echo "" >> $GOSS_VARS
-
-# Add variables based on local system
-add_local_vars "$GOSS_VARS"
-
-if [ -f "/etc/dnsmasq.d/statics.conf" ]; then
-  k8s_nodes=$(cat /etc/dnsmasq.d/statics.conf | grep -ohE 'ncn-[mw]([0-9]{3})' | grep -v ncn-m001 | awk '!a[$0]++')
-else
-  k8s_nodes=$(cat /etc/hosts | grep -ohE 'ncn-[mw]([0-9]{3})' | awk '!a[$0]++')
-fi
-
-# add node names from statics.conf to temp variables file
-if [ `echo $k8s_nodes | wc -w` -ne 0 ];then
-  echo "" >> $GOSS_VARS
-  echo "k8s_nodes:" >> $GOSS_VARS
-  for node in $k8s_nodes; do
-    echo "  - $node" >> $GOSS_VARS
-  done
-else
-  echo "Node names could not be found in files! Exiting now."
-  exit 1
-fi
-
-if [ -f $pit_file ]; then
+# is_pit_node is defined in run-ncn-tests.sh
+if is_pit_node; then
   # running on a pit node
   echo $'\e[1;33m'PIT Node Kubernetes Checks$'\e[0m'
   echo $'\e[1;33m'--------------------------$'\e[0m'
-  if [ -f $kube_creds ]; then
+  if [[ -f ${kube_creds} ]]; then
     # run livecd local Kubernetes cluster tests
     k8s_local_tests
   else
     # We preface this warning with 'Total Tests:' to make it more visible, because the install documentation
     # has the user grep for that string to review the results of the tests.
-    echo $'\e[1;31m'Total Tests: WARNING: Unable to run local Kubernetes checks because $kube_creds does not exist$'\e[0m'
+    echo $'\e[1;31m'Total Tests: WARNING: Unable to run local Kubernetes checks because ${kube_creds} does not exist$'\e[0m'
     echo
   fi
 else
@@ -89,37 +57,46 @@ fi
 echo $'\e[1;33m'Master Node Kubernetes Checks$'\e[0m'
 echo $'\e[1;33m'-----------------------------$'\e[0m'
 
-# find the master node names and query the server endpoint
-if [ -f "/etc/dnsmasq.d/statics.conf" ]; then
-  nodes=$(cat /etc/dnsmasq.d/statics.conf | grep -ohE "ncn-m([0-9]{3})" | grep -v ncn-m001 | awk '!a[$0]++')
-  for node in $nodes ; do \
-    run_ncn_tests "$node" "8996" "ncn-kubernetes-tests-master" ; \
-  done
-else
-  nodes=$(cat /etc/hosts | grep -ohE "ncn-m([0-9]{3})" | awk '!a[$0]++')
-  for node in $nodes ; do \
-    run_ncn_tests "$node" "8996" "ncn-kubernetes-tests-master" ; \
-    run_ncn_tests "$node" "9007" "ncn-afterpitreboot-kubernetes-tests-master" ; \
-  done
+# The get_ncns function is defined in run-ncn-tests.sh
+if nodes=$(get_ncns --masters --exclude-pit); then
+
+	# The get_ncns function should always give NCNs if its return code was 0, but better safe than sorry
+	if [[ -z ${nodes} ]]; then
+		print_error "No master NCNs found"
+	else
+		# Query the server endpoints
+		for node in ${nodes} ; do
+			run_ncn_tests "${node}" "8996" "ncn-kubernetes-tests-master"
+			if ! is_pit_node ; then
+				run_ncn_tests "${node}" "9007" "ncn-afterpitreboot-kubernetes-tests-master"
+			fi
+		done
+	fi
+
 fi
+
 echo
 
 # worker nodes
 echo $'\e[1;33m'Worker Node Kubernetes Checks$'\e[0m'
 echo $'\e[1;33m'-----------------------------$'\e[0m'
 
-# find the worker node names and query the server endpoint
-if [ -f "/etc/dnsmasq.d/statics.conf" ]; then
-  nodes=$(cat /etc/dnsmasq.d/statics.conf | grep -ohE "ncn-w([0-9]{3})" | awk '!a[$0]++')
-  for node in $nodes ; do \
-    run_ncn_tests "$node" "8998" "ncn-kubernetes-tests-worker"; \
-  done
-else
-  nodes=$(cat /etc/hosts | grep -ohE "ncn-w([0-9]{3})" | awk '!a[$0]++')
-  for node in $nodes ; do \
-    run_ncn_tests "$node" "8998" "ncn-kubernetes-tests-worker" ; \
-    run_ncn_tests "$node" "9008" "ncn-afterpitreboot-kubernetes-tests-worker" ; \
-  done
+# The get_ncns function is defined in run-ncn-tests.sh
+if nodes=$(get_ncns --workers); then
+
+	# The get_ncns function should always give NCNs if its return code was 0, but better safe than sorry
+	if [[ -z ${nodes} ]]; then
+		print_error "No worker NCNs found"
+	else
+		# Query the server endpoints
+		for node in ${nodes} ; do
+			run_ncn_tests "${node}" "8998" "ncn-kubernetes-tests-worker"
+			if ! is_pit_node ; then
+				run_ncn_tests "${node}" "9008" "ncn-afterpitreboot-kubernetes-tests-worker"
+			fi
+		done
+	fi
+
 fi
 
 exit

--- a/goss-testing/automated/ncn-postgres-tests
+++ b/goss-testing/automated/ncn-postgres-tests
@@ -44,6 +44,8 @@ echo $'\e[1;33m'---------------$'\e[0m'
 postgresClusters="$(kubectl get postgresql -A | awk '/postgres/ || NR==1' | \
                     grep -v NAME | awk '{print $1","$2}')"
 for postgresCluster in ${postgresClusters}; do
+  # $tmpvars is set by the create_tmpvars_file function earlier
+  #shellcheck disable=SC2154
   CLUSTER_NAME=$(echo ${postgresCluster} | awk -F, '{print $2;}') \
   CLUSTER_NS=$(echo ${postgresCluster} | awk -F, '{print $1;}') \
   goss -g \

--- a/goss-testing/automated/ncn-postgres-tests
+++ b/goss-testing/automated/ncn-postgres-tests
@@ -23,23 +23,32 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 # GOSS_BASE isn't set by default on the NCNs, just on LiveCD
-[[ -z $GOSS_BASE ]] && export GOSS_BASE="/opt/cray/tests/install/ncn"
-
-vars_file="$GOSS_BASE/vars/variables-ncn.yaml"
+[[ -z ${GOSS_BASE} ]] && export GOSS_BASE="/opt/cray/tests/install/ncn"
 
 export GOSS_LOG_BASE_DIR=/opt/cray/tests/install/logs
+
+source "${GOSS_BASE}/automated/run-ncn-tests.sh"
+
+# These tests should not be run from the PIT node.
+if is_pit_node ; then
+    err_exit "These tests cannot be run from the LiveCD."
+fi
+
+# The create_tmpvars_file function is defined in run-ncn-tests.sh
+# It creates the temporary variables file and saves the path to it in the ${tmpvars} variable
+create_tmpvars_file || exit 1
 
 echo $'\e[1;33m'NCN Postgres Tests$'\e[0m'
 echo $'\e[1;33m'---------------$'\e[0m'
 
 postgresClusters="$(kubectl get postgresql -A | awk '/postgres/ || NR==1' | \
                     grep -v NAME | awk '{print $1","$2}')"
-for postgresCluster in $postgresClusters; do
-  CLUSTER_NAME=$(echo $postgresCluster | awk -F, '{print $2;}') \
-  CLUSTER_NS=$(echo $postgresCluster | awk -F, '{print $1;}') \
+for postgresCluster in ${postgresClusters}; do
+  CLUSTER_NAME=$(echo ${postgresCluster} | awk -F, '{print $2;}') \
+  CLUSTER_NS=$(echo ${postgresCluster} | awk -F, '{print $1;}') \
   goss -g \
-    "$GOSS_BASE/suites/ncn-postgres-tests.yaml" \
-    --vars "$vars_file" \
+    "${GOSS_BASE}/suites/ncn-postgres-tests.yaml" \
+    --vars "${tmpvars}" \
     validate
 done
 

--- a/goss-testing/automated/ncn-preflight-checks
+++ b/goss-testing/automated/ncn-preflight-checks
@@ -23,25 +23,28 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 # GOSS_BASE isn't set by default on the NCNs, just on LiveCD
-[[ -z $GOSS_BASE ]] && export GOSS_BASE="/opt/cray/tests/install/ncn"
+[[ -z ${GOSS_BASE} ]] && export GOSS_BASE="/opt/cray/tests/install/ncn"
 
 export GOSS_LOG_BASE_DIR=/opt/cray/tests/install/logs
 
-source "$GOSS_BASE/automated/run-ncn-tests.sh"
+source "${GOSS_BASE}/automated/run-ncn-tests.sh"
 
 echo $'\e[1;33m'NCN Preflight Checks$'\e[0m'
 echo $'\e[1;33m'--------------------$'\e[0m'
 
-if [ ! -f "/etc/dnsmasq.d/statics.conf" ]; then
-  echo "ERROR: These tests can only be run from the LiveCD."
-  exit 1
+if ! is_pit_node ; then
+    err_exit "These tests can only be run from the LiveCD."
 fi
 
-# find the ncn node names and query the server endpoint
-nodes=$(grep -ohE "ncn-[msw]([0-9]{3})" /etc/dnsmasq.d/statics.conf | grep -v ncn-m001 | awk '!a[$0]++')
+# Find the NCN node names and query the server endpoint
+# The get_ncns function is defined in run-ncn-tests.sh
+nodes=$(get_ncns --exclude-pit) || exit 1
 
-for node in $nodes; do
-  run_ncn_tests $node 8995 ncn-preflight-tests
+# The get_ncns function should always give NCNs if its return code was 0, but better safe than sorry
+[[ -n ${nodes} ]] || err_exit "No NCNs found"
+
+for node in ${nodes}; do
+    run_ncn_tests "${node}" 8995 ncn-preflight-tests
 done
 
 exit

--- a/goss-testing/automated/ncn-smoke-tests
+++ b/goss-testing/automated/ncn-smoke-tests
@@ -23,25 +23,28 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 # GOSS_BASE isn't set by default on the NCNs, just on LiveCD
-[[ -z $GOSS_BASE ]] && export GOSS_BASE="/opt/cray/tests/install/ncn"
+[[ -z ${GOSS_BASE} ]] && export GOSS_BASE="/opt/cray/tests/install/ncn"
 
 export GOSS_LOG_BASE_DIR=/opt/cray/tests/install/logs
 
-source "$GOSS_BASE/automated/run-ncn-tests.sh"
+source "${GOSS_BASE}/automated/run-ncn-tests.sh"
 
 echo $'\e[1;33m'NCN Smoke Tests$'\e[0m'
 echo $'\e[1;33m'---------------$'\e[0m'
 
-if [ ! -f "/etc/dnsmasq.d/statics.conf" ]; then
-  echo "ERROR: These tests can only be run from the LiveCD."
-  exit 1
+if ! is_pit_node ; then
+    err_exit "These tests can only be run from the LiveCD."
 fi
 
-# find the ncn node names and query the server endpoint
-nodes=$(grep -ohE "ncn-[msw]([0-9]{3})" /etc/dnsmasq.d/statics.conf | grep -v ncn-m001 | awk '!a[$0]++')
+# Find the NCN node names and query the server endpoint
+# The get_ncns function is defined in run-ncn-tests.sh
+nodes=$(get_ncns --exclude-pit) || exit 1
 
-for node in $nodes; do
-  run_ncn_tests $node 9002 ncn-smoke-tests
+# The get_ncns function should always give NCNs if its return code was 0, but better safe than sorry
+[[ -n ${nodes} ]] || err_exit "No NCNs found"
+
+for node in ${nodes}; do
+    run_ncn_tests "${node}" 9002 ncn-smoke-tests
 done
 
 exit

--- a/goss-testing/automated/ncn-spire-healthchecks
+++ b/goss-testing/automated/ncn-spire-healthchecks
@@ -23,25 +23,29 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 # GOSS_BASE isn't set by default on the NCNs, just on LiveCD
-[[ -z $GOSS_BASE ]] && export GOSS_BASE="/opt/cray/tests/install/ncn"
+[[ -z ${GOSS_BASE} ]] && export GOSS_BASE="/opt/cray/tests/install/ncn"
 
 export GOSS_LOG_BASE_DIR=/opt/cray/tests/install/logs
 
-vars_file="$GOSS_BASE/vars/variables-ncn.yaml"
+source "${GOSS_BASE}/automated/run-ncn-tests.sh"
 
-source "$GOSS_BASE/automated/run-ncn-tests.sh"
+# The create_tmpvars_file function is defined in run-ncn-tests.sh
+# It creates the temporary variables file and saves the path to it in the ${tmpvars} variable
+create_tmpvars_file || exit 1
 
 echo $'\e[1;33m'Spire Health Checks$'\e[0m'
 echo $'\e[1;33m'-------------------$'\e[0m'
 
-# find the ncn node names and query the server endpoint
-if [ -f "/etc/dnsmasq.d/statics.conf" ]; then
-  cat /etc/dnsmasq.d/statics.conf | grep -ohE "ncn-[mw]([0-9]{3})" | grep -v ncn-m001 | awk '!a[$0]++' | \
-    while read node ; do run_ncn_tests "$node" "9003" "ncn-spire-healthchecks" ; done
-else
-  cat /etc/hosts | grep -ohE "ncn-[mw]([0-9]{3})" | awk '!a[$0]++' | while read node ; do run_ncn_tests "$node" "9003" \
-    "ncn-spire-healthchecks" ; done
-fi
+# Find the NCN node names and query the server endpoint
+# The get_ncns function is defined in run-ncn-tests.sh
+nodes=$(get_ncns --exclude-pit) || exit 1
+
+# The get_ncns function should always give NCNs if its return code was 0, but better safe than sorry
+[[ -n ${nodes} ]] || err_exit "No NCNs found"
+
+for node in ${nodes} ; do
+    run_ncn_tests "${node}" "9003" "ncn-spire-healthchecks"
+done
 
 # Specify the spire postgres clusters and call the postgres tests.
 # This only needs to be done once on the NCN that this script is
@@ -55,12 +59,12 @@ echo $'\n\e[1;33m'---------------$'\e[0m'
 echo $'\e[1;33m'NCN Spire Postgres Pods Running$'\e[0m'
 echo "Test Name: goss-k8s-postgres-pods-running"
 echo "Description: Validate that spire postgres pods are running."
-goss -g  "$GOSS_BASE/tests/goss-k8s-postgres-pods-running.yaml" --vars "$vars_file"  validate --format documentation
+goss -g  "${GOSS_BASE}/tests/goss-k8s-postgres-pods-running.yaml" --vars "${tmpvars}"  validate --format documentation
 echo $'\n\e[1;33m'---------------$'\e[0m'
 echo $'\e[1;33m'NCN Spire Postgres Pods Have a Leader$'\e[0m'
 echo "Test Name: goss-k8s-postgres-leader"
 echo "Description: Validate that spire postgres pods have a leader."
-goss -g  "$GOSS_BASE/tests/goss-k8s-postgres-leader.yaml" --vars "$vars_file" validate --format documentation
+goss -g  "${GOSS_BASE}/tests/goss-k8s-postgres-leader.yaml" --vars "${tmpvars}" validate --format documentation
 
 echo $'\n\e[1;33m'-------------------$'\e[0m'
 echo $'\e[1;33m'Spire Health Checks Completed$'\e[0m\n'

--- a/goss-testing/automated/ncn-storage-checks
+++ b/goss-testing/automated/ncn-storage-checks
@@ -23,34 +23,31 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 # GOSS_BASE isn't set by default on the NCNs, just on LiveCD
-[[ -z $GOSS_BASE ]] && export GOSS_BASE="/opt/cray/tests/install/ncn"
+[[ -z ${GOSS_BASE} ]] && export GOSS_BASE="/opt/cray/tests/install/ncn"
 
 export GOSS_LOG_BASE_DIR=/opt/cray/tests/install/logs
 
-source "$GOSS_BASE/automated/run-ncn-tests.sh"
+source "${GOSS_BASE}/automated/run-ncn-tests.sh"
 
 echo $'\e[1;33m'Storage Node Automated Tests$'\e[0m'
 echo $'\e[1;33m'----------------------------$'\e[0m'
 
-# Find the storage node names
-if [ -f "/etc/dnsmasq.d/statics.conf" ]; then
-	storage_nodes=$(grep -oE 'ncn-s[0-9]{3}' /etc/dnsmasq.d/statics.conf | sort -u)
-else
-	storage_nodes=$(grep -oE 'ncn-s[0-9]{3}' /etc/hosts | sort -u)
+# The get_storage_ncns function is defined in run-ncn-tests.sh
+storage_nodes=$(get_ncns --storage) || exit 1
+
+# Excluding storage_nodes from the parenthesis because it contains newlines (which we do not want to include in the echo)
+echo "List of storage NCNs: "${storage_nodes}
+
+# The get_ncns function should always give NCNs if its return code was 0, but better safe than sorry
+[[ -n ${storage_nodes} ]] || err_exit "No storage nodes found"
+
+# It is important that we ran on ncn-s001, since some of the tests only run from that node
+if ! echo ${storage_nodes} | grep -q ncn-s001 ; then
+	print_error "ncn-s001 not listed among the storage nodes"
 fi
 
-echo "List of storage NCNs: $storage_nodes"
-
-if [[ -z $storage_nodes ]]; then
-	echo "ERROR: No storage nodes found"
-	exit 1
-elif ! echo $storage_nodes | grep -q ncn-s001 ; then
-	# It is important that we ran on ncn-s001, since some of the tests only run from that node
-	echo "ERROR: ncn-s001 not listed among the storage nodes"
-fi
-
-for nodename in $storage_nodes ; do
-	run_ncn_tests "$nodename" "8997" "ncn-storage-tests"
+for node in ${storage_nodes} ; do
+	run_ncn_tests "${node}" "8997" "ncn-storage-tests"
 done
 
 # We always exit 0 -- this does not indicate that the tests passed.

--- a/goss-testing/automated/run-ncn-tests.sh
+++ b/goss-testing/automated/run-ncn-tests.sh
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # MIT License
 #
 # (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
@@ -23,6 +22,10 @@
 #
 # This file is sourced by the NCN automated testing scripts.
 
+# No shebang line at the top of the file, because this is not intended to be executed, only included as a source in other Bash scripts.
+# The following line lets the linter know how to appripriately check this file.
+# shellcheck shell=bash
+
 function print_warn {
     echo "WARNING: $*" 1>&2
 }
@@ -44,6 +47,10 @@ function is_pit_node {
 
 # Prints a list of all NCNs
 # Prints warnings if there are fewer than expected
+#
+# Disable the following check because this function does get called with arguments, just
+# not from within this file.
+#shellcheck disable=SC2120
 function get_ncns {
     # Usage: get_ncns [--exclude-pit] [--masters] [--storage] [--workers]
     #
@@ -54,7 +61,7 @@ function get_ncns {
     # Regardless of the above, if --exclude-pit is specified, and this function is being called on the PIT node,
     # then ncn-m001 will be excluded from the results.
     # 
-    local ncns type_char_pattern type_string
+    local type_char_pattern type_string
 
     local masters=N
     local storage=N
@@ -67,7 +74,7 @@ function get_ncns {
             "--storage") storage=Y ;;
             "--workers") workers=Y ;;
             "--exclude-pit") if is_pit_node; then exclude_m001=Y ; fi ;;
-            *) err_exit"PROGRAMMING LOGIC ERROR: get_ncns: Invalid argument: '$1'"
+            *) err_exit "PROGRAMMING LOGIC ERROR: get_ncns: Invalid argument: '$1'"
         esac
         shift
     done
@@ -225,16 +232,13 @@ function run_ncn_tests {
     echo Running tests against node $'\e[1;33m'${NODE}$'\e[0m'
     url="http://${NODE}.hmn:${port}/${endpoint}"
 
-    echo Server URL: ${url}
-    #shellcheck disable=SC2006
+    echo "Server URL: ${url}"
     if ! results=`curl -s "${url}"` ; then
         echo $'\e[1;31m'ERROR: Server endpoint could not be reached$'\e[0m'
         return 1
     fi
 
-    #shellcheck disable=SC2092
-    #shellcheck disable=SC2006
-    if ! `echo ${results} | jq -e > /dev/null 2>&1`; then
+    if ! echo ${results} | jq -e > /dev/null 2>&1; then
         echo $'\e[1;31m'ERROR: Output not valid JSON$'\e[0m'
         return 1
     else
@@ -358,7 +362,7 @@ function create_tmpvars_file {
         return 1
     fi
 
-    tmpvars=$(mktemp /tmp/goss-variables-$(date +%s)-XXXXXX-temp.yaml)
+    tmpvars=$(mktemp "/tmp/goss-variables-$(date +%s)-XXXXXX-temp.yaml")
     if [[ $? -ne 0 ]]; then
         print_error "create_tmpvars_file: mktemp command failed"
         return 1

--- a/goss-testing/automated/run-ncn-tests.sh
+++ b/goss-testing/automated/run-ncn-tests.sh
@@ -23,113 +23,354 @@
 #
 # This file is sourced by the NCN automated testing scripts.
 
+function print_warn {
+    echo "WARNING: $*" 1>&2
+}
+
+function print_error {
+    echo "ERROR: $*" 1>&2
+}
+
+# Print an error message and exit
+function err_exit {
+    print_error "$@"
+    exit 1
+}
+
+function is_pit_node {
+    [[ -f /etc/pit-release ]]
+    return $?
+}
+
+# Prints a list of all NCNs
+# Prints warnings if there are fewer than expected
+function get_ncns {
+    # Usage: get_ncns [--exclude-pit] [--masters] [--storage] [--workers]
+    #
+    # The base set of NCNs returned is based on the --masters, --storage, --workers flags.
+    # If none of those are specified, then all NCNs are included. If any of them are specified, then
+    # only the specified types of NCNs are returned.
+    #
+    # Regardless of the above, if --exclude-pit is specified, and this function is being called on the PIT node,
+    # then ncn-m001 will be excluded from the results.
+    # 
+    local ncns type_char_pattern type_string
+
+    local masters=N
+    local storage=N
+    local workers=N
+    local exclude_m001=N
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            "--masters") masters=Y ;;
+            "--storage") storage=Y ;;
+            "--workers") workers=Y ;;
+            "--exclude-pit") if is_pit_node; then exclude_m001=Y ; fi ;;
+            *) err_exit"PROGRAMMING LOGIC ERROR: get_ncns: Invalid argument: '$1'"
+        esac
+        shift
+    done
+    if [[ ${masters} == N && ${storage} == N && ${workers} == N ]]; then masters=Y ; storage=Y; workers=Y; fi
+
+    if [[ ${masters} == N ]]; then
+        # No need to exclude ncn-m001 if we aren't including it in the first place
+        exclude_m001=N
+    fi
+
+    if [[ ${masters} == Y && ${storage} == Y && ${workers} == Y ]]; then
+        type_string="NCN"
+        type_char_pattern="[msw]"
+    else
+        type_string=""
+        type_char_pattern="["
+        if [[ ${masters} == Y ]]; then type_char_pattern+="m" ; type_string+="/master" ; fi
+        if [[ ${storage} == Y ]]; then type_char_pattern+="s" ; type_string+="/storage" ; fi
+        if [[ ${workers} == Y ]]; then type_char_pattern+="w" ; type_string+="/worker" ; fi
+        type_string+=" NCN"
+        # Strip the first character, which is a /
+        type_string=${type_string:1}
+        type_char_pattern="${type_char_pattern}]"
+    fi
+    # Pattern to match 100-999: [1-9][0-9][0-9]
+    # Pattern to match 010-099: 0[1-9][0-9]
+    # Pattern to match 001-009: 00[1-9]
+    local ncn_num_pattern="([1-9][0-9][0-9]|0[1-9][0-9]|00[1-9])"
+    local ncn_string_pattern="ncn-${type_char_pattern}${ncn_num_pattern}"
+
+    # Define a local function to do the output filtering based on the arguments passed in here.
+    # End with a grep command that will give status code 0 if any output is matched (that is, the output is not blank)
+    if [[ ${exclude_m001} == Y ]]; then
+        function __unique_ncns { grep -oE "${ncn_string_pattern}" | sort -u | grep -v ncn-m001 | grep . ; }
+    else
+        function __unique_ncns { grep -oE "${ncn_string_pattern}" | sort -u | grep . ; }
+    fi
+
+    # If the GOSS_TEST_NCN_LIST environment variable has been set, this will be used. This allows users a method to
+    # run the automated scripts in cases where the usual methods of obtaining the NCN list does not work.
+    if [[ -n ${GOSS_TEST_NCN_LIST} ]]; then
+        if echo "${GOSS_TEST_NCN_LIST}" | __unique_ncns ; then
+            return 0
+        fi
+        print_warn "GOSS_TEST_NCN_LIST variable is set, but unable to obtain ${type_string} list from it: '${GOSS_TEST_NCN_LIST}'"
+    fi
+
+    if is_pit_node; then
+        if [[ -z ${PITDATA} ]]; then
+            print_warn "The PITDATA environment variable is not set."
+        elif [[ -z ${SYSTEM_NAME} ]]; then
+            print_warn "The SYSTEM_NAME environment variable is not set."
+        else
+            local sys_prep_dir="${PITDATA}/prep/${SYSTEM_NAME}"
+            local sls_json="${sys_prep_dir}/sls_input_file.json"
+            local sys_prep_dnsmasqd_statics="${sys_prep_dir}/dnsmasq.d/statics.conf"
+
+            if [[ ! -s ${sls_json} ]]; then
+                print_warn "The '${sls_json}' file does not exist or is empty"
+            else
+                if cat "${sls_json}" |
+                        jq -r '.Hardware | .[] | select(.Type=="comptype_node" and .TypeString=="Node" and .ExtraProperties.Role=="Management") | .ExtraProperties.Aliases | .[]' |
+                        __unique_ncns
+                then
+                    return 0
+                fi
+                print_warn "Unable to obtain ${type_string} list from '${sls_json}'"
+            fi
+
+            if [[ ! -s ${sys_prep_dnsmasqd_statics} ]]; then
+                print_warn "The '${sys_prep_dnsmasqd_statics}' file does not exist or is empty"
+            else
+                if cat "${sys_prep_dnsmasqd_statics}" | __unique_ncns ; then
+                    return 0
+                fi
+                print_warn "Unable to obtain ${type_string} list from '${sys_prep_dnsmasqd_statics}'"
+            fi
+        fi
+        
+        # Final backup option is to use the live dnsmasq statics file
+        local dnsmasqd_statics=/etc/dnsmasq.d/statics.conf
+
+        if [[ ! -s ${dnsmasqd_statics} ]]; then
+            print_warn "The '${dnsmasqd_statics}' file does not exist or is empty"
+        else
+            if cat "${dnsmasqd_statics}" | __unique_ncns ; then
+                return 0
+            fi
+            print_warn "Unable to obtain ${type_string} list from '${dnsmasqd_statics}'"
+        fi
+    else
+        # Not on a PIT node
+
+        # Loop until node names are found
+        while true ; do
+
+            # Try getting node list from basecamp metadata endpoint first
+            if curl -s http://ncn-m001:8888/meta-data | jq -r '.Global.host_records[].aliases[1]' | __unique_ncns ; then
+                return 0
+            fi
+            # No warning message is printed in this case, because this is expected to fail once the PIT node is redeployed
+
+            # Try BSS metadata
+            if curl -s http://api-gw-service-nmn.local:8888/meta-data | jq -r '.Global.host_records[].aliases[1]' | __unique_ncns ; then
+                return 0
+            else
+                print_warn "Unable to obtain ${type_string} list from BSS"
+            fi
+
+            if [[ ! -s /etc/hosts ]]; then
+                print_warn "File does not exist or is empty: /etc/hosts"
+            else
+                if cat /etc/hosts | __unique_ncns ; then
+                    return 0
+                fi
+                print_warn "Unable to obtain ${type_string} list from /etc/hosts"
+            fi
+            
+            echo "${type_string} names could not be found. Sleeping for 30 seconds and retrying" 1>&2
+            sleep 30
+
+        done
+    fi
+    print_error "Unable to obtain ${type_string} list from any source"
+    return 1
+}
+
 function k8s_local_tests {
-  if [[ ! -f "/etc/dnsmasq.d/statics.conf" ]]; then
-    # Running on the PIT node -- run the PIT-appropriate suite
-    echo "Test Suite: Kubernetes Cluster Checks (on PIT node)"
-    /usr/bin/goss -g $GOSS_BASE/suites/common-kubernetes-tests-cluster.yaml v
-    echo
-  else
-    # Not on the PIT node
-    echo "Test Suite: Kubernetes Cluster Checks"
-    /usr/bin/goss -g $GOSS_BASE/suites/ncn-kubernetes-tests-cluster.yaml v
-    echo
-  fi
+    local tmpvars GOSS_VARS
+
+    # create_tmpvars_file creates the temporary variables file and saves the path to it in the ${tmpvars} variable
+    create_tmpvars_file || return 1
+
+    export GOSS_VARS=${tmpvars}
+    if is_pit_node; then
+        # Running on the PIT node -- run the PIT-appropriate suite
+        echo "Test Suite: Kubernetes Cluster Checks (on PIT node)"
+        /usr/bin/goss -g "${GOSS_BASE}/suites/common-kubernetes-tests-cluster.yaml" v
+        echo
+    else
+        # Not on the PIT node
+        echo "Test Suite: Kubernetes Cluster Checks"
+        /usr/bin/goss -g "${GOSS_BASE}/suites/ncn-kubernetes-tests-cluster.yaml" v
+        echo
+    fi
 }
 
 function run_ncn_tests {
-  export NODE=$1
-  port=$2
-  endpoint=$3
+    local NODE port endpoint
+    NODE=$1
+    port=$2
+    endpoint=$3
 
-  echo
-  echo Running tests against node $'\e[1;33m'$NODE$'\e[0m'
-  url=http://$NODE.hmn:$port/$endpoint
+    echo
+    echo Running tests against node $'\e[1;33m'${NODE}$'\e[0m'
+    url="http://${NODE}.hmn:${port}/${endpoint}"
 
-  echo Server URL: $url
-  #shellcheck disable=SC2006
-  results=`curl -s $url`
+    echo Server URL: ${url}
+    #shellcheck disable=SC2006
+    if ! results=`curl -s "${url}"` ; then
+        echo $'\e[1;31m'ERROR: Server endpoint could not be reached$'\e[0m'
+        return 1
+    fi
 
-  if [[ $? == 0 ]]; then
-  #shellcheck disable=SC2092
-  #shellcheck disable=SC2006
-    if ! `echo $results | jq -e > /dev/null 2>&1`; then
-      echo $'\e[1;31m'ERROR: Output not valid JSON$'\e[0m'
-      return 1
+    #shellcheck disable=SC2092
+    #shellcheck disable=SC2006
+    if ! `echo ${results} | jq -e > /dev/null 2>&1`; then
+        echo $'\e[1;31m'ERROR: Output not valid JSON$'\e[0m'
+        return 1
     else
-      echo $results | jq -c '.results | sort_by(.result) | .[]' | while read -r test; do
-        result=$(echo $test | jq -r '.result')
+        echo ${results} | jq -c '.results | sort_by(.result) | .[]' | while read -r test; do
+            result=$(echo ${test} | jq -r '.result')
 
-        if [ -z $result ]; then
-          continue
-        elif [ $result == 0 ]; then
-          result=PASS
-          echo $'\e[1;32m'
-        else
-          result=FAIL
-          echo $'\e[1;31m'
-        fi
+            if [[ -z ${result} ]]; then
+                continue
+            elif [[ ${result} == 0 ]]; then
+                result=PASS
+                echo $'\e[1;32m'
+            else
+                result=FAIL
+                echo $'\e[1;31m'
+            fi
 
-        title=$(echo $test | jq -r '.title')
-        description=$(echo $test | jq -r '.meta.desc')
-        severity=$(echo $test | jq -r '.meta.sev')
-        summary=$(echo $test | jq -r '."summary-line"')
-        time=$(echo $test | jq -r '.duration')
-        time=$(echo "scale=8; $time/1000000000" | bc | awk '{printf "%.8f\n", $0}')
+            title=$(echo ${test} | jq -r '.title')
+            description=$(echo ${test} | jq -r '.meta.desc')
+            severity=$(echo ${test} | jq -r '.meta.sev')
+            summary=$(echo ${test} | jq -r '."summary-line"')
+            time=$(echo ${test} | jq -r '.duration')
+            time=$(echo "scale=8; ${time}/1000000000" | bc | awk '{printf "%.8f\n", $0}')
 
-        echo "Result: $result"
-        echo "Test Name: $title"
-        echo "Description: $description"
-        echo "Severity: $severity"
-        echo "Test Summary: $summary"
-        echo "Execution Time: $time seconds"
-        echo "Node: $NODE"
-      done
+            echo "Result: ${result}"
+            echo "Test Name: ${title}"
+            echo "Description: ${description}"
+            echo "Severity: ${severity}"
+            echo "Test Summary: ${summary}"
+            echo "Execution Time: ${time} seconds"
+            echo "Node: ${NODE}"
+        done
     fi
 
     echo $'\e[0m'
 
-    total=$(echo $results | jq -r '.summary."test-count"')
-    failed=$(echo $results | jq -r '.summary."failed-count"')
-    time=$(echo $results | jq -r '.summary."total-duration"')
-    time=$(echo "scale=4; $time/1000000000" | bc | awk '{printf "%.4f\n", $0}')
+    total=$(echo ${results} | jq -r '.summary."test-count"')
+    failed=$(echo ${results} | jq -r '.summary."failed-count"')
+    time=$(echo ${results} | jq -r '.summary."total-duration"')
+    time=$(echo "scale=4; ${time}/1000000000" | bc | awk '{printf "%.4f\n", $0}')
 
-    echo "Total Tests: $total, Total Passed: $((total-failed)), Total Failed: $failed, Total Execution Time: $time seconds"
-  else
-    echo $'\e[1;31m'ERROR: Server endpoint could not be reached$'\e[0m'
-  fi
-  return 0
+    echo "Total Tests: ${total}, Total Passed: $((total-failed)), Total Failed: ${failed}, Total Execution Time: ${time} seconds"
+    return 0
 }
 
-function add_local_vars
-{
+function add_local_vars {
     # $1 - goss variable file
     if [[ $# -ne 1 ]]; then
-        echo "ERROR: add_local_vars: Function requires exactly 1 argument but received $#: $*"
+        print_error "add_local_vars: Function requires exactly 1 argument but received $#: $*"
         return 1
     elif [[ -z $1 ]]; then
-        echo "ERROR: add_local_vars: Argument may not be blank"
+        print_error "add_local_vars: Argument may not be blank"
         return 1
     elif [[ ! -e $1 ]]; then
-        echo "ERROR: add_local_vars: File '$1' does not exist"
+        print_error "add_local_vars: File '$1' does not exist"
         return 1
     elif [[ ! -f $1 ]]; then
-        echo "ERROR: add_local_vars: '$1' exists but is not a regular file"
+        print_error "add_local_vars: '$1' exists but is not a regular file"
         return 1
     fi
 
-    local this_node_name this_node_manufacturer var_string
+    local this_node_name this_node_manufacturer var_string node nodes
 
     # Add local nodename as variable
     this_node_name=$(hostname -s | grep -Eo '(ncn-[msw][0-9]{3}|.*-pit)$')
-    var_string="\nthis_node_name: \"${this_node_name}\"\n"
+    var_string="\n\nthis_node_name: \"${this_node_name}\"\n"
     
     # Add hardware manufacturer as variable
     this_node_manufacturer=$(ipmitool mc info | 
         grep -E "^Manufacturer Name[[:space:]]{1,}:[[:space:]]*[^[:space:]]" |
         sed -e 's/^Manufacturer Name[[:space:]]*:[[:space:]]*//' -e 's/[[:space:]]*$//')
-    var_string="${var_string}\nthis_node_manufacturer: \"${this_node_manufacturer}\"\n"
+    var_string+="\nthis_node_manufacturer: \"${this_node_manufacturer}\"\n"
 
-    echo -e "${var_string}" >> $1
+    # Get NCN list
+    nodes=$(get_ncns)
+
+    # add list of all nodes
+    var_string+="\nnodes:\n"
+    for node in ${nodes}; do
+        var_string+="  - ${node}\n"
+    done
+
+    # add list of k8s nodes
+    var_string+="\nk8s_nodes:\n"
+    for node in $(echo "${nodes}" | grep -oE "ncn-[mw][0-9]{3}") ; do
+        var_string+="  - ${node}\n"
+    done
+    
+    # add list of storage nodes
+    var_string+="\nstorage_nodes:\n"
+    for node in $(echo "${nodes}" | grep -oE "ncn-s[0-9]{3}") ; do
+        var_string+="  - ${node}\n"
+    done
+
+    echo -e "${var_string}" >> "$1"
     return $?
+}
+
+# Sets ${tmpvars} variable to the name of the temporary variable file it creates
+function create_tmpvars_file {
+    if [[ -z ${GOSS_BASE} ]]; then
+        print_error "create_tmpvars_file: GOSS_BASE variable is not set"
+        return 1
+    elif [[ ! -d ${GOSS_BASE}/vars ]]; then
+        print_error "create_tmpvars_file: Directory does not exist: ${GOSS_BASE}/vars"
+        return 1
+    fi
+    
+    local base_var_file
+    
+    if is_pit_node ; then
+        base_var_file="${GOSS_BASE}/vars/variables-livecd.yaml"
+    else
+        base_var_file="${GOSS_BASE}/vars/variables-ncn.yaml"
+    fi
+
+    if [[ ! -e ${base_var_file} ]]; then
+        print_error "create_tmpvars_file: File does not exist: ${base_var_file}"
+        return 1
+    elif [[ ! -f ${base_var_file} ]]; then
+        print_error "create_tmpvars_file: Not a regular file: ${base_var_file}"
+        return 1
+    fi
+
+    tmpvars=$(mktemp /tmp/goss-variables-$(date +%s)-XXXXXX-temp.yaml)
+    if [[ $? -ne 0 ]]; then
+        print_error "create_tmpvars_file: mktemp command failed"
+        return 1
+    fi
+
+    if ! cp "${base_var_file}" "${tmpvars}" ; then
+        print_error "create_tmpvars_file: Command failed: cp '${base_var_file}' '${tmpvars}'"
+        return 1
+    fi
+    
+    add_local_vars "${tmpvars}" || return 1
+    
+    echo "Using Goss variable file: ${tmpvars}"
+    return 0
 }

--- a/goss-testing/tests/common/goss-k8s-nodes-age-valid.yaml
+++ b/goss-testing/tests/common/goss-k8s-nodes-age-valid.yaml
@@ -21,12 +21,15 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# Variable set: k8s_nodes
 
 {{ $kubectl := .Vars.kubectl }}
+{{ $pit_node := .Vars.pit_node }}
 {{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
   {{range $node := index .Vars "k8s_nodes"}}
+  # Do not run this test on ncn-m001 if this is executing on the PIT node
+  {{if $pit_node}}
+  {{if ne $node "ncn-m001"}}
   {{ $testlabel := $node | printf "k8s_node_%s_age_valid" }}
   {{$testlabel}}:
         title: Kubernetes Node '{{$node}}' Valid Age
@@ -42,4 +45,6 @@ command:
         exit-status: 0
         timeout: 20000
         skip: false
+  {{end}}
+  {{end}}
   {{end}}

--- a/goss-testing/tests/common/goss-k8s-nodes-joined-cluster.yaml
+++ b/goss-testing/tests/common/goss-k8s-nodes-joined-cluster.yaml
@@ -22,11 +22,14 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-# Variable set: k8s_nodes
 {{ $kubectl := .Vars.kubectl }}
+{{ $pit_node := .Vars.pit_node }}
 {{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
     {{range $node := index .Vars "k8s_nodes"}}
+    # Do not run this test on ncn-m001 if this is executing on the PIT node
+    {{if $pit_node}}
+    {{if ne $node "ncn-m001"}}
     {{ $testlabel := $node | printf "k8s_node_%s_joined_cluster" }}
     {{$testlabel}}:
         title: Kubernetes Node '{{$node}}' Ready
@@ -42,4 +45,6 @@ command:
         exit-status: 0
         timeout: 20000
         skip: false
+    {{end}}
+    {{end}}
     {{end}}

--- a/goss-testing/vars/variables-common.yaml
+++ b/goss-testing/vars/variables-common.yaml
@@ -47,54 +47,22 @@
 #       It starts with the livecd/ncn variable file that has been installed on the system, and appends to it some system-specific values (which are
 #       determined when the function is called).
 
-network_interfaces:
-  - bond0
-  - bond0.nmn0
-  - bond0.hmn0
-  - bond0.can0
-  - bond0.cmn0
+networks:
+  - "nmn"
+  - "hmn"
+  - "mtl"
+  - "can"
 
-services_enabled:
-  - dnsmasq
-  - nexus
-  - basecamp
-  - conman
+k8s_ceph_csi_configmaps:
+  - ceph-csi-config
+  - cephfs-csi-sc
+  - kube-csi-sc
+  - sma-csi-sc
+  - sts-rados-config
 
-services_running:
-  - dnsmasq
-  - nexus
-  - basecamp
-  - conman
+k8s_ceph_csi_secrets:
+  - csi-cephfs-secret
+  - csi-kube-secret
+  - csi-sma-secret
 
-datajson:
-  - "/var/www/ephemeral/configs/data.json"
-
-staticsconf:
-  - "/etc/dnsmasq.d/statics.conf"
-
-qnd:
-  - "/var/www/ephemeral/qnd-1.4.sh"
-
-commands:
-  - 'kubectl version --client'
-  - 'ipmitool -V'
-  - 'csi version'
-  - 'cray --version'
-
-artifact_symlinks:
-  - filesystem.squashfs
-  - initrd.img.xz
-  - kernel
-
-unbound_hostnames:
-  - rgw-vip.nmn
-  - rgw-vip.hmn
-  - api-gw-service
-  - api-gw-service.local
-  - api-gw-service-nmn.local
-  - packages
-  - registry
-
-bond_member_mtu: 1500
-
-pit_node: true
+kubectl: "/usr/bin/kubectl"

--- a/goss-testing/vars/variables-livecd.yaml
+++ b/goss-testing/vars/variables-livecd.yaml
@@ -94,6 +94,6 @@ unbound_hostnames:
   - packages
   - registry
 
-kubectl: "/usr/local/bin/kubectl"
+kubectl: "/usr/bin/kubectl"
 
 bond_member_mtu: 1500

--- a/goss-testing/vars/variables-livecd.yaml
+++ b/goss-testing/vars/variables-livecd.yaml
@@ -97,3 +97,5 @@ unbound_hostnames:
 kubectl: "/usr/bin/kubectl"
 
 bond_member_mtu: 1500
+
+pit_node: true

--- a/goss-testing/vars/variables-ncn.yaml
+++ b/goss-testing/vars/variables-ncn.yaml
@@ -21,11 +21,31 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-networks:
-  - "nmn"
-  - "hmn"
-  - "mtl"
-  - "can"
+# The following files in this repository govern the Goss test variables:
+#
+# - goss-testing\vars\variables-common.yaml 
+#       Definitions of variables that should have the same values when Goss tests are run on the LiveCD/PIT or on an NCN.
+#
+# - goss-testing\vars\variables-livecd.yaml 
+#       Definitions of variables for Goss tests run on the LiveCD/PIT. These could be variables only needed for tests run on
+#       the PIT, or these could be variables whose values need to be different when run on the PIT.
+#
+# - goss-testing\vars\variables-ncn.yaml 
+#       Definitions of variables for Goss tests run on the NCNs. These could be variables only needed for tests run on
+#       NCNs, or these could be variables whose values need to be different when run on NCNs.
+#
+# - csm-testing.spec
+#       When installing the test RPM on a system, the variables-livecd.yaml and variables-ncn.yaml files that are installed on
+#       the system are created by appending the livecd/ncn variable file from the repository to the common variable file from the repository.
+#       The common variable file itself is not installed on the system.
+#
+#       NOTE: No intelligence is included in the merging of the common file with the livecd/ncn file -- if a variable is defined in both the common
+#       file and the NCN or livecd file, then it will end up being defined twice in the final file.
+#
+# - goss-testing/automated/run-ncn-tests.sh
+#       This shared Bash library contains a function which dynamically generates a variable file before Goss tests are run.
+#       It starts with the livecd/ncn variable file that has been installed on the system, and appends to it some system-specific values (which are
+#       determined when the function is called).
 
 network_interfaces:
   - bond0.nmn0
@@ -95,18 +115,6 @@ k8s_istio_services:
   - istio-ingressgateway
   - istio-ingressgateway-local
 
-k8s_ceph_csi_configmaps:
-  - ceph-csi-config
-  - cephfs-csi-sc
-  - kube-csi-sc
-  - sma-csi-sc
-  - sts-rados-config
-
-k8s_ceph_csi_secrets:
-  - csi-cephfs-secret
-  - csi-kube-secret
-  - csi-sma-secret
-
 k8s_worker_mounts:
   - /var/lib/containerd
   - /var/lib/kubelet
@@ -127,8 +135,6 @@ ceph_services:
   - mds
   - osd
   - rgw
-
-kubectl: "/usr/bin/kubectl"
 
 commands:
   - 'kubectl version --client'

--- a/goss-testing/vars/variables-ncn.yaml
+++ b/goss-testing/vars/variables-ncn.yaml
@@ -153,3 +153,5 @@ storage_fs_labels:
   - CEPHETC
   - CEPHVAR
   - CONTAIN
+
+pit_node: false

--- a/start-goss-servers.sh
+++ b/start-goss-servers.sh
@@ -27,167 +27,120 @@
 export GOSS_BASE=/opt/cray/tests/install/ncn
 export GOSS_LOG_BASE_DIR=/opt/cray/tests/install/logs
 
+source "${GOSS_BASE}/automated/run-ncn-tests.sh"
+
 # necessary for kubectl commands to run
 export KUBECONFIG=/etc/kubernetes/admin.conf
 
-# variables for ncn tests
-vars_file="/opt/cray/tests/install/ncn/vars/variables-ncn.yaml"
-
-# temporary variable file location
-tmpvars=/tmp/goss-variables-$(date +%s)-temp.yaml
-cat $vars_file > $tmpvars
-echo "" >> $tmpvars
-
-echo "Using Goss vars: $tmpvars"
-
-source "$GOSS_BASE/automated/run-ncn-tests.sh"
-# Add variables based on local system
-add_local_vars "$tmpvars"
-
-nodes=""
-# add node names from basecamp or bss metadata to temp variables file
-while [[ `echo $nodes | wc -w` -eq 0 || "$nodes" == "null" ]]; do
-  # try getting node list from basecamp metadata endpoint first
-  nodes=$(curl -s http://ncn-m001:8888/meta-data | jq -r .Global.host_records[].aliases[1] | grep -ohE "ncn-[m,w,s]([0-9]{3})" | awk '!a[$0]++')
-
-  if [[ `echo $nodes | wc -w` -eq 0 || "$nodes" == "null" ]]; then
-    echo "Node names not found in Basecamp. Trying to query BSS metadata instead."
-    nodes=$(curl -s http://api-gw-service-nmn.local:8888/meta-data | jq -r .Global.host_records[].aliases[1] | grep -ohE "ncn-[m,w,s]([0-9]{3})" | awk '!a[$0]++')
-  fi
-
-  if [[ `echo $nodes | wc -w` -ne 0 && "$nodes" != "null" ]]; then
-    # add list of all nodes
-    echo "Found nodes $nodes"
-    echo "nodes:" >> $tmpvars
-    for node in $nodes; do
-      echo "  - $node" >> $tmpvars
-    done
-    echo "" >> $tmpvars
-
-    # add lists of k8s and storage nodes
-    k8s_nodes=$(echo $nodes | grep -ohE "ncn-[m,w]([0-9]{3})")
-    echo "k8s_nodes:" >> $tmpvars
-    for node in $k8s_nodes; do
-      echo "  - $node" >> $tmpvars
-    done
-    echo "" >> $tmpvars
-
-    storage_nodes=$(echo $nodes | grep -ohE "ncn-[s]([0-9]{3})")
-    echo "storage_nodes:" >> $tmpvars
-    for node in $storage_nodes; do
-      echo "  - $node" >> $tmpvars
-    done
-  else
-    echo "Node names could not be found in Basecamp. Waiting for 30s"
-    sleep 30
-  fi
-done
+# The create_tmpvars_file function is defined in run-ncn-tests.sh
+# It creates the temporary variables file and saves the path to it in the $tmpvars variable
+create_tmpvars_file || exit 1
 
 # for security reasons we only want to run the servers on the HMN network, which is not connected to open Internet
 #shellcheck disable=SC2046
 ip=$(host $(hostname).hmn | grep -Po '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
-[[ -z $ip ]] && exit 2
+[[ -z ${ip} ]] && exit 2
 
 # start servers with NCN test suites
 # designated goss-servers port range: 8994-9008
 
 echo "starting ncn-preflight-tests in background"
-/usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-preflight-tests.yaml --vars $tmpvars serve \
+/usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-preflight-tests.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
   --endpoint /ncn-preflight-tests \
-  --listen-addr $ip:8995 &
+  --listen-addr "${ip}":8995 &
 
 echo "starting ncn-kubernetes-tests-master in background"
-/usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-kubernetes-tests-master.yaml --vars $tmpvars serve \
+/usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-kubernetes-tests-master.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
   --endpoint /ncn-kubernetes-tests-master \
-  --listen-addr $ip:8996 &
+  --listen-addr "${ip}":8996 &
 
 echo "starting ncn-kubernetes-tests-worker in background"
-/usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-kubernetes-tests-worker.yaml --vars $tmpvars serve \
+/usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-kubernetes-tests-worker.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
   --endpoint /ncn-kubernetes-tests-worker \
-  --listen-addr $ip:8998 &
+  --listen-addr "${ip}":8998 &
 
 echo "starting ncn-storage-tests in background"
-/usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-storage-tests.yaml --vars $tmpvars serve \
+/usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-storage-tests.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
   --endpoint /ncn-storage-tests \
-  --listen-addr $ip:8997 &
+  --listen-addr "${ip}":8997 &
 
 echo "starting ncn-healthcheck-master in background"
-/usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-healthcheck-master.yaml --vars $tmpvars serve \
+/usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-healthcheck-master.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
   --endpoint /ncn-healthcheck-master \
-  --listen-addr $ip:8994 &
+  --listen-addr "${ip}":8994 &
 
 echo "starting ncn-healthcheck-worker in background"
-/usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-healthcheck-worker.yaml --vars $tmpvars serve \
+/usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-healthcheck-worker.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
   --endpoint /ncn-healthcheck-worker \
-  --listen-addr $ip:9000 &
+  --listen-addr "${ip}":9000 &
 
 echo "starting ncn-healthcheck-storage in background"
-/usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-healthcheck-storage.yaml --vars $tmpvars serve \
+/usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-healthcheck-storage.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
   --endpoint /ncn-healthcheck-storage \
-  --listen-addr $ip:9001 &
+  --listen-addr "${ip}":9001 &
 
 echo "starting ncn-smoke-tests in background"
-/usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-smoke-tests.yaml --vars $tmpvars serve \
+/usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-smoke-tests.yaml --vars "${tmpvars}" serve \
   --format json \
   --endpoint /ncn-smoke-tests \
   --max-concurrent 4 \
-  --listen-addr $ip:9002 &
+  --listen-addr "${ip}":9002 &
 
 echo "starting ncn-spire-healthchecks in background"
-nohup /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-spire-healthchecks.yaml --vars $tmpvars serve \
+nohup /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-spire-healthchecks.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
   --endpoint /ncn-spire-healthchecks \
-  --listen-addr $ip:9003 &
+  --listen-addr "${ip}":9003 &
 
 echo "starting ncn-afterpitreboot-healthcheck-master in background"
-nohup /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-healthcheck-master.yaml --vars $tmpvars serve \
+nohup /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-healthcheck-master.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
   --endpoint /ncn-afterpitreboot-healthcheck-master \
-  --listen-addr $ip:9004 &
+  --listen-addr "${ip}":9004 &
 
 echo "starting ncn-afterpitreboot-healthcheck-worker in background"
-nohup /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-healthcheck-worker.yaml --vars $tmpvars serve \
+nohup /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-healthcheck-worker.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
   --endpoint /ncn-afterpitreboot-healthcheck-worker \
-  --listen-addr $ip:9005 &
+  --listen-addr "${ip}":9005 &
 
 echo "starting ncn-afterpitreboot-healthcheck-storage in background"
-nohup /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-healthcheck-storage.yaml --vars $tmpvars serve \
+nohup /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-healthcheck-storage.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
   --endpoint /ncn-afterpitreboot-healthcheck-storage \
-  --listen-addr $ip:9006 &
+  --listen-addr "${ip}":9006 &
 
 echo "starting ncn-afterpitreboot-kubernetes-tests-master in background"
-nohup /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-kubernetes-tests-master.yaml --vars $tmpvars serve \
+nohup /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-kubernetes-tests-master.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
   --endpoint /ncn-afterpitreboot-kubernetes-tests-master \
-  --listen-addr $ip:9007 &
+  --listen-addr "${ip}":9007 &
 
 echo "starting ncn-afterpitreboot-kubernetes-tests-worker in background"
-nohup /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-kubernetes-tests-worker.yaml --vars $tmpvars serve \
+nohup /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-kubernetes-tests-worker.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
   --endpoint /ncn-afterpitreboot-kubernetes-tests-worker \
-  --listen-addr $ip:9008 &
+  --listen-addr "${ip}":9008 &
 
 echo "Goss servers started in background"
 

--- a/start-goss-servers.sh
+++ b/start-goss-servers.sh
@@ -37,14 +37,15 @@ export KUBECONFIG=/etc/kubernetes/admin.conf
 create_tmpvars_file || exit 1
 
 # for security reasons we only want to run the servers on the HMN network, which is not connected to open Internet
-#shellcheck disable=SC2046
-ip=$(host $(hostname).hmn | grep -Po '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
+ip=$(host "$(hostname).hmn" | grep -Po '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
 [[ -z ${ip} ]] && exit 2
 
 # start servers with NCN test suites
 # designated goss-servers port range: 8994-9008
 
 echo "starting ncn-preflight-tests in background"
+# $tmpvars is set by the create_tmpvars_file function earlier
+#shellcheck disable=SC2154
 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-preflight-tests.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
@@ -52,6 +53,8 @@ echo "starting ncn-preflight-tests in background"
   --listen-addr "${ip}":8995 &
 
 echo "starting ncn-kubernetes-tests-master in background"
+# $tmpvars is set by the create_tmpvars_file function earlier
+#shellcheck disable=SC2154
 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-kubernetes-tests-master.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
@@ -59,6 +62,8 @@ echo "starting ncn-kubernetes-tests-master in background"
   --listen-addr "${ip}":8996 &
 
 echo "starting ncn-kubernetes-tests-worker in background"
+# $tmpvars is set by the create_tmpvars_file function earlier
+#shellcheck disable=SC2154
 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-kubernetes-tests-worker.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
@@ -66,6 +71,8 @@ echo "starting ncn-kubernetes-tests-worker in background"
   --listen-addr "${ip}":8998 &
 
 echo "starting ncn-storage-tests in background"
+# $tmpvars is set by the create_tmpvars_file function earlier
+#shellcheck disable=SC2154
 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-storage-tests.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
@@ -73,6 +80,8 @@ echo "starting ncn-storage-tests in background"
   --listen-addr "${ip}":8997 &
 
 echo "starting ncn-healthcheck-master in background"
+# $tmpvars is set by the create_tmpvars_file function earlier
+#shellcheck disable=SC2154
 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-healthcheck-master.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
@@ -80,6 +89,8 @@ echo "starting ncn-healthcheck-master in background"
   --listen-addr "${ip}":8994 &
 
 echo "starting ncn-healthcheck-worker in background"
+# $tmpvars is set by the create_tmpvars_file function earlier
+#shellcheck disable=SC2154
 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-healthcheck-worker.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
@@ -87,6 +98,8 @@ echo "starting ncn-healthcheck-worker in background"
   --listen-addr "${ip}":9000 &
 
 echo "starting ncn-healthcheck-storage in background"
+# $tmpvars is set by the create_tmpvars_file function earlier
+#shellcheck disable=SC2154
 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-healthcheck-storage.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
@@ -94,6 +107,8 @@ echo "starting ncn-healthcheck-storage in background"
   --listen-addr "${ip}":9001 &
 
 echo "starting ncn-smoke-tests in background"
+# $tmpvars is set by the create_tmpvars_file function earlier
+#shellcheck disable=SC2154
 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-smoke-tests.yaml --vars "${tmpvars}" serve \
   --format json \
   --endpoint /ncn-smoke-tests \
@@ -101,42 +116,54 @@ echo "starting ncn-smoke-tests in background"
   --listen-addr "${ip}":9002 &
 
 echo "starting ncn-spire-healthchecks in background"
-nohup /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-spire-healthchecks.yaml --vars "${tmpvars}" serve \
+# $tmpvars is set by the create_tmpvars_file function earlier
+#shellcheck disable=SC2154
+/usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-spire-healthchecks.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
   --endpoint /ncn-spire-healthchecks \
   --listen-addr "${ip}":9003 &
 
 echo "starting ncn-afterpitreboot-healthcheck-master in background"
-nohup /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-healthcheck-master.yaml --vars "${tmpvars}" serve \
+# $tmpvars is set by the create_tmpvars_file function earlier
+#shellcheck disable=SC2154
+/usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-healthcheck-master.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
   --endpoint /ncn-afterpitreboot-healthcheck-master \
   --listen-addr "${ip}":9004 &
 
 echo "starting ncn-afterpitreboot-healthcheck-worker in background"
-nohup /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-healthcheck-worker.yaml --vars "${tmpvars}" serve \
+# $tmpvars is set by the create_tmpvars_file function earlier
+#shellcheck disable=SC2154
+/usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-healthcheck-worker.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
   --endpoint /ncn-afterpitreboot-healthcheck-worker \
   --listen-addr "${ip}":9005 &
 
 echo "starting ncn-afterpitreboot-healthcheck-storage in background"
-nohup /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-healthcheck-storage.yaml --vars "${tmpvars}" serve \
+# $tmpvars is set by the create_tmpvars_file function earlier
+#shellcheck disable=SC2154
+/usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-healthcheck-storage.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
   --endpoint /ncn-afterpitreboot-healthcheck-storage \
   --listen-addr "${ip}":9006 &
 
 echo "starting ncn-afterpitreboot-kubernetes-tests-master in background"
-nohup /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-kubernetes-tests-master.yaml --vars "${tmpvars}" serve \
+# $tmpvars is set by the create_tmpvars_file function earlier
+#shellcheck disable=SC2154
+/usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-kubernetes-tests-master.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
   --endpoint /ncn-afterpitreboot-kubernetes-tests-master \
   --listen-addr "${ip}":9007 &
 
 echo "starting ncn-afterpitreboot-kubernetes-tests-worker in background"
-nohup /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-kubernetes-tests-worker.yaml --vars "${tmpvars}" serve \
+# $tmpvars is set by the create_tmpvars_file function earlier
+#shellcheck disable=SC2154
+/usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-kubernetes-tests-worker.yaml --vars "${tmpvars}" serve \
   --format json \
   --max-concurrent 4 \
   --endpoint /ncn-afterpitreboot-kubernetes-tests-worker \


### PR DESCRIPTION
## Summary and Scope

### TL;DR

* Create common function to determine if script is running on the PIT node; update other scripts to call it.
* Create common function to generate list of NCNs; update other scripts to call it.
* Update goss-k8s-nodes-age-valid and goss-k8s-nodes-joined-cluster tests so they realize ncn-m001 is not in the cluster if they are running on the PIT node.
* Update value of kubectl variable for the PIT node
* Create common goss variable file for variables with same value between PIT and NCN; Modify RPM builder so that it generates NCN/PIT variable files by combining common file with PIT/NCN file.
* Moved a couple of common functions into the common function library.
* General linting and cleanup to make the scripts more consistent.

### Details

This ticket began just as a fix to a problem being seen on the surtur install, where the dnsmasq statics file had been deleted from the PIT node at some point, which caused the csm-testing scripts to assume that it was a normal NCN. This caused other problems.

While there is no surefire way to determine the node identity if someone may be going around changing things in the environment (like deleting the dnsmasq file), it seems better to key off something like the pit-release file regardless. So this PR was originally going to make that change. But then I realized that there was code all across the automated scripts that was deciding whether or not the particular script was running on the PIT node. So I used this PR to change all of those to instead use a shared function for this, so we don't play whack-a-mole when individual scripts mess up.

In the process of doing that, I also noticed some other code that could be made common, in order to make the scripts more consistent and less error prone. And I realized that if we were assuming that the dnsmasq file may not be there, then our code for making a list of NCNs would need to change. And this is code which existed in different forms in several places. So another common function I created was one to get the list of NCNs on the system (either all of them, or particular types, with an option to exclude the PIT). 

In the process of testing this, I discovered that a couple of Kubernetes checks were being made for ncn-m001 even though the test was running from the booted PIT node. So I modified those tests to omit ncn-m001 when executing on the PIT node.

While doing all of that, I tried to do other minor cleanup, linting, etc, to make the scripts more consistent in appearance and convention.

And finally, I noticed on surtur today that path for kubectl on the PIT node had changed, which tripped some of the goss tests up, so I am correcting that here as well. When doing that, I noticed that we had a fair number of variables which were in common from NCNs and LiveCDs. So I created a common variables file with the shared values, and then added a little code in the RPM builder to have it create the installed variable files based on a merger of the PIT/NCN variable file and the common variable file.

## Issues and Related PRs

https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5025

## Testing

I tested the changes on surtur by running all of the automated scripts on both the PIT node and on other NCNs. In addition, I made sure that the updated goss service script file was correctly populating the variable file and starting the servers.

## Risks and Mitigations

Moderate risk in the sense that a lot of code was touched. But the result is a much more maintainable situation than we had before, so even if problems are found that eluded my testing on surtur, it should be much easier to correct them.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
