### PR TITLE
CASMPET-5620 Add additional TLS tests

### DIFF
--- a/goss-testing/suites/ncn-healthcheck-master.yaml
+++ b/goss-testing/suites/ncn-healthcheck-master.yaml
@@ -29,6 +29,8 @@ gossfile:
   ../tests/goss-interfaces-have-same-mac.yaml: {}
   ../tests/goss-unbound-ip.yaml: {}
   ../tests/goss-platform-ca-certs-exist.yaml: {}
+  ../tests/goss-validate-certifi-version.yaml: {}
+  ../tests/goss-platform-ca-in-bundle.yaml: {}
   ../tests/goss-k8s-sealed-secret-key.yaml: {}
   ../tests/goss-k8s-storageclass.yaml: {}
   ../tests/goss-k8s-velero-backup-storage-locations-available.yaml: {}

--- a/goss-testing/suites/ncn-healthcheck-worker.yaml
+++ b/goss-testing/suites/ncn-healthcheck-worker.yaml
@@ -29,6 +29,8 @@ gossfile:
   ../tests/goss-interfaces-have-same-mac.yaml: {}
   ../tests/goss-unbound-ip.yaml: {}
   ../tests/goss-platform-ca-certs-exist.yaml: {}
+  ../tests/goss-validate-certifi-version.yaml: {}
+  ../tests/goss-platform-ca-in-bundle.yaml: {}
   ../tests/goss-k8s-storageclass.yaml: {}
   ../tests/goss-k8s-velero-backup-storage-locations-available.yaml: {}
   ../tests/goss-k8s-velero-backup-vault-schedule-exists.yaml: {}

--- a/goss-testing/tests/ncn/goss-platform-ca-in-bundle.yaml
+++ b/goss-testing/tests/ncn/goss-platform-ca-in-bundle.yaml
@@ -1,0 +1,33 @@
+#
+# MIT License
+#
+# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+command:
+  platform_ca_in_bundle:
+    title: "Validates that the platform CA is included in ca-bundle.pem"
+    meta:
+      desc: "If this fails but the platform-ca-certs-match-cloud-init test passes then running the following commands should fix this issue: `rm /var/lib/ca-certificates/ca-bundle.pem;update-ca-certificates`"
+      sev: 0
+    exec: "keytool -printcert -v -file /etc/pki/trust/anchors/platform-ca-certs.crt  | grep SHA1 | awk '{print $2}' | while read line; do if ! keytool -printcert -v -file /etc/ssl/ca-bundle.pem | grep -q $line; then exit 1; fi; done"
+    exit-status: 0
+    timeout: 10000
+    skip: false

--- a/goss-testing/tests/ncn/goss-platform-ca-in-bundle.yaml
+++ b/goss-testing/tests/ncn/goss-platform-ca-in-bundle.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/goss-testing/tests/ncn/goss-validate-certifi-version.yaml
+++ b/goss-testing/tests/ncn/goss-validate-certifi-version.yaml
@@ -1,0 +1,36 @@
+#
+# MIT License
+#
+# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+command:
+  validate_certifi_version:
+    title: "Validate certifi is the correct version."
+    meta:
+      desc: "If this fails then validate that an upstream version of certifi has not been installed. If a non-SLES certifi package has been installed the uninstall it by running `pip uninstall certifi`."
+      sev: 0
+    exec: "pip show certifi"
+    exit-status: 0
+    stdout:
+      - "Version: 2018.1.18"
+      - "Location: /usr/lib/python3.6/site-packages"
+    timeout: 10000
+    skip: false

--- a/goss-testing/tests/ncn/goss-validate-certifi-version.yaml
+++ b/goss-testing/tests/ncn/goss-validate-certifi-version.yaml
@@ -29,7 +29,9 @@ command:
     meta:
       desc: "If this fails then validate that an upstream version of certifi has not been installed. If a non-SLES certifi package has been installed the uninstall it by running `pip uninstall certifi`."
       sev: 0
-    exec: "pip show certifi"
+    exec: |-
+      "{{$logrun}}" -l "{{$testlabel}}" \
+        pip show certifi
     exit-status: 0
     stdout:
       - "Version: 2018.1.18"

--- a/goss-testing/tests/ncn/goss-validate-certifi-version.yaml
+++ b/goss-testing/tests/ncn/goss-validate-certifi-version.yaml
@@ -21,6 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
   validate_certifi_version:
     title: "Validate certifi is the correct version."

--- a/goss-testing/tests/ncn/goss-validate-certifi-version.yaml
+++ b/goss-testing/tests/ncn/goss-validate-certifi-version.yaml
@@ -27,7 +27,7 @@ command:
   {{$testlabel}}:
     title: "Validate certifi is the correct version."
     meta:
-      desc: "If this fails then validate that an upstream version of certifi has not been installed. If a non-SLES certifi package has been installed the uninstall it by running `pip uninstall certifi`."
+      desc: "If this fails, then validate that an upstream version of certifi has not been installed. If a non-SLES certifi package has been installed, then uninstall it by running `pip uninstall certifi`."
       sev: 0
     exec: |-
       "{{$logrun}}" -l "{{$testlabel}}" \

--- a/goss-testing/tests/ncn/goss-validate-certifi-version.yaml
+++ b/goss-testing/tests/ncn/goss-validate-certifi-version.yaml
@@ -23,7 +23,8 @@
 #
 {{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  validate_certifi_version:
+  {{ $testlabel := "validate_certifi_version" }}
+  {{$testlabel}}:
     title: "Validate certifi is the correct version."
     meta:
       desc: "If this fails then validate that an upstream version of certifi has not been installed. If a non-SLES certifi package has been installed the uninstall it by running `pip uninstall certifi`."

--- a/goss-testing/tests/ncn/goss-validate-certifi-version.yaml
+++ b/goss-testing/tests/ncn/goss-validate-certifi-version.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
## Summary and Scope

Adds tests to validate that the platform CA is included in the ca-bundle.pem and that a new version of certifi has not been installed.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5620](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5620)

## Testing


### Tested on:


  * Shandy

### Test description:

Validated that goss tests passed on systems setup correctly and failed when modified.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N, new tests.
- Was downgrade tested? If not, why? N, new tests.
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

