### PR TITLE
CASMINST-4278 1.3fix : AUTOMATION: Find a solution/automated remediation/re-execution failed velero backups

### DIFF
--- a/goss-testing/scripts/velero_backups_check.sh
+++ b/goss-testing/scripts/velero_backups_check.sh
@@ -43,7 +43,7 @@ cleanup_velero_backups() {
                     # Check if the PartiallyFailed backup occured within 10 minutes after the schedule was created. If so delete the backup.
 
                     time_from_schedule_creation_to_backup=$(( $backup_creation_date_sec - $schedule_creation_date_sec ))
-                    if [[ ! -z $backup_creation_date_sec && ${time_from_schedule_creation_to_backup} -gt 0 && ${time_from_schedule_creation_to_backup} -lt $ten_minutes ]]
+                    if [[ ! -z $backup_creation_date_sec && ${time_from_schedule_creation_to_backup} -ge 0 && ${time_from_schedule_creation_to_backup} -lt $ten_minutes ]]
                     then
                         delete_count+=1
 		        echo "velero backup delete ${backup_name}"


### PR DESCRIPTION
…ion/re-execute failed velero backups

## Summary and Scope

One issues needs fixed - is it possible for the schedule and the backup to have the same timestamp.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-4278](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4278)
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

vshasta

### Tested on:

  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_
```
ncn-m001-5558eea0:~ # velero schedule get
NAME                 STATUS    CREATED                         SCHEDULE    BACKUP TTL   LAST BACKUP   SELECTOR
vault-daily-backup   Enabled   2022-08-08 14:05:52 +0000 UTC   0 2 * * *   0s           19m ago       vault_cr=cray-vault

# velero backup get
NAME                                STATUS            ERRORS   WARNINGS   CREATED                         EXPIRES   STORAGE LOCATION   SELECTOR
vault-daily-backup-20220808140552   PartiallyFailed   13       0          2022-08-08 14:05:52 +0000 UTC   29d       default            vault_cr=cray-vault

ncn-m001-5558eea0:~ # ./velero_backups_check.sh

schedule_name: vault-daily-backup
schedule_creation_date: 2022-08-08T14:05:52Z
velero_partiallyfailed_backups:
vault-daily-backup-20220808140552
velero backup delete vault-daily-backup-20220808140552
Request to delete backup "vault-daily-backup-20220808140552" submitted successfully.
The backup will be fully deleted after all associated data (disk snapshots, backup files, restores) are removed.
PASS
ncn-m001-5558eea0:~ # velero backup get
ncn-m001-5558eea0:~ #
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

