### PR TITLE
CASMINST-5129: Fix typo in ncn-healthcheck-master script

### DIFF
--- a/goss-testing/automated/ncn-healthcheck-master
+++ b/goss-testing/automated/ncn-healthcheck-master
@@ -34,7 +34,7 @@ echo $'\e[1;33m'-------------------$'\e[0m'
 
 # Find the NCN node names and query the server endpoint
 # The get_ncns function is defined in run-ncn-tests.sh
-nodes=$(get_ncns --master --exclude-pit) || exit 1
+nodes=$(get_ncns --masters --exclude-pit) || exit 1
 
 # The get_ncns function should always give NCNs if its return code was 0, but better safe than sorry
 [[ -n ${nodes} ]] || err_exit "No master NCNs found"


### PR DESCRIPTION
## Summary and Scope

A typo in the ncn-healthcheck-master script meant that it was calling the get_ncns function with an invalid argument ("--master" instead of "--masters"). This PR fixes that. 

I also grepped all of the other files and verified that none of them were using invalid arguments with this function.

## Issues and Related PRs

Injected by CASMINST-5025.

## Testing

I tested the updated script on surtur and verified that it now works properly.

## Risks and Mitigations

One character change. Low risk.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
