### PR TITLE
CASMINST-5171: Move Goss server endpoint definitions to config file

### DIFF
--- a/csm-testing.spec
+++ b/csm-testing.spec
@@ -25,6 +25,8 @@
 %define install_dir %{test_dir}/install
 %define livecd %{install_dir}/livecd
 %define ncn %{install_dir}/ncn
+%define dat %{install_dir}/dat
+%define logs %{install_dir}/logs
 
 Name: csm-testing
 License: HPE Software License Agreement
@@ -48,6 +50,8 @@ They test both the LiveCD and NCN environment.
 %install
 
 # Install testing files
+install -d -m 755 %{buildroot}%{dat}
+install -d -m 755 %{buildroot}%{logs}
 install -d -m 755 %{buildroot}%{livecd}/automated
 install -d -m 755 %{buildroot}%{livecd}/tests
 install -d -m 755 %{buildroot}%{livecd}/vars
@@ -93,8 +97,8 @@ cp -a goss-testing/suites/ncn-*         %{buildroot}%{ncn}/suites
 chmod +x -R %{buildroot}%{ncn}/scripts/
 chmod +x -R %{buildroot}%{livecd}/scripts/
 chmod +x -R %{buildroot}%{ncn}/automated/
-# Create default test log directories
-mkdir -p %{buildroot}/opt/cray/tests/install/logs
+# Install goss-servers config file
+install -m 755 goss-testing/dat/goss-servers.cfg	%{buildroot}%{dat}
 
 # Install goss-servers files
 mkdir -p %{buildroot}/usr/sbin
@@ -103,13 +107,16 @@ install -m 755 start-goss-servers.sh %{buildroot}/usr/sbin/
 install -m 755 goss-servers.service %{buildroot}/etc/systemd/system/
 
 %clean
+rm -rf %{buildroot}%{dat}
 rm -rf %{buildroot}%{livecd}
 rm -rf %{buildroot}%{ncn}
 # Remove log directories only if empty
-rmdir %{buildroot}/opt/cray/tests/install/logs || true
+rmdir %{buildroot}%{logs} || true
 
 %files
 %defattr(755, root, root)
+%{dat}
+%{logs}
 %{livecd}
 %{ncn}
 

--- a/goss-testing/automated/ncn-healthcheck-master
+++ b/goss-testing/automated/ncn-healthcheck-master
@@ -41,9 +41,9 @@ nodes=$(get_ncns --masters --exclude-pit) || exit 1
 
 # Query the server endpoint
 for node in ${nodes} ; do
-	run_ncn_tests "${node}" "8994" "ncn-healthcheck-master"
+	run_ncn_tests "${node}" "ncn-healthcheck-master"
 	if ! is_pit_node ; then
-		run_ncn_tests "${node}" "9004" "ncn-afterpitreboot-healthcheck-master"
+		run_ncn_tests "${node}" "ncn-afterpitreboot-healthcheck-master"
 	fi
 done
 

--- a/goss-testing/automated/ncn-healthcheck-storage
+++ b/goss-testing/automated/ncn-healthcheck-storage
@@ -41,9 +41,9 @@ nodes=$(get_ncns --storage) || exit 1
 
 # Query the server endpoint
 for node in ${nodes} ; do
-	run_ncn_tests "${node}" "9001" "ncn-healthcheck-storage"
+	run_ncn_tests "${node}" "ncn-healthcheck-storage"
 	if ! is_pit_node ; then
-		run_ncn_tests "${node}" "9006" "ncn-afterpitreboot-healthcheck-storage"
+		run_ncn_tests "${node}" "ncn-afterpitreboot-healthcheck-storage"
 	fi
 done
 

--- a/goss-testing/automated/ncn-healthcheck-worker
+++ b/goss-testing/automated/ncn-healthcheck-worker
@@ -43,9 +43,9 @@ if nodes=$(get_ncns --workers); then
 	else
 		# Query the server endpoints
 		for node in ${nodes} ; do
-			run_ncn_tests "${node}" "9000" "ncn-healthcheck-worker"
+			run_ncn_tests "${node}" "ncn-healthcheck-worker"
 			if ! is_pit_node ; then
-				run_ncn_tests "${node}" "9005" "ncn-afterpitreboot-healthcheck-worker"
+				run_ncn_tests "${node}" "ncn-afterpitreboot-healthcheck-worker"
 			fi
 		done
 	fi

--- a/goss-testing/automated/ncn-kubernetes-checks
+++ b/goss-testing/automated/ncn-kubernetes-checks
@@ -66,9 +66,9 @@ if nodes=$(get_ncns --masters --exclude-pit); then
 	else
 		# Query the server endpoints
 		for node in ${nodes} ; do
-			run_ncn_tests "${node}" "8996" "ncn-kubernetes-tests-master"
+			run_ncn_tests "${node}" "ncn-kubernetes-tests-master"
 			if ! is_pit_node ; then
-				run_ncn_tests "${node}" "9007" "ncn-afterpitreboot-kubernetes-tests-master"
+				run_ncn_tests "${node}" "ncn-afterpitreboot-kubernetes-tests-master"
 			fi
 		done
 	fi
@@ -90,9 +90,9 @@ if nodes=$(get_ncns --workers); then
 	else
 		# Query the server endpoints
 		for node in ${nodes} ; do
-			run_ncn_tests "${node}" "8998" "ncn-kubernetes-tests-worker"
+			run_ncn_tests "${node}" "ncn-kubernetes-tests-worker"
 			if ! is_pit_node ; then
-				run_ncn_tests "${node}" "9008" "ncn-afterpitreboot-kubernetes-tests-worker"
+				run_ncn_tests "${node}" "ncn-afterpitreboot-kubernetes-tests-worker"
 			fi
 		done
 	fi

--- a/goss-testing/automated/ncn-preflight-checks
+++ b/goss-testing/automated/ncn-preflight-checks
@@ -44,7 +44,7 @@ nodes=$(get_ncns --exclude-pit) || exit 1
 [[ -n ${nodes} ]] || err_exit "No NCNs found"
 
 for node in ${nodes}; do
-    run_ncn_tests "${node}" 8995 ncn-preflight-tests
+    run_ncn_tests "${node}" ncn-preflight-tests
 done
 
 exit

--- a/goss-testing/automated/ncn-smoke-tests
+++ b/goss-testing/automated/ncn-smoke-tests
@@ -44,7 +44,7 @@ nodes=$(get_ncns --exclude-pit) || exit 1
 [[ -n ${nodes} ]] || err_exit "No NCNs found"
 
 for node in ${nodes}; do
-    run_ncn_tests "${node}" 9002 ncn-smoke-tests
+    run_ncn_tests "${node}" ncn-smoke-tests
 done
 
 exit

--- a/goss-testing/automated/ncn-spire-healthchecks
+++ b/goss-testing/automated/ncn-spire-healthchecks
@@ -44,7 +44,7 @@ nodes=$(get_ncns --exclude-pit) || exit 1
 [[ -n ${nodes} ]] || err_exit "No NCNs found"
 
 for node in ${nodes} ; do
-    run_ncn_tests "${node}" "9003" "ncn-spire-healthchecks"
+    run_ncn_tests "${node}" "ncn-spire-healthchecks"
 done
 
 # Specify the spire postgres clusters and call the postgres tests.

--- a/goss-testing/automated/ncn-storage-checks
+++ b/goss-testing/automated/ncn-storage-checks
@@ -47,7 +47,7 @@ if ! echo ${storage_nodes} | grep -q ncn-s001 ; then
 fi
 
 for node in ${storage_nodes} ; do
-	run_ncn_tests "${node}" "8997" "ncn-storage-tests"
+	run_ncn_tests "${node}" "ncn-storage-tests"
 done
 
 # We always exit 0 -- this does not indicate that the tests passed.

--- a/goss-testing/dat/goss-servers.cfg
+++ b/goss-testing/dat/goss-servers.cfg
@@ -1,0 +1,22 @@
+# This configuration file defines the Goss test suite endpoints that will be started on NCNs.
+# The suite name will be the name of the endpoint with a ".yaml" extension appended
+# Endpoint names should begin with an alphanumeric character and only contain alphanumeric characters,
+# underscores, and dashes.
+#
+# Designated goss-servers port range: 8994-9008
+#
+# endpoint                                     port    NCN types where it should start
+ncn-preflight-tests                            8995    master,storage,worker
+ncn-kubernetes-tests-master                    8996    master
+ncn-kubernetes-tests-worker                    8998    worker
+ncn-storage-tests                              8997    storage
+ncn-healthcheck-master                         8994    master
+ncn-healthcheck-worker                         9000    worker
+ncn-healthcheck-storage                        9001    storage
+ncn-smoke-tests                                9002    master,storage,worker
+ncn-spire-healthchecks                         9003    master,storage,worker
+ncn-afterpitreboot-healthcheck-master          9004    master
+ncn-afterpitreboot-healthcheck-worker          9005    worker
+ncn-afterpitreboot-healthcheck-storage         9006    storage
+ncn-afterpitreboot-kubernetes-tests-master     9007    master
+ncn-afterpitreboot-kubernetes-tests-worker     9008    worker


### PR DESCRIPTION
## Summary and Scope

Currently, the various Goss server endpoints and ports are not defined in a central place. The service has a shell script which starts up the endpoints, and there are several automated scripts which do curl calls to the endpoints, but they each have the endpoint names and ports hard-coded into them. Any changes to one will break the other, if they are not kept in sync.

In addition, we currently start Goss server endpoints on NCNs where those tests will never run, because we start every endpoint on every NCNs. But, for example, the worker test endpoints don't really need to be started on the masters or storage nodes. It's not a huge deal that they're running, but it's unnecessary.

This PR corrects both issues by creating a single configuration file which defines all of the endpoints, port numbers, and NCN types where the endpoint should run. Associated functions are defined in the common function library to assist with parsing this file. The server startup script reads this file and uses it to determine which endpoints to start (based on its type) and which ports to use. The test scripts also read that file in order to determine the port number for the endpoint they wish to use.

Ultimately these changes should be transparent to the end user, beyond perhaps noticing that fewer goss servers are started up on any given NCN.

## Issues and Related PRs

This is another part of the enablement work I'm doing for [CASMINST-5161](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5161)

## Testing

I tested this on drax. I verified that the expected endpoints were running on each NCN type, and I verified that the automated scripts to run the tests (those that use the endpoints, specifically) were still able to run them.

### master node:

```
ncn-m002:~ # systemctl -n 50 status goss-servers
● goss-servers.service - goss-servers
     Loaded: loaded (/etc/systemd/system/goss-servers.service; enabled; vendor preset: disabled)
     Active: active (running) since Tue 2022-08-02 19:28:50 UTC; 17s ago
   Main PID: 1270414 (bash)
      Tasks: 42
     CGroup: /system.slice/goss-servers.service
             ├─1270414 /bin/bash /usr/sbin/start-goss-servers.sh
             ├─1270461 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-preflight-tests.yaml --vars /tmp/goss-variables-1659468530-yVPcSi-temp.yaml serve --format json --max-concurrent 4 --endpoint /ncn-prefligh>
             ├─1270462 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-kubernetes-tests-master.yaml --vars /tmp/goss-variables-1659468530-yVPcSi-temp.yaml serve --format json --max-concurrent 4 --endpoint /ncn->
             ├─1270463 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-healthcheck-master.yaml --vars /tmp/goss-variables-1659468530-yVPcSi-temp.yaml serve --format json --max-concurrent 4 --endpoint /ncn-healt>
             ├─1270464 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-smoke-tests.yaml --vars /tmp/goss-variables-1659468530-yVPcSi-temp.yaml serve --format json --max-concurrent 4 --endpoint /ncn-smoke-tests >
             ├─1270473 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-spire-healthchecks.yaml --vars /tmp/goss-variables-1659468530-yVPcSi-temp.yaml serve --format json --max-concurrent 4 --endpoint /ncn-spire>
             ├─1270474 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-healthcheck-master.yaml --vars /tmp/goss-variables-1659468530-yVPcSi-temp.yaml serve --format json --max-concurrent 4 --endp>
             ├─1270479 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-kubernetes-tests-master.yaml --vars /tmp/goss-variables-1659468530-yVPcSi-temp.yaml serve --format json --max-concurrent 4 ->
             └─1270488 sleep infinity

Aug 02 19:28:50 ncn-m002 systemd[1]: Started goss-servers.
Aug 02 19:28:50 ncn-m002 bash[1270414]: Using Goss variable file: /tmp/goss-variables-1659468530-yVPcSi-temp.yaml
Aug 02 19:28:50 ncn-m002 bash[1270414]: node_type = master
Aug 02 19:28:50 ncn-m002 bash[1270460]: starting ncn-preflight-tests in background on port 8995
Aug 02 19:28:50 ncn-m002 bash[1270460]: starting ncn-kubernetes-tests-master in background on port 8996
Aug 02 19:28:50 ncn-m002 bash[1270460]: Skipping goss server entry because it does not match node type: ncn-kubernetes-tests-worker 8998 worker
Aug 02 19:28:50 ncn-m002 bash[1270460]: Skipping goss server entry because it does not match node type: ncn-storage-tests 8997 storage
Aug 02 19:28:50 ncn-m002 bash[1270460]: starting ncn-healthcheck-master in background on port 8994
Aug 02 19:28:50 ncn-m002 bash[1270460]: Skipping goss server entry because it does not match node type: ncn-healthcheck-worker 9000 worker
Aug 02 19:28:50 ncn-m002 bash[1270460]: Skipping goss server entry because it does not match node type: ncn-healthcheck-storage 9001 storage
Aug 02 19:28:50 ncn-m002 bash[1270460]: starting ncn-smoke-tests in background on port 9002
Aug 02 19:28:50 ncn-m002 bash[1270460]: starting ncn-spire-healthchecks in background on port 9003
Aug 02 19:28:50 ncn-m002 bash[1270460]: starting ncn-afterpitreboot-healthcheck-master in background on port 9004
Aug 02 19:28:50 ncn-m002 bash[1270460]: Skipping goss server entry because it does not match node type: ncn-afterpitreboot-healthcheck-worker 9005 worker
Aug 02 19:28:50 ncn-m002 bash[1270460]: Skipping goss server entry because it does not match node type: ncn-afterpitreboot-healthcheck-storage 9006 storage
Aug 02 19:28:50 ncn-m002 bash[1270460]: starting ncn-afterpitreboot-kubernetes-tests-master in background on port 9007
Aug 02 19:28:50 ncn-m002 bash[1270460]: Skipping goss server entry because it does not match node type: ncn-afterpitreboot-kubernetes-tests-worker 9008 worker
Aug 02 19:28:50 ncn-m002 bash[1270414]: Goss servers started in background
```

### storage node

```
● goss-servers.service - goss-servers
     Loaded: loaded (/etc/systemd/system/goss-servers.service; enabled; vendor preset: disabled)
     Active: active (running) since Tue 2022-08-02 19:28:50 UTC; 1min 7s ago
   Main PID: 131084 (bash)
      Tasks: 32
     CGroup: /system.slice/goss-servers.service
             ├─131084 /bin/bash /usr/sbin/start-goss-servers.sh
             ├─131138 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-preflight-tests.yaml --vars /tmp/goss-variables-1659468530-nkNVmW-temp.yaml serve --format json --max-concurrent 4 --endpoint /ncn-preflight-tests --listen-addr 10.254.1.20:8995
             ├─131139 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-storage-tests.yaml --vars /tmp/goss-variables-1659468530-nkNVmW-temp.yaml serve --format json --max-concurrent 4 --endpoint /ncn-storage-tests --listen-addr 10.254.1.20:8997
             ├─131144 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-healthcheck-storage.yaml --vars /tmp/goss-variables-1659468530-nkNVmW-temp.yaml serve --format json --max-concurrent 4 --endpoint /ncn-healthcheck-storage --listen-addr 10.254.1.20:9001
             ├─131145 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-smoke-tests.yaml --vars /tmp/goss-variables-1659468530-nkNVmW-temp.yaml serve --format json --max-concurrent 4 --endpoint /ncn-smoke-tests --listen-addr 10.254.1.20:9002
             ├─131148 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-spire-healthchecks.yaml --vars /tmp/goss-variables-1659468530-nkNVmW-temp.yaml serve --format json --max-concurrent 4 --endpoint /ncn-spire-healthchecks --listen-addr 10.254.1.20:9003
             ├─131151 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-healthcheck-storage.yaml --vars /tmp/goss-variables-1659468530-nkNVmW-temp.yaml serve --format json --max-concurrent 4 --endpoint /ncn-afterpitreboot-healthcheck-storage --listen-addr 10.254.1.20:9006
             └─131160 sleep infinity

Aug 02 19:28:50 ncn-s003 systemd[1]: Started goss-servers.
Aug 02 19:28:50 ncn-s003 bash[131084]: Using Goss variable file: /tmp/goss-variables-1659468530-nkNVmW-temp.yaml
Aug 02 19:28:50 ncn-s003 bash[131084]: node_type = storage
Aug 02 19:28:50 ncn-s003 bash[131137]: starting ncn-preflight-tests in background on port 8995
Aug 02 19:28:50 ncn-s003 bash[131137]: Skipping goss server entry because it does not match node type: ncn-kubernetes-tests-master 8996 master
Aug 02 19:28:50 ncn-s003 bash[131137]: Skipping goss server entry because it does not match node type: ncn-kubernetes-tests-worker 8998 worker
Aug 02 19:28:50 ncn-s003 bash[131137]: starting ncn-storage-tests in background on port 8997
Aug 02 19:28:50 ncn-s003 bash[131137]: Skipping goss server entry because it does not match node type: ncn-healthcheck-master 8994 master
Aug 02 19:28:50 ncn-s003 bash[131137]: Skipping goss server entry because it does not match node type: ncn-healthcheck-worker 9000 worker
Aug 02 19:28:50 ncn-s003 bash[131137]: starting ncn-healthcheck-storage in background on port 9001
Aug 02 19:28:50 ncn-s003 bash[131137]: starting ncn-smoke-tests in background on port 9002
Aug 02 19:28:50 ncn-s003 bash[131137]: starting ncn-spire-healthchecks in background on port 9003
Aug 02 19:28:50 ncn-s003 bash[131137]: Skipping goss server entry because it does not match node type: ncn-afterpitreboot-healthcheck-master 9004 master
Aug 02 19:28:50 ncn-s003 bash[131137]: Skipping goss server entry because it does not match node type: ncn-afterpitreboot-healthcheck-worker 9005 worker
Aug 02 19:28:50 ncn-s003 bash[131137]: starting ncn-afterpitreboot-healthcheck-storage in background on port 9006
Aug 02 19:28:50 ncn-s003 bash[131137]: Skipping goss server entry because it does not match node type: ncn-afterpitreboot-kubernetes-tests-master 9007 master
Aug 02 19:28:50 ncn-s003 bash[131137]: Skipping goss server entry because it does not match node type: ncn-afterpitreboot-kubernetes-tests-worker 9008 worker
Aug 02 19:28:50 ncn-s003 bash[131084]: Goss servers started in background
```

### worker node

```
● goss-servers.service - goss-servers
     Loaded: loaded (/etc/systemd/system/goss-servers.service; enabled; vendor preset: disabled)
     Active: active (running) since Tue 2022-08-02 19:28:52 UTC; 1min 45s ago
   Main PID: 2745658 (bash)
      Tasks: 46
     CGroup: /system.slice/goss-servers.service
             ├─2745658 /bin/bash /usr/sbin/start-goss-servers.sh
             ├─2745707 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-preflight-tests.yaml --vars /tmp/goss-variables-1659468532-qF3hEa-temp.yaml serve --format json --max-concurrent 4 --endpoint /ncn-preflight-tests --listen-addr 10.254.1.10:8995
             ├─2745708 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-kubernetes-tests-worker.yaml --vars /tmp/goss-variables-1659468532-qF3hEa-temp.yaml serve --format json --max-concurrent 4 --endpoint /ncn-kubernetes-tests-worker --listen-addr 10.254.1.10:8998
             ├─2745709 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-healthcheck-worker.yaml --vars /tmp/goss-variables-1659468532-qF3hEa-temp.yaml serve --format json --max-concurrent 4 --endpoint /ncn-healthcheck-worker --listen-addr 10.254.1.10:9000
             ├─2745710 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-smoke-tests.yaml --vars /tmp/goss-variables-1659468532-qF3hEa-temp.yaml serve --format json --max-concurrent 4 --endpoint /ncn-smoke-tests --listen-addr 10.254.1.10:9002
             ├─2745711 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-spire-healthchecks.yaml --vars /tmp/goss-variables-1659468532-qF3hEa-temp.yaml serve --format json --max-concurrent 4 --endpoint /ncn-spire-healthchecks --listen-addr 10.254.1.10:9003
             ├─2745716 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-healthcheck-worker.yaml --vars /tmp/goss-variables-1659468532-qF3hEa-temp.yaml serve --format json --max-concurrent 4 --endpoint /ncn-afterpitreboot-healthcheck-worker --listen-addr 10.254.1.10:9005
             ├─2745721 /usr/bin/goss -g /opt/cray/tests/install/ncn/suites/ncn-afterpitreboot-kubernetes-tests-worker.yaml --vars /tmp/goss-variables-1659468532-qF3hEa-temp.yaml serve --format json --max-concurrent 4 --endpoint /ncn-afterpitreboot-kubernetes-tests-worker --listen-addr 10.254.1.10:9008
             └─2745730 sleep infinity

Aug 02 19:28:52 ncn-w001 systemd[1]: Started goss-servers.
Aug 02 19:28:52 ncn-w001 bash[2745658]: Using Goss variable file: /tmp/goss-variables-1659468532-qF3hEa-temp.yaml
Aug 02 19:28:52 ncn-w001 bash[2745658]: node_type = worker
Aug 02 19:28:52 ncn-w001 bash[2745706]: starting ncn-preflight-tests in background on port 8995
Aug 02 19:28:52 ncn-w001 bash[2745706]: Skipping goss server entry because it does not match node type: ncn-kubernetes-tests-master 8996 master
Aug 02 19:28:52 ncn-w001 bash[2745706]: starting ncn-kubernetes-tests-worker in background on port 8998
Aug 02 19:28:52 ncn-w001 bash[2745706]: Skipping goss server entry because it does not match node type: ncn-storage-tests 8997 storage
Aug 02 19:28:52 ncn-w001 bash[2745706]: Skipping goss server entry because it does not match node type: ncn-healthcheck-master 8994 master
Aug 02 19:28:52 ncn-w001 bash[2745706]: starting ncn-healthcheck-worker in background on port 9000
Aug 02 19:28:52 ncn-w001 bash[2745706]: Skipping goss server entry because it does not match node type: ncn-healthcheck-storage 9001 storage
Aug 02 19:28:52 ncn-w001 bash[2745706]: starting ncn-smoke-tests in background on port 9002
Aug 02 19:28:52 ncn-w001 bash[2745706]: starting ncn-spire-healthchecks in background on port 9003
Aug 02 19:28:52 ncn-w001 bash[2745706]: Skipping goss server entry because it does not match node type: ncn-afterpitreboot-healthcheck-master 9004 master
Aug 02 19:28:52 ncn-w001 bash[2745706]: starting ncn-afterpitreboot-healthcheck-worker in background on port 9005
Aug 02 19:28:52 ncn-w001 bash[2745706]: Skipping goss server entry because it does not match node type: ncn-afterpitreboot-healthcheck-storage 9006 storage
Aug 02 19:28:52 ncn-w001 bash[2745706]: Skipping goss server entry because it does not match node type: ncn-afterpitreboot-kubernetes-tests-master 9007 master
Aug 02 19:28:52 ncn-w001 bash[2745706]: starting ncn-afterpitreboot-kubernetes-tests-worker in background on port 9008
Aug 02 19:28:52 ncn-w001 bash[2745658]: Goss servers started in background
```

## Risks and Mitigations

Fairly low risk. Plus this makes the codebase more maintainable going forward.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
