### PR TITLE
CASMPET-5838-1.3 : Break/Fix: Etcd health checks failing - need to specify etcd container

### DIFF
--- a/goss-testing/scripts/etcd_database_health.sh
+++ b/goss-testing/scripts/etcd_database_health.sh
@@ -24,7 +24,7 @@
 #
 for pod in $(kubectl get pods -l app=etcd -n services -o jsonpath='{.items[*].metadata.name}')
 do
-    dbc=$(kubectl -n services exec ${pod} -- /bin/sh \
+    dbc=$(kubectl -n services exec ${pod} -c etcd -- /bin/sh \
                   -c "ETCDCTL_API=3 etcdctl put foo fooCheck && \
                   ETCDCTL_API=3 etcdctl get foo && \
                   ETCDCTL_API=3 etcdctl del foo && \

--- a/goss-testing/scripts/etcd_health_check.sh
+++ b/goss-testing/scripts/etcd_health_check.sh
@@ -90,7 +90,7 @@ do
         for pod in $pods
         do
             #shellcheck disable=SC2034
-            temp=$(kubectl -n services exec ${pod} -- /bin/sh -c "ETCDCTL_API=3 etcdctl endpoint health -w json")
+            temp=$(kubectl -n services exec ${pod} -c etcd -- /bin/sh -c "ETCDCTL_API=3 etcdctl endpoint health -w json")
             if [[ $? != 0 ]]
             then
                 endpoint_msg="${endpoint_msg}Error with endpoint health of ${pod}.  "
@@ -107,7 +107,7 @@ do
         alarm_msg=""
         for pod in $pods
         do
-            alarm=$(kubectl -n $namespace exec ${pod} -- /bin/sh -c "ETCDCTL_API=3 etcdctl alarm list")
+            alarm=$(kubectl -n $namespace exec ${pod} -c etcd -- /bin/sh -c "ETCDCTL_API=3 etcdctl alarm list")
             if [ ! -z $alarm ]
             then
                 alarm_msg="${alarm_msg}Alarms for ${pod}: ${alarm}.  "


### PR DESCRIPTION
## Summary and Scope

Adding the container (-c etcd) when exec'ing into the etcd pods in goss tests.
_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix? bug fix

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5838](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5838) for goss test, docs which are in progress
* Change will also be needed in NA (only needed for CSM 1.3 and beyond)
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after `<insert PR URL here>`

## Testing

drax

### Tested on:

  * `drax`

### Test description:

Ran goss test to verify no regressions in the fix.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? NA
- Were continuous integration tests run? If not, why? NA
- Was upgrade tested? If not, why? NA
- Was downgrade tested? If not, why? NA
- Were new tests (or test issues/Jiras) created for this change? NA

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_ No


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

