### PR TITLE
CASMINST-5162: Parallelize execution of remote Goss tests

### DIFF
--- a/goss-testing/automated/python/goss_suite_urls.py
+++ b/goss-testing/automated/python/goss_suite_urls.py
@@ -39,12 +39,14 @@ from lib.common import argparse_yaml_file_name,     \
                        ScriptException
 from lib.endpoints  import load_goss_endpoints
 
+from typing import List, Tuple
+
 import argparse
 import sys
 
 port_endpoint = dict()
 
-def get_port_endpoint(node: str, suite: str) -> tuple[int, str]:
+def get_port_endpoint(node: str, suite: str) -> Tuple[int, str]:
     node_type = get_ncn_type(node)
     try:
         return port_endpoint[node_type]
@@ -56,14 +58,14 @@ def get_port_endpoint(node: str, suite: str) -> tuple[int, str]:
                 return port, endpoint_name
         raise ScriptException(f"No port/endpoint found for suite {suite} for NCN {node_type} nodes")
 
-def parse_args() -> tuple[str, list]:
+def parse_args() -> Tuple[str, List[str]]:
     parser = argparse.ArgumentParser(description="Print list of Goss endpoints.")
     parser.add_argument("suite", type=argparse_yaml_file_name, help="Goss suite name.")
     parser.add_argument("nodes", nargs="+", type=argparse_valid_ncn_name, help="Target nodes.")
     args = parser.parse_args()
     return args.suite, args.nodes
 
-def get_suite_urls_nodelist(suite: str, *nodes) -> list:
+def get_suite_urls_nodelist(suite: str, *nodes) -> List[str]:
     urls = list()
     for node in nodes:
         port, endpoint = get_port_endpoint(node, suite)

--- a/goss-testing/automated/python/goss_suite_urls.py
+++ b/goss-testing/automated/python/goss_suite_urls.py
@@ -44,7 +44,7 @@ import sys
 
 port_endpoint = dict()
 
-def get_port_endpoint(node, suite):
+def get_port_endpoint(node: str, suite: str) -> tuple[int, str]:
     node_type = get_ncn_type(node)
     try:
         return port_endpoint[node_type]
@@ -56,14 +56,14 @@ def get_port_endpoint(node, suite):
                 return port, endpoint_name
         raise ScriptException(f"No port/endpoint found for suite {suite} for NCN {node_type} nodes")
 
-def parse_args():
+def parse_args() -> tuple[str, list]:
     parser = argparse.ArgumentParser(description="Print list of Goss endpoints.")
     parser.add_argument("suite", type=argparse_yaml_file_name, help="Goss suite name.")
     parser.add_argument("nodes", nargs="+", type=argparse_valid_ncn_name, help="Target nodes.")
     args = parser.parse_args()
     return args.suite, args.nodes
 
-def get_suite_urls_nodelist(suite, *nodes):
+def get_suite_urls_nodelist(suite: str, *nodes) -> list:
     urls = list()
     for node in nodes:
         port, endpoint = get_port_endpoint(node, suite)

--- a/goss-testing/automated/python/goss_suite_urls.py
+++ b/goss-testing/automated/python/goss_suite_urls.py
@@ -35,9 +35,9 @@ Exits 0 on success, non-0 otherwise.
 from lib.common import argparse_yaml_file_name,     \
                        argparse_valid_ncn_name,     \
                        get_ncn_type,                \
-                       load_goss_endpoints,         \
                        NCN_TYPES,                   \
                        ScriptException
+from lib.endpoints  import load_goss_endpoints
 
 import argparse
 import sys

--- a/goss-testing/automated/python/goss_suites_endpoints_ports.py
+++ b/goss-testing/automated/python/goss_suites_endpoints_ports.py
@@ -35,9 +35,9 @@ Each line of output is of the format:
 Exits 0 on success, non-0 otherwise.
 """
 
-from lib.common import goss_suites_dir,             \
-                       load_goss_endpoints,         \
-                       my_ncn_type
+from lib.common     import  goss_suites_dir,             \
+                            my_ncn_type
+from lib.endpoints  import load_goss_endpoints
 
 import sys
 

--- a/goss-testing/automated/python/lib/common.py
+++ b/goss-testing/automated/python/lib/common.py
@@ -27,7 +27,7 @@
 Helper functions for Goss Python automated scripts
 """
 
-from typing import Tuple
+from typing import Callable, Tuple
 
 import argparse
 import colorama
@@ -174,7 +174,7 @@ def log_dir(script_name: str) -> str:
     glbd = goss_log_base_dir()
     return f"{glbd}/{script_name}/{timestamp}-{mypid}-{randstring}"
 
-def log_values(logmethod: function, **kwargs) -> None:
+def log_values(logmethod: Callable, **kwargs) -> None:
     for k, v in kwargs.items():
         # For dictionary values, format them nicely
         if isinstance(v, dict):
@@ -186,7 +186,7 @@ def log_values(logmethod: function, **kwargs) -> None:
                 pass
         logmethod(f"{k}={v}")
 
-def log_goss_env_variables(logmethod: function) -> None:
+def log_goss_env_variables(logmethod: Callable) -> None:
     log_values(logmethod=logmethod, **goss_env_variables())
 
 def stderr_print(s: str) -> None:

--- a/goss-testing/automated/python/lib/common.py
+++ b/goss-testing/automated/python/lib/common.py
@@ -27,6 +27,8 @@
 Helper functions for Goss Python automated scripts
 """
 
+from typing import Tuple
+
 import argparse
 import colorama
 from datetime import datetime
@@ -49,7 +51,7 @@ DEFAULT_GOSS_SCRIPT_MAX_THREADS = 16
 DEFAULT_GOSS_INSTALL_BASE_DIR = "/opt/cray/tests/install"
 PIT_NODE_RELEASE_FILE = "/etc/pit-release"
 
-def goss_base_dirs(validate: bool = False) -> tuple[str, str]:
+def goss_base_dirs(validate: bool = False) -> Tuple[str, str]:
     """
     Returns GOSS_INSTALL_BASE_DIR, GOSS_BASE
     """

--- a/goss-testing/automated/python/lib/common.py
+++ b/goss-testing/automated/python/lib/common.py
@@ -46,7 +46,7 @@ DEFAULT_LOG_LEVEL = "INFO"
 DEFAULT_GOSS_INSTALL_BASE_DIR = "/opt/cray/tests/install"
 PIT_NODE_RELEASE_FILE = "/etc/pit-release"
 
-def goss_base_dirs(validate=False):
+def goss_base_dirs(validate: bool = False) -> tuple[str, str]:
     """
     Returns GOSS_INSTALL_BASE_DIR, GOSS_BASE
     """
@@ -83,26 +83,26 @@ def goss_base_dirs(validate=False):
 
     return install_base_dir, base_dir
 
-def goss_install_base_dir(*args, **kwargs):
+def goss_install_base_dir(*args, **kwargs) -> str:
     return goss_base_dirs(*args, **kwargs)[0]
 
-def goss_base(*args, **kwargs):
+def goss_base(*args, **kwargs) -> str:
     return goss_base_dirs(*args, **kwargs)[1]
 
-def goss_script_log_level():
+def goss_script_log_level() -> int:
     # Make it uppercase, just so that people who accidentally set a lowercase
     # log level are not tripped up
     requested_log_level = os.environ.get("GOSS_SCRIPT_LOG_LEVEL", DEFAULT_LOG_LEVEL).upper()
     return logging.getLevelName(requested_log_level)
 
-def goss_servers_config(validate=False):
+def goss_servers_config(validate: bool = False) -> str:
     gibd = goss_install_base_dir()
     config_file = os.environ.get("GOSS_SERVERS_CONFIG", f"{gibd}/dat/goss-servers.cfg")
     if validate and not os.path.isfile(config_file):
         raise ScriptException(f"GOSS_SERVERS_CONFIG file does not exist or is not a file: {config_file}")
     return config_file
 
-def goss_log_base_dir(validate=False):
+def goss_log_base_dir(validate: bool = False) -> str:
     gibd = goss_install_base_dir()
     log_dir = os.environ.get("GOSS_LOG_BASE_DIR", f"{gibd}/logs")
     if validate and not os.path.isdir(log_dir):
@@ -120,22 +120,22 @@ class ScriptException(Exception):
 class ScriptUsageException(ScriptException):
     pass
 
-def err_text(s):
+def err_text(s: str) ->str:
     return f"{ERR_TEXT_CODE}{s}{RESET_TEXT_CODE}"
 
-def warn_text(s):
+def warn_text(s: str) -> str:
     return f"{WARN_TEXT_CODE}{s}{RESET_TEXT_CODE}"
 
-def ok_text(s):
+def ok_text(s: str) -> str:
     return f"{OK_TEXT_CODE}{s}{RESET_TEXT_CODE}"
 
-def is_pit_node():
+def is_pit_node() -> bool:
     return os.path.isfile(PIT_NODE_RELEASE_FILE)
 
-def goss_suites_dir():
+def goss_suites_dir() -> str:
     return f"{goss_base()}/suites"
 
-def goss_env_variables():
+def goss_env_variables() -> dict:
     return { 
         "GOSS_INSTALL_BASE_DIR": goss_install_base_dir(),
         "GOSS_SCRIPT_LOG_LEVEL": goss_script_log_level(),
@@ -143,7 +143,7 @@ def goss_env_variables():
         "GOSS_LOG_BASE_DIR": goss_log_base_dir(),
         "GOSS_BASE": goss_base() }
 
-def log_dir(script_name):
+def log_dir(script_name: str) -> str:
     # Strip off path and .py, if present, in script name
     script_name = script_name.split('/')[-1]
     if script_name[-3:] == ".py":
@@ -156,7 +156,7 @@ def log_dir(script_name):
     glbd = goss_log_base_dir()
     return f"{glbd}/{script_name}/{timestamp}-{mypid}-{randstring}"
 
-def log_values(logmethod, **kwargs):
+def log_values(logmethod: function, **kwargs) -> None:
     for k, v in kwargs.items():
         # For dictionary values, format them nicely
         if isinstance(v, dict):
@@ -168,22 +168,22 @@ def log_values(logmethod, **kwargs):
                 pass
         logmethod(f"{k}={v}")
 
-def log_goss_env_variables(logmethod):
+def log_goss_env_variables(logmethod: function) -> None:
     log_values(logmethod=logmethod, **goss_env_variables())
 
-def stderr_print(s):
+def stderr_print(s: str) -> None:
     sys.stderr.write(f"{s}\n")
     sys.stderr.flush()
 
-def stdout_print(s):
+def stdout_print(s: str) -> None:
     sys.stdout.write(f"{s}\n")
     sys.stdout.flush()
 
-def multi_print(s, *methods):
+def multi_print(s: str, *methods) -> None:
     for m in methods:
         m(s)
 
-def get_hostname():
+def get_hostname() -> str:
     return socket.gethostname()
 
 ncn_num_pattern="([1-9][0-9][0-9]|0[1-9][0-9]|00[1-9])"
@@ -197,27 +197,27 @@ ncn_master_re_prog = re.compile(ncn_master_pattern)
 ncn_storage_re_prog = re.compile(ncn_storage_pattern)
 ncn_worker_re_prog = re.compile(ncn_worker_pattern)
 
-def is_ncn_name(n):
+def is_ncn_name(n: str) -> bool:
     if ncn_re_prog.match(n):
         return True
     return False
 
-def is_master_ncn_name(n):
+def is_master_ncn_name(n: str) -> bool:
     if ncn_master_re_prog.match(n):
         return True
     return False
 
-def is_storage_ncn_name(n):
+def is_storage_ncn_name(n: str) -> bool:
     if ncn_storage_re_prog.match(n):
         return True
     return False
 
-def is_worker_ncn_name(n):
+def is_worker_ncn_name(n: str) -> bool:
     if ncn_worker_re_prog.match(n):
         return True
     return False
 
-def get_ncn_type(ncn_name):
+def get_ncn_type(ncn_name: str) -> str:
     if is_master_ncn_name(ncn_name):
         return "master"
     elif is_storage_ncn_name(ncn_name):
@@ -226,15 +226,15 @@ def get_ncn_type(ncn_name):
         return "worker"
     raise ScriptException(f"Unexpected NCN name format: {ncn_name}")
 
-def my_ncn_type():
+def my_ncn_type() -> str:
     return get_ncn_type(get_hostname())
 
-def argparse_nonempty_string(s):
+def argparse_nonempty_string(s: str) -> str:
     if len(s) > 0:
         return s
     raise argparse.ArgumentTypeError("Arguments may not be blank")
 
-def argparse_yaml_file_name(s):
+def argparse_yaml_file_name(s: str) -> str:
     try:
         argparse_nonempty_string(s)
     except argparse.ArgumentTypeError:
@@ -243,10 +243,10 @@ def argparse_yaml_file_name(s):
         return s
     raise argparse.ArgumentTypeError(f"YAML file names are expected to have .yaml extension. Invalid: {s}")
 
-def argparse_valid_ncn_name(n):
+def argparse_valid_ncn_name(n: str) -> str:
     if is_ncn_name(n):
         return n
     raise argparse.ArgumentTypeError(f"Invalid NCN name: {n}")
 
-def fmt_exc(e):
+def fmt_exc(e: Exception) -> str:
     return f"{type(e).__name__}: {e}"

--- a/goss-testing/automated/python/lib/common.py
+++ b/goss-testing/automated/python/lib/common.py
@@ -160,9 +160,13 @@ def log_values(logmethod, **kwargs):
     for k, v in kwargs.items():
         # For dictionary values, format them nicely
         if isinstance(v, dict):
-            logmethod(f"{k}=\n" + json.dumps(v, indent=2))
-        else:
-            logmethod(f"{k}={v}")
+            try:
+                logmethod(f"{k}=\n" + json.dumps(v, indent=2))
+                continue
+            except TypeError:
+                # This can happen if the dict contains stuff that cannot be serialized as JSON
+                pass
+        logmethod(f"{k}={v}")
 
 def log_goss_env_variables(logmethod):
     log_values(logmethod=logmethod, **goss_env_variables())

--- a/goss-testing/automated/python/lib/endpoints.py
+++ b/goss-testing/automated/python/lib/endpoints.py
@@ -57,7 +57,7 @@ port_re_prog = re.compile(port_pattern)
 
 goss_endpoints_by_ncn_type = None
 
-def parse_config_file_line(line):
+def parse_config_file_line(line: str) -> tuple[int, str, list]:
     """
     Returns port, suite file, and list of NCN types
     Raises ScriptException in case of error
@@ -88,7 +88,7 @@ def parse_config_file_line(line):
         raise ScriptException(f"Line includes duplicate NCN types.")
     return port, suite, type_list
 
-def load_goss_endpoints():
+def load_goss_endpoints() -> dict:
     """
     Reads Goss server configuration file (goss-servers.json) and for each NCN type, generates a mapping from
     port number to endpoint name + suite name.

--- a/goss-testing/automated/python/lib/endpoints.py
+++ b/goss-testing/automated/python/lib/endpoints.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+"""
+Helper functions for Goss Python automated scripts
+
+These functions relate to the Goss server endpoints.
+"""
+
+from .common import argparse_yaml_file_name,     \
+                    goss_servers_config,         \
+                    NCN_TYPES,                   \
+                    ScriptException
+
+import argparse
+import re
+
+# We assume our Goss server ports will be between 1000 and 65535 (the maximum TCP port number)
+
+# Pattern for 1000-9999     = [1-9][0-9]{3}
+# Pattern for 10000-59999   = [1-5][0-9]{4}
+# Pattern for 60000-64999   = 6[0-4][0-9]{3}
+# Pattern for 65000-65499   = 65[0-4][0-9]{2}
+# Pattern for 65500-65529   = 655[0-2][0-9]
+# Pattern for 65530-65535   = 6553[0-5]
+port_patterns = [ 
+    "[1-9][0-9]{3}", 
+    "[1-5][0-9]{4}",
+    "6[0-4][0-9]{3}",
+    "65[0-4][0-9]{2}",
+    "655[0-2][0-9]",
+    "6553[0-5]" ]
+port_pattern = "^(" + "|".join(port_patterns) + ")$"
+port_re_prog = re.compile(port_pattern)
+
+goss_endpoints_by_ncn_type = None
+
+def parse_config_file_line(line):
+    """
+    Returns port, suite file, and list of NCN types
+    Raises ScriptException in case of error
+    """
+    fields = line.split()
+    # All valid non-blank, non-commented lines have 3 or more fields
+    # 1. Port number
+    # 2. YAML suite file
+    # 3. List of NCN types
+
+    if len(fields) < 3:
+        raise ScriptException(f"Line must have at least three fields.")
+
+    port_string=fields[0]
+    if not port_re_prog.match(port_string):
+        raise ScriptException(f"Line has invalid port format.")
+    port = int(port_string)
+
+    try:
+        suite = argparse_yaml_file_name(fields[1])
+    except argparse.ArgumentTypeError as e:
+        raise ScriptException(f"{e}. Invalid YAML suite file name.")
+
+    type_list = fields[2:]
+    if not all(t in NCN_TYPES for t in type_list):
+        raise ScriptException(f"Line includes invalid NCN type.")
+    elif len(type_list) != len(set(type_list)):
+        raise ScriptException(f"Line includes duplicate NCN types.")
+    return port, suite, type_list
+
+def load_goss_endpoints():
+    """
+    Reads Goss server configuration file (goss-servers.json) and for each NCN type, generates a mapping from
+    port number to endpoint name + suite name.
+    These mappings are returned.
+    """
+    global goss_endpoints_by_ncn_type
+    if goss_endpoints_by_ncn_type != None:
+        return goss_endpoints_by_ncn_type
+    config_file = goss_servers_config(validate=True)
+    
+    endpoints_by_type = { ntype: list() for ntype in NCN_TYPES }
+    with open(config_file, "rt") as f:
+        for line in f.readlines():
+            line = line.strip()
+            if len(line) == 0 or line[0] == "#":
+                continue
+            try:
+                port, suite, type_list = parse_config_file_line(line)
+            except ScriptException as e:
+                raise ScriptException(f"Configuration file ({config_file}) error: {e}. Invalid line: {line}")
+            # Endpoint name is the suite name, minus the .yaml extension
+            endpoint_name = suite[:-5]
+
+            for ntype in type_list:
+                for (s, e, p) in endpoints_by_type[ntype]:
+                    if s == suite:
+                        raise ScriptException(f"Configuration file ({config_file}) error: Multiple lines for suite {s} on NCN type {ntype}. Invalid line: {line}")
+                    elif p == port:
+                        raise ScriptException(f"Configuration file ({config_file}) error: Multiple lines for port {p} on NCN type {ntype}. Invalid line: {line}")
+
+                # Add it to the list of endpoints for this NCN type
+                endpoints_by_type[ntype].append( (suite, endpoint_name, port) )
+
+    if sum(len(eplist) for eplist in endpoints_by_type.values()) == 0:
+        raise ScriptException(f"Server configuration ({config_file}) error: No endpoints specified")
+
+    goss_endpoints_by_ncn_type = endpoints_by_type
+    return goss_endpoints_by_ncn_type

--- a/goss-testing/automated/python/lib/endpoints.py
+++ b/goss-testing/automated/python/lib/endpoints.py
@@ -34,8 +34,13 @@ from .common import argparse_yaml_file_name,     \
                     NCN_TYPES,                   \
                     ScriptException
 
+from typing import Dict, List, Tuple
+
 import argparse
 import re
+
+StringList = List[str]
+EndpointTuple = Tuple[str, str, int]
 
 # We assume our Goss server ports will be between 1000 and 65535 (the maximum TCP port number)
 
@@ -57,7 +62,7 @@ port_re_prog = re.compile(port_pattern)
 
 goss_endpoints_by_ncn_type = None
 
-def parse_config_file_line(line: str) -> tuple[int, str, list]:
+def parse_config_file_line(line: str) -> Tuple[int, str, StringList]:
     """
     Returns port, suite file, and list of NCN types
     Raises ScriptException in case of error
@@ -88,7 +93,7 @@ def parse_config_file_line(line: str) -> tuple[int, str, list]:
         raise ScriptException(f"Line includes duplicate NCN types.")
     return port, suite, type_list
 
-def load_goss_endpoints() -> dict:
+def load_goss_endpoints() -> Dict[str, List[EndpointTuple]]:
     """
     Reads Goss server configuration file (goss-servers.json) and for each NCN type, generates a mapping from
     port number to endpoint name + suite name.

--- a/goss-testing/automated/python/print_goss_json_results.py
+++ b/goss-testing/automated/python/print_goss_json_results.py
@@ -60,19 +60,20 @@ Other error                 3
 If multiple exit codes apply, the highest one is used.
 """
 
-from lib.common import err_text,               \
-                       fmt_exc,                \
-                       get_hostname,           \
-                       log_goss_env_variables, \
-                       goss_script_log_level,  \
-                       log_dir,                \
-                       log_values,             \
-                       multi_print,            \
-                       ok_text,                \
-                       ScriptException,        \
-                       ScriptUsageException,   \
-                       stderr_print,           \
-                       stdout_print,           \
+from lib.common import err_text,                \
+                       fmt_exc,                 \
+                       get_hostname,            \
+                       log_goss_env_variables,  \
+                       goss_script_log_level,   \
+                       goss_script_max_threads, \
+                       log_dir,                 \
+                       log_values,              \
+                       multi_print,             \
+                       ok_text,                 \
+                       ScriptException,         \
+                       ScriptUsageException,    \
+                       stderr_print,            \
+                       stdout_print,            \
                        warn_text
 
 from typing import Callable, List, Tuple

--- a/goss-testing/automated/python/print_goss_json_results.py
+++ b/goss-testing/automated/python/print_goss_json_results.py
@@ -424,7 +424,7 @@ def main(input_sources: list) -> int:
         mylock = threading.Lock()
         json_results_map = dict()
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=16) as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=goss_script_max_threads()) as executor:
             executor.map(get_json_from_input_url, url_sources, itertools.repeat(mylock, num_urls), itertools.repeat(json_results_map, num_urls))
 
         for source in url_sources:

--- a/goss-testing/automated/python/print_goss_json_results.py
+++ b/goss-testing/automated/python/print_goss_json_results.py
@@ -464,14 +464,15 @@ def main(input_sources: list) -> int:
     total_passed = 0
     total_failed = 0
     total_unknown = 0
-    multi_print("\nChecking test results", outfile_print, logging.info, stdout_print)
-    stdout_print("Only errors will be printed to the screen")
-    for results in all_results:
-        log_values(logging.debug, results=results)
-        passed, failed, unknown = show_results(**results)
-        total_passed += passed
-        total_failed += failed
-        total_unknown += unknown
+    if all_results:
+        multi_print("\nChecking test results", outfile_print, logging.info, stdout_print)
+        stdout_print("Only errors will be printed to the screen")
+        for results in all_results:
+            log_values(logging.debug, results=results)
+            passed, failed, unknown = show_results(**results)
+            total_passed += passed
+            total_failed += failed
+            total_unknown += unknown
 
     print_newline()
     if total_unknown == 0:

--- a/goss-testing/automated/python/print_goss_json_results.py
+++ b/goss-testing/automated/python/print_goss_json_results.py
@@ -95,7 +95,7 @@ outfile = None
 MY_LOG_DIR = None
 MY_LOG_FILE = None
 
-def outfile_print(s):
+def outfile_print(s: str) -> None:
     global outfile
     if outfile == None:
         return
@@ -108,20 +108,20 @@ def outfile_print(s):
         stderr_print(msg)
         outfile = None
 
-def print_newline():
+def print_newline() -> None:
     multi_print("", outfile_print, stdout_print)
 
-def error(s):
+def error(s: str) -> None:
     stderr_print(err_text(f"ERROR: {s}"))
     logging.error(s)
     outfile_print(f"ERROR: {s}")
 
-def warning(s):
+def warning(s: str) -> None:
     stderr_print(warn_text(f"WARNING: {s}"))
     logging.warning(s)
     outfile_print(f"WARNING: {s}")
 
-def get_node_from_url(url):
+def get_node_from_url(url: str) -> str:
     # The node name we use (as a label for results) is the first string after the //, up until
     # the first period, colon, or / (whichever is first)
     node = url.split("/")[2]
@@ -135,7 +135,7 @@ def get_node_from_url(url):
         return node[:colon_index]
     return node
 
-def print_reading_test_results_message(node, label=None):
+def print_reading_test_results_message(node: str, label: str = "") -> None:
     if label:
         stdout_print(f"Reading test results for node {warn_text(node)} ({label})")
         outfile_print(f"Reading test results for node {node} ({label})")
@@ -143,7 +143,7 @@ def print_reading_test_results_message(node, label=None):
         stdout_print(f"Reading test results for node {warn_text(node)}")
         outfile_print(f"Reading test results for node {node}")
 
-def read_and_decode_json(input_file, node):
+def read_and_decode_json(input_file: str, node: str) -> dict:
     if input_file == "stdin" or input_file[:6] == "stdin:":
         logging.debug("Reading standard input for JSON results")
         if input_file == "stdin":
@@ -175,13 +175,13 @@ def read_and_decode_json(input_file, node):
 # The function name is a bit misleading. This just makes sure that log_values makes a single call to
 # the logging method, guaranteeing that the entry will all go in together. That way it won't be interleaved
 # with entries from other threads.
-def threaded_log_values(log_method, **kwargs):
+def threaded_log_values(log_method: function, **kwargs) -> None:
     log_values(log_method, values=kwargs)
 
 # input_url suffices as a unique name for this function in a multi-threading context, as we do not
 # permit duplicate URLs. It is important to include this in all logging calls made in this function,
 # in order to identify which thread was making the call. Also, 
-def get_json_from_input_url(input_url, lock, json_results_map):
+def get_json_from_input_url(input_url: str, lock: threading.Lock, json_results_map: dict) -> None:
     logging.info(f"Making GET request to {input_url}")
     try:
         resp = requests.get(input_url)
@@ -217,7 +217,7 @@ def get_json_from_input_url(input_url, lock, json_results_map):
         json_results_map[input_url] = json_results
     return
 
-def extract_results_data(json_results):
+def extract_results_data(json_results: dict) -> tuple[list, int, float]:
     try:
         results = json_results["results"]
         # Make list of results with a numeric result
@@ -248,7 +248,7 @@ def extract_results_data(json_results):
     selected_results.sort(key=lambda r: (r["title"], r["result"]))
     return selected_results, failed_count, total_duration
 
-def show_results(source, selected_results, failed_count, total_duration, node_name):
+def show_results(source: str, selected_results: list, failed_count: int, total_duration: float, node_name: str) -> tuple[int, int, int]:
     """
     Prints all results to outfile.
     Prints failures to stderr.
@@ -326,13 +326,13 @@ def show_results(source, selected_results, failed_count, total_duration, node_na
 
     return manual_pass_count, manual_fail_count, manual_unknown_count
 
-def is_url(s):
+def is_url(s: str) -> bool:
     """
     Very basic check to see if string appears to be a URL
     """
     return s.find("http://") == 0 or s.find("https://") == 0
 
-def parse_args():
+def parse_args() -> list:
     parser = argparse.ArgumentParser(description="Summarize JSON-format Goss test results with pretty colors.")
     parser.add_argument("sources", nargs="+", help="Sources for test results.")
     # In Python 3.6, the exit_on_error option to ArgumentParser does not yet exist, so a cruder method is
@@ -361,7 +361,7 @@ def parse_args():
 
     return input_sources
 
-def main(input_sources):
+def main(input_sources: list) -> int:
     """
     Returns number of failed tests
 
@@ -497,7 +497,7 @@ def main(input_sources):
         raise ScriptException()
     return total_failed
 
-def setup_logging():
+def setup_logging() -> tuple[str, str]:
     MY_LOG_DIR = log_dir(__file__)
     try:
         # create log directory; it is NOT ok if it already exists

--- a/goss-testing/automated/python/print_goss_json_results.py
+++ b/goss-testing/automated/python/print_goss_json_results.py
@@ -75,7 +75,7 @@ from lib.common import err_text,               \
                        stdout_print,           \
                        warn_text
 
-from typing import List, Tuple
+from typing import Callable, List, Tuple
 
 import argparse
 import concurrent.futures
@@ -177,7 +177,7 @@ def read_and_decode_json(input_file: str, node: str) -> dict:
 # The function name is a bit misleading. This just makes sure that log_values makes a single call to
 # the logging method, guaranteeing that the entry will all go in together. That way it won't be interleaved
 # with entries from other threads.
-def threaded_log_values(log_method: function, **kwargs) -> None:
+def threaded_log_values(log_method: Callable, **kwargs) -> None:
     log_values(log_method, values=kwargs)
 
 # input_url suffices as a unique name for this function in a multi-threading context, as we do not

--- a/goss-testing/automated/python/print_goss_json_results.py
+++ b/goss-testing/automated/python/print_goss_json_results.py
@@ -75,6 +75,8 @@ from lib.common import err_text,               \
                        stdout_print,           \
                        warn_text
 
+from typing import List, Tuple
+
 import argparse
 import concurrent.futures
 import itertools
@@ -217,7 +219,7 @@ def get_json_from_input_url(input_url: str, lock: threading.Lock, json_results_m
         json_results_map[input_url] = json_results
     return
 
-def extract_results_data(json_results: dict) -> tuple[list, int, float]:
+def extract_results_data(json_results: dict) -> Tuple[List[dict], int, float]:
     try:
         results = json_results["results"]
         # Make list of results with a numeric result
@@ -248,7 +250,7 @@ def extract_results_data(json_results: dict) -> tuple[list, int, float]:
     selected_results.sort(key=lambda r: (r["title"], r["result"]))
     return selected_results, failed_count, total_duration
 
-def show_results(source: str, selected_results: list, failed_count: int, total_duration: float, node_name: str) -> tuple[int, int, int]:
+def show_results(source: str, selected_results: List[dict], failed_count: int, total_duration: float, node_name: str) -> Tuple[int, int, int]:
     """
     Prints all results to outfile.
     Prints failures to stderr.
@@ -332,7 +334,7 @@ def is_url(s: str) -> bool:
     """
     return s.find("http://") == 0 or s.find("https://") == 0
 
-def parse_args() -> list:
+def parse_args() -> List[str]:
     parser = argparse.ArgumentParser(description="Summarize JSON-format Goss test results with pretty colors.")
     parser.add_argument("sources", nargs="+", help="Sources for test results.")
     # In Python 3.6, the exit_on_error option to ArgumentParser does not yet exist, so a cruder method is
@@ -361,7 +363,7 @@ def parse_args() -> list:
 
     return input_sources
 
-def main(input_sources: list) -> int:
+def main(input_sources: List[str]) -> int:
     """
     Returns number of failed tests
 
@@ -498,7 +500,7 @@ def main(input_sources: list) -> int:
         raise ScriptException()
     return total_failed
 
-def setup_logging() -> tuple[str, str]:
+def setup_logging() -> Tuple[str, str]:
     MY_LOG_DIR = log_dir(__file__)
     try:
         # create log directory; it is NOT ok if it already exists

--- a/goss-testing/dat/goss-servers.cfg
+++ b/goss-testing/dat/goss-servers.cfg
@@ -1,38 +1,35 @@
 # This configuration file defines the Goss test suite endpoints that will be started on NCNs.
 #
 # Designated goss-servers port range: 8994-9008
-# Ports will be assigned automatically to the endpoints, starting with the start_port, going no higher than end_port.
-# For test suites which run on multiple NCN types, it may not have the same port number on each type (however, it will
-# have the same port number on all NCNs of a given type).
 
 # In this file, lines beginning with # and lines with only whitespace are ignored.
 
-start_port  8994
-end_port    9008
+#port      Suite file                                              NCN type(s) where it will be run
+8994 	   ncn-preflight-tests.yaml                                master storage worker
 
-#           Suite file                                              NCN type(s) where it will be run
-suite       ncn-healthcheck-master.yaml                             master
-suite       ncn-healthcheck-master-single.yaml                      master
-suite       ncn-healthcheck-storage.yaml                            storage
-suite       ncn-healthcheck-worker.yaml                             worker
-suite       ncn-healthcheck-worker-single.yaml                      worker
+8995       ncn-smoke-tests.yaml                                    master storage worker
 
-suite       ncn-afterpitreboot-healthcheck-master.yaml              master
-suite       ncn-afterpitreboot-healthcheck-storage.yaml             storage
-suite       ncn-afterpitreboot-healthcheck-worker.yaml              worker
-suite       ncn-afterpitreboot-healthcheck-worker-single.yaml       worker
+8996       ncn-spire-healthchecks.yaml                             master storage worker
 
-suite       ncn-kubernetes-tests-master.yaml                        master
-suite       ncn-kubernetes-tests-master-single.yaml                 master
-suite       ncn-kubernetes-tests-worker.yaml                        worker
+8997       ncn-healthcheck-master.yaml                             master
+8997       ncn-healthcheck-storage.yaml                            storage
+8997       ncn-healthcheck-worker.yaml                             worker
 
-suite       ncn-afterpitreboot-kubernetes-tests-master-single.yaml  master
-suite       ncn-afterpitreboot-kubernetes-tests-worker-single.yaml  worker
+8998       ncn-healthcheck-master-single.yaml                      master
+8998       ncn-healthcheck-worker-single.yaml                      worker
 
-suite       ncn-preflight-tests.yaml                                master storage worker
+8999       ncn-afterpitreboot-healthcheck-master.yaml              master
+8999       ncn-afterpitreboot-healthcheck-storage.yaml             storage
+8999       ncn-afterpitreboot-healthcheck-worker.yaml              worker
 
-suite       ncn-storage-tests.yaml                                  storage
+9000       ncn-afterpitreboot-healthcheck-worker-single.yaml       worker
 
-suite       ncn-smoke-tests.yaml                                    master storage worker
+9001       ncn-kubernetes-tests-master.yaml                        master
+9001       ncn-kubernetes-tests-worker.yaml                        worker
 
-suite       ncn-spire-healthchecks.yaml                             master storage worker
+9002       ncn-kubernetes-tests-master-single.yaml                 master
+
+9003       ncn-afterpitreboot-kubernetes-tests-master-single.yaml  master
+9003       ncn-afterpitreboot-kubernetes-tests-worker-single.yaml  worker
+
+9004       ncn-storage-tests.yaml                                  storage


### PR DESCRIPTION
## Summary and Scope

Among a number of smaller changes, this PR modifies the automated scripts so that when they are running Goss tests using server endpoints, it runs them in parallel. This allows significant reduction in execution time. Specifically, the combined NCN and Kubernetes health check script went from taking 1m 33s to 44s -- halving the time.

My testing revealed no problems with this, but in case problems are seen on any particular system, I did make the number of parallel threads to be configurable using an environment variable, so even serial execution can be used if needed.

This PR also reverses course on a change made in the Goss server data file format made in a recent PR. I decided it felt safer to specify the port numbers explicitly in the file, rather than have them calculated dynamically. (The end result should be transparent to anyone who is not editing the server config file on their NCNs).

Inspired by a comment by Rusty in another PR, I also made a first pass at adding Python 3 type hint annotations to the automated/python files. (I did not try to do this to the scripts/python files at this time).

## Testing

I tested the PIT-only scripts on redbull, and the NCN scripts on surtur.

### ncn-healthcheck

```text
# /opt/cray/tests/install/ncn/automated/ncn-healthcheck
NCN Run-Time Checks
-------------------

Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20220811_210418.414451-2221323-BFmVyTHp/out

Reading test results for node ncn-m001 (tests/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml)
Running remote tests

Checking test results
Only errors will be printed to the screen

GRAND TOTAL: 435 passed, 0 failed

PASSED
```

### ncn-healthcheck-master

```text
# /opt/cray/tests/install/ncn/automated/ncn-healthcheck-master
NCN Master Run-Time Checks
-------------------

Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20220811_210503.070466-2226847-VJ0gQEfO/out

Running remote tests

Checking test results
Only errors will be printed to the screen

GRAND TOTAL: 172 passed, 0 failed

PASSED
```

### ncn-healthcheck-storage

```text
# /opt/cray/tests/install/ncn/automated/ncn-healthcheck-storage
NCN Storage Run-Time Checks
-------------------

Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20220811_210513.419917-2231619-l8eeLii3/out

Running remote tests

Checking test results
Only errors will be printed to the screen

GRAND TOTAL: 117 passed, 0 failed

PASSED
```

### ncn-healthcheck-worker

```text
# /opt/cray/tests/install/ncn/automated/ncn-healthcheck-worker
NCN Worker Run-Time Checks
-------------------

Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20220811_210517.566771-2232243-qX4echh9/out

Reading test results for node ncn-m001 (tests/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml)
Running remote tests

Checking test results
Only errors will be printed to the screen

GRAND TOTAL: 146 passed, 0 failed

PASSED
```

### ncn-k8s-combined-healthcheck

```text
# /opt/cray/tests/install/ncn/automated/ncn-k8s-combined-healthcheck
NCN and Kubernetes Checks
------------------------------

Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20220811_210604.622143-2233006-lmu27s71/out

Reading test results for node ncn-m001 (suites/ncn-combined-k8s-bgp-tests.yaml)
Running remote tests

Checking test results
Only errors will be printed to the screen

GRAND TOTAL: 545 passed, 0 failed

PASSED
```

### ncn-kubernetes-checks

```text
# /opt/cray/tests/install/ncn/automated/ncn-kubernetes-checks
Kubernetes Checks
------------------------------

Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20220811_210646.938415-2239551-O9tUXKgz/out

Reading test results for node ncn-m001 (suites/ncn-kubernetes-tests-cluster.yaml)
Running remote tests

Checking test results
Only errors will be printed to the screen

GRAND TOTAL: 110 passed, 0 failed

PASSED
```

### ncn-spire-healthchecks

```text
# /opt/cray/tests/install/ncn/automated/ncn-spire-healthchecks
Spire Health Checks
-------------------
Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20220811_210649.069424-2241046-02C4eXMc/out

Running remote tests

Checking test results
Only errors will be printed to the screen

GRAND TOTAL: 72 passed, 0 failed

PASSED

---------------
NCN Spire Postgres Pods Running
Test Name: goss-k8s-postgres-pods-running
Description: Validate that spire postgres pods are running.
Title: Kubernetes Postgres Clusters have the  Correct Number of Pods 'Running'
Meta:
    desc: If this test fails, run the script "/opt/cray/tests/install/ncn/scripts/postgres_pods_running.sh -p" to see a  printed description of errors. Refer to 'operations/kubernetes/Troubleshoot_Postgres_Database.md' in the CSM documentation for more information on diagnosing and fixing pods not in a running state.
    sev: 0
Command: k8s_postgres_pods_per_cluster: exit-status: matches expectation: [0]
Command: k8s_postgres_pods_per_cluster: stdout: matches expectation: [PASS]


Total Duration: 8.606s
Count: 2, Failed: 0, Skipped: 0

---------------
NCN Spire Postgres Pods Have a Leader
Test Name: goss-k8s-postgres-leader
Description: Validate that spire postgres pods have a leader.
Title: Kubernetes Postgres Clusters Have Leaders
Meta:
    desc: If this test fails, run the script "/opt/cray/tests/install/ncn/scripts/postgres_clusters_leader.sh -p" to see printed descriptions of errors. Refer to 'operations/kubernetes/Troubleshoot_Postgres_Database.md' in the CSM documentation for more information on diagnosing and fixing postgres clusters without a leader.
    sev: 0
Command: k8s_postgres_clusters_have_leaders: exit-status: matches expectation: [0]
Command: k8s_postgres_clusters_have_leaders: stdout: matches expectation: [PASS]


Total Duration: 12.199s
Count: 2, Failed: 0, Skipped: 0

-------------------
Spire Health Checks Completed
```

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

