### PR TITLE
CASMINST-5159: Speed up Goss test result reporting

### DIFF
--- a/goss-testing/automated/livecd-preflight-checks
+++ b/goss-testing/automated/livecd-preflight-checks
@@ -29,7 +29,7 @@ set -e
 
 # GOSS_BASE should already be set on the PIT node, but just in case we
 # will set it here
-export GOSS_BASE=${GOSS_BASE-"/opt/cray/tests/install/livecd"}
+export GOSS_BASE=${GOSS_BASE:-"/opt/cray/tests/install/livecd"}
 
 source "${GOSS_BASE}/automated/run-ncn-tests.sh"
 

--- a/goss-testing/automated/livecd-preflight-checks
+++ b/goss-testing/automated/livecd-preflight-checks
@@ -29,9 +29,7 @@ set -e
 
 # GOSS_BASE should already be set on the PIT node, but just in case we
 # will set it here
-[[ -z ${GOSS_BASE} ]] && export GOSS_BASE="/opt/cray/tests/install/livecd"
-
-export GOSS_LOG_BASE_DIR=/opt/cray/tests/install/logs
+export GOSS_BASE=${GOSS_BASE-"/opt/cray/tests/install/livecd"}
 
 source "${GOSS_BASE}/automated/run-ncn-tests.sh"
 
@@ -54,57 +52,9 @@ echo $'\e[1;33m'Running LiveCD preflight checks \(may take a few minutes to comp
 
 # Run the LiveCD preflight Goss test suite
 export GOSS_VARS=${tmpvars}
-set +e
-results=$(/usr/bin/goss validate -f json)
-set -e
 
-if ! `echo ${results} | jq -e > /dev/null 2>&1`; then
-  err_exit $'\e[1;31m'Output not valid JSON$'\e[0m'
-fi
+/usr/bin/goss validate -f json | "${GOSS_BASE}/automated/print_goss_json_results" --input - ||
+	err_exit $'\e[1;31m'"There were test errors"$'\e[0m'
 
-echo ${results} | jq -c '.results | sort_by(.result) | .[]' | while read -r test; do
-  result=$(echo ${test} | jq -r '.result')
-
-  if [[ -z ${result} ]]; then
-    continue
-  elif [[ ${result} == 0 ]]; then
-    result=PASS
-    echo $'\e[1;32m'
-  else
-    result=FAIL
-    echo $'\e[1;31m'
-  fi
-
-  title=$(echo ${test} | jq -r '.title')
-  description=$(echo ${test} | jq -r '.meta.desc')
-  severity=$(echo ${test} | jq -r '.meta.sev')
-  summary=$(echo ${test} | jq -r '."summary-line"')
-  time=$(echo ${test} | jq -r '.duration')
-  time=$(echo "scale=8; ${time}/1000000000" | bc | awk '{printf "%.8f\n", $0}')
-
-  echo "Result: ${result}"
-  echo "Test Name: ${title}"
-  echo "Description: ${description}"
-  echo "Severity: ${severity}"
-  echo "Test Summary: ${summary}"
-  echo "Execution Time: ${time} seconds"
-  echo "Node: ncn-m001"
-done
-
-echo $'\e[0m'
-
-total=$(echo ${results} | jq -r '.summary."test-count"')
-failed=$(echo ${results} | jq -r '.summary."failed-count"')
-time=$(echo ${results} | jq -r '.summary."total-duration"')
-time=$(echo "scale=4; ${time}/1000000000" | bc | awk '{printf "%.4f\n", $0}')
-
-echo "Total Tests: ${total}, Total Passed: $((total-failed)), Total Failed: ${failed}, Total Execution Time: ${time} seconds"
-echo
-
-if [[ ${total} -eq 0 ]]; then
-    err_exit "No tests were run!"
-elif [[ ${failed} -ne 0 ]]; then
-    err_exit "Not all tests passed"
-fi
 echo "All tests passed!"
 exit 0

--- a/goss-testing/automated/livecd-provisioning-checks
+++ b/goss-testing/automated/livecd-provisioning-checks
@@ -24,7 +24,7 @@
 
 # GOSS_BASE should already be set on the PIT node, but just in case we
 # will set it here
-export GOSS_BASE=${GOSS_BASE-"/opt/cray/tests/install/livecd"}
+export GOSS_BASE=${GOSS_BASE:-"/opt/cray/tests/install/livecd"}
 
 source "${GOSS_BASE}/automated/run-ncn-tests.sh"
 

--- a/goss-testing/automated/livecd-provisioning-checks
+++ b/goss-testing/automated/livecd-provisioning-checks
@@ -24,9 +24,7 @@
 
 # GOSS_BASE should already be set on the PIT node, but just in case we
 # will set it here
-[[ -z ${GOSS_BASE} ]] && export GOSS_BASE="/opt/cray/tests/install/livecd"
-
-export GOSS_LOG_BASE_DIR=/opt/cray/tests/install/logs
+export GOSS_BASE=${GOSS_BASE-"/opt/cray/tests/install/livecd"}
 
 source "${GOSS_BASE}/automated/run-ncn-tests.sh"
 
@@ -40,49 +38,9 @@ echo $'\e[1;33m'Running LiveCD provisioning checks \(may take a few minutes to c
 
 # Run the LiveCD provisioning Goss test suite
 export GOSS_VARS=${tmpvars}
-results=$(/usr/bin/goss validate -f json)
 
-if ! `echo ${results} | jq -e > /dev/null 2>&1`; then
-  echo $'\e[1;31m'ERROR: Output not valid JSON$'\e[0m'
-  exit 1
-fi
+/usr/bin/goss validate -f json | "${GOSS_BASE}/automated/print_goss_json_results" --input - ||
+	err_exit $'\e[1;31m'"There were test errors"$'\e[0m'
 
-echo ${results} | jq -c '.results | sort_by(.result) | .[]' | while read -r test; do
-  result=$(echo ${test} | jq -r '.result')
-
-  if [ -z ${result} ]; then
-    continue
-  elif [ ${result} == 0 ]; then
-    result=PASS
-    echo $'\e[1;32m'
-  else
-    result=FAIL
-    echo $'\e[1;31m'
-  fi
-
-  title=$(echo ${test} | jq -r '.title')
-  description=$(echo ${test} | jq -r '.meta.desc')
-  severity=$(echo ${test} | jq -r '.meta.sev')
-  summary=$(echo ${test} | jq -r '."summary-line"')
-  time=$(echo ${test} | jq -r '.duration')
-  time=$(echo "scale=8; ${time}/1000000000" | bc | awk '{printf "%.8f\n", $0}')
-
-  echo "Result: ${result}"
-  echo "Test Name: ${title}"
-  echo "Description: ${description}"
-  echo "Severity: ${severity}"
-  echo "Test Summary: ${summary}"
-  echo "Execution Time: ${time} seconds"
-  echo "Node: ncn-m001"
-done
-
-echo $'\e[0m'
-
-total=$(echo ${results} | jq -r '.summary."test-count"')
-failed=$(echo ${results} | jq -r '.summary."failed-count"')
-time=$(echo ${results} | jq -r '.summary."total-duration"')
-time=$(echo "scale=4; ${time}/1000000000" | bc | awk '{printf "%.4f\n", $0}')
-
-echo "Total Tests: ${total}, Total Passed: $((total-failed)), Total Failed: ${failed}, Total Execution Time: ${time} seconds"
-
-exit
+echo "All tests passed!"
+exit 0

--- a/goss-testing/automated/print_goss_json_results
+++ b/goss-testing/automated/print_goss_json_results
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+"""
+Usage: print_goss_json_results.py [--input filename|url] [--node node-name] [--override-rc]
+
+Reads JSON-format Goss test results from filename or URL (or stdin if
+filename/URL is "-" or not specified) and prints the results (passes in green, fails in red).
+If node name is specified, it will be included in the test result stanzas.
+
+Exit codes:
+                            default         --override-rc
+All tests passed            0               0
+At least one test failed    3               0
+No passed or failed tests   4               0
+Usage error                 2               2
+Other error                 1               1
+
+Script log file is in directory /opt/cray/tests/install/logs
+"""
+
+import argparse
+import colorama
+import json
+import logging
+import os
+import requests
+import sys
+import traceback
+
+logger = logging.getLogger(__file__)
+logger.setLevel(logging.DEBUG)
+
+myname = sys.argv[0].split('/')[-1]
+# Strip off .py, if present
+if myname[-3:] == ".py":
+    myname = myname[:-3]
+
+# set up logging to file
+logFileDir = "/opt/cray/tests/install/logs"
+# create log directory; it is ok if it already exists
+os.makedirs(logFileDir, exist_ok=True)
+logFilePath = f"{logFileDir}/{myname}.log"
+file_handler = logging.FileHandler(filename=logFilePath)
+file_handler.setLevel(os.environ.get("PRINT_GOSS_FILE_LOG_LEVEL", logging.DEBUG))
+logger.addHandler(file_handler)
+
+err_text = colorama.Fore.LIGHTRED_EX
+warn_text = colorama.Fore.LIGHTYELLOW_EX
+ok_text = colorama.Fore.LIGHTGREEN_EX
+reset_text = colorama.Style.RESET_ALL
+
+def stderr_print(s):
+    sys.stderr.write(f"{s}\n")
+    sys.stderr.flush()
+
+def warn(msg):
+    stderr_print(f"{warn_text}WARNING: {msg}{reset_text}")
+
+def err(msg):
+    stderr_print(f"{err_text}ERROR: {msg}{reset_text}")
+
+def debug_log_values(**kwargs):
+    logger.debug(" ".join([ f"{k}={v}" for (k, v) in kwargs.items() ]))
+
+class ScriptException(Exception):
+    pass
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Print JSON-format Goss test results with pretty colors")
+    parser.add_argument("--input", default="-", metavar="input_source", help="Source file or URL for test results. Defaults to stdin.")
+    parser.add_argument("--node_name", help="Node name to include in result stanzas ")
+    parser.add_argument("--override-rc", action="store_true", dest="override_rc", help="Make script exit code ignore test results")
+    args = parser.parse_args()
+    input_source, node_name, override_rc = args.input, args.node_name, args.override_rc
+    debug_log_values(input_source=input_source, node_name=node_name, override_rc=override_rc)
+    return input_source, node_name, override_rc
+
+def read_and_decode_json(input_file):
+    if input_file == "-":
+        input = sys.stdin.read()
+    else:
+        try:
+            with open(input_file, "rt") as infile:
+                input = infile.read()
+        except OSError:
+            logger.error(traceback.format_exc())
+            traceback.print_exc()
+            raise ScriptException(f"Problem reading input file {input_file}")
+    try:
+        return json.loads(input)
+    except json.decoder.JSONDecodeError:
+        debug_log_values(input=input)
+        logger.error(traceback.format_exc())
+        traceback.print_exc()
+        raise ScriptException("Unable to decode JSON input")
+
+def get_json_from_input_url(input_url):
+    logger.debug(f"Making GET request to {input_url}")
+    resp = requests.get(input_url)
+    debug_log_values(status_code=resp.status_code, reason=resp.reason, headers=resp.headers, ok=resp.ok)
+    # Expected responses are 200 (meaning no tests failed) or 503 (which can mean either that there were test failures OR that there was
+    # another Goss issue, like syntax errors in the test files).
+    if resp.status_code not in { 200, 503 }:
+        raise ScriptException(f"Status code {resp.status_code} received from Goss URL {input_url}: {resp.text}")
+    try:
+        return resp.json()
+    except Exception:
+        logger.error(traceback.format_exc())
+        traceback.print_exc()
+        debug_log_values(text=resp.text)
+        raise ScriptException("Unable to decode JSON from endpoint response")
+
+def extract_results_data(json_results):
+    try:
+        results = json_results["results"]
+
+        # Make list of results with a numeric result
+        selected_results = [ 
+            {   "result":       result_entry["result"],
+                "title":        result_entry["title"], 
+                "summary-line": result_entry["summary-line"], 
+                "duration":     result_entry["duration"], 
+                "resource-id":  result_entry["resource-id"],
+                "desc":         result_entry["meta"]["desc"] }
+            for result_entry in results if isinstance(result_entry["result"], int) ]
+
+        # Get some of the summary fields
+        summary = json_results["summary"]
+        failed_count = summary["failed-count"]
+        total_duration = summary["total-duration"]
+    except (KeyError, TypeError) as e:
+        debug_log_values(json_results=json_results)
+        logger.error(traceback.format_exc())
+        raise ScriptException(f"Goss test results have unexpected format. {type(e)}: {e}")
+    # Sort the results
+    selected_results.sort(key=lambda r: (r["result"], r["title"]))
+    return selected_results, failed_count, total_duration
+
+def show_results(selected_results, failed_count, total_duration, node_name, override_rc):
+    manual_fail_count=0
+    total_count=len(selected_results)
+    for res in selected_results:
+        debug_log_values(resource_id=res["resource-id"], result=res["result"], node=node_name)
+        if res["result"] == 0:
+            print(f"{ok_text}Result: PASS")
+        else:
+            print(f"{err_text}Result: FAIL")
+            manual_fail_count+=1
+        print(f"Test Name: {res['title']}\nDescription: {res['desc']}\nTest Summary: {res['summary-line']}\nExecution Time: {res['duration']/1000000000:.8f} seconds")
+        if node_name:
+            print(f"Node: {node_name}")
+        # Reset text color while adding newline after this result block; flush stdout while we're at it
+        print(reset_text, flush=True)
+
+    summary=f"Total Tests: {total_count}, Total Passed: {total_count-manual_fail_count}, Total Failed: {manual_fail_count}, Total Execution Time: {total_duration/1000000000:.8f} seconds"
+    logger.debug(summary)
+    print(summary, flush=True)
+    if failed_count != manual_fail_count:
+        mismatch=f"failed_count in results ({failed_count}) does not match manual tally of test failures ({manual_fail_count})"
+        logger.warning(mismatch)
+        # Only bother printing it to the screen if it is a case where we didn't see any failures but Goss says there were some,
+        # or vice versa
+        if manual_fail_count == 0 or failed_count == 0:
+            warn(mismatch)
+    elif total_count == 0:
+        if failed_count == 0:
+            warn("No tests executed")
+        else:
+            warn(f"Goss reports that no tests executed, but also that {failed_count} tests failed")
+    if override_rc:
+        return 0
+    elif total_count == 0:
+        return 4
+    elif manual_fail_count == 0 and failed_count == 0:
+        return 0
+    else:
+        return 3
+
+def main():
+    logger.debug(f"Called with {len(sys.argv)} argument(s): {' '.join(sys.argv)}")
+    input_source, node_name, override_rc = parse_args()
+    if input_source.find("http://") == 0 or input_source.find("https://") == 0:
+        json_results = get_json_from_input_url(input_source)
+    else:
+        json_results = read_and_decode_json(input_source)
+    selected_results, failed_count, total_duration = extract_results_data(json_results)
+    return show_results(selected_results, failed_count, total_duration, node_name, override_rc)
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except ScriptException as e:
+        err(e)
+        logger.error(e)
+        sys.exit(1)

--- a/goss-testing/automated/print_goss_json_results
+++ b/goss-testing/automated/print_goss_json_results
@@ -89,10 +89,10 @@ class ScriptException(Exception):
     pass
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Print JSON-format Goss test results with pretty colors")
+    parser = argparse.ArgumentParser(description="Print JSON-format Goss test results with pretty colors.")
     parser.add_argument("--input", default="-", metavar="input_source", help="Source file or URL for test results. Defaults to stdin.")
-    parser.add_argument("--node_name", help="Node name to include in result stanzas ")
-    parser.add_argument("--override-rc", action="store_true", dest="override_rc", help="Make script exit code ignore test results")
+    parser.add_argument("--node_name", help="Node name to include in result stanzas.")
+    parser.add_argument("--override-rc", action="store_true", dest="override_rc", help="Make script exit code ignore test results.")
     args = parser.parse_args()
     input_source, node_name, override_rc = args.input, args.node_name, args.override_rc
     debug_log_values(input_source=input_source, node_name=node_name, override_rc=override_rc)
@@ -111,7 +111,7 @@ def read_and_decode_json(input_file):
             raise ScriptException(f"Problem reading input file {input_file}")
     try:
         return json.loads(input)
-    except json.decoder.JSONDecodeError:
+    except Exception:
         debug_log_values(input=input)
         logger.error(traceback.format_exc())
         traceback.print_exc()

--- a/goss-testing/automated/run-ncn-tests.sh
+++ b/goss-testing/automated/run-ncn-tests.sh
@@ -59,7 +59,7 @@ if [[ -z ${GOSS_BASE} ]]; then
 fi
 export GOSS_BASE
 
-export GOSS_LOG_BASE_DIR=${GOSS_LOG_BASE_DIR-"${GOSS_INSTALL_BASE_DIR}/logs"}
+export GOSS_LOG_BASE_DIR=${GOSS_LOG_BASE_DIR:-"${GOSS_INSTALL_BASE_DIR}/logs"}
 
 # Prints a list of all NCNs
 # Prints warnings if there are fewer than expected


### PR DESCRIPTION
## Summary and Scope

A few of the Goss automated scripts use Bash scripting and a lot of jq commands to parse the results and display them. This is very slow and can take longer than the tests themselves, more than doubling the time of the script execution.

This PR creates a Python script which replaces that code. The script makes a GET request to a Goss endpoint, or reads Goss JSON results from stdin (or from a file). Either way, it then parses the JSON results and presents them in the same way that the current scripts do. Just much faster (see testing section for details).

[CASMINST-5159](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5159) is phase 1 of a multi-part plan. The next stage is [CASMINST-5161](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5161), to modify our scripts which make calls to multiple goss endpoints so that they can present a grand total result summary at the end of the output, thus removing the need for our current "grep for the total lines" stuff in our docs. The goal here would also be to only output failures (if any) and a summary of execution -- not the current page after page of test successes. That output would instead be sent to a log file.

The final phase is [CASMINST-5162](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5162), to, if our tests don't have conflicts that prevent it, hit  the test endpoints in parallel on the nodes.

But for this PR, it just replaces the JSON parsing with something much faster.

## Testing

Three files contained this parsing code:
livecd-preflight-checks
livecd-provisioning-checks
run-ncn-tests.sh

I tested the two livecd scripts on the surtur PIT node. 

I tested the run-ncn-tests.sh changes by calling the ncn-healthcheck script on rocket, because it in turn calls the three ncn-healthcheck-master, -storage, and -worker scripts, and each of those call the modified function in run-ncn-tests.sh. 

I ran the scripts both with and without this PR in place. The results were the same for both in terms of the tests being executed and the output reported (as in, no problems were introduced).  However, the speeds were improved:

Script | Time without PR | Time with PR 
------ | ------------------ | ---------------
livecd-preflight-checks | 54.364s | 17.516s
livecd-provisioning-checks | 3.286s | 0.398s
ncn-healthcheck | 5m27.408s | 3m10.443s

In addition, I made sure that I tested cases where there were test failures, to ensure that they were properly handled.

## Risks and Mitigations

The only change is to the logic for parsing the test output. Low risk.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
