### PR TITLE
CASMINST-5218: Minor bug fixes in Python script error paths

### DIFF
--- a/goss-testing/automated/python/print_goss_json_results.py
+++ b/goss-testing/automated/python/print_goss_json_results.py
@@ -393,7 +393,7 @@ def main(input_sources: List[str]) -> int:
             error(f"Skipping {source} due to error\n")
             unexpected_error = True
             continue
-        except Exception as e:
+        except Exception:
             multi_print(traceback.format_exc(), outfile_print, logging.error)
             error(f"Skipping {source} due to error\n")
             unexpected_error = True
@@ -401,12 +401,12 @@ def main(input_sources: List[str]) -> int:
         # Extract the results from the JSON
         try:
             selected_results, failed_count, total_duration = extract_results_data(json_results)
-        except ScriptException:
+        except ScriptException as e:
             error(e)
             error(f"Skipping {source} due to error\n")
             unexpected_error = True
             continue
-        except Exception as e:
+        except Exception:
             # Add a newline before printing errors
             print_newline()
             multi_print(traceback.format_exc(), outfile_print, logging.error)
@@ -447,12 +447,12 @@ def main(input_sources: List[str]) -> int:
             # Extract the results from the JSON
             try:
                 selected_results, failed_count, total_duration = extract_results_data(json_results)
-            except ScriptException:
+            except ScriptException as e:
                 error(e)
                 error(f"Skipping {source} due to error\n")
                 unexpected_error = True
                 continue
-            except Exception as e:
+            except Exception:
                 multi_print(traceback.format_exc(), outfile_print, logging.error)
                 error(f"Skipping {source} due to error extracting test results from JSON data\n")
                 unexpected_error = True


### PR DESCRIPTION
## Summary and Scope

Reviewing the code, I identified a few small mistakes in some of the error paths in the Python scripts. Specifically, sometimes an Exception is needlessly assigned to a variable (no big deal), but a couple of times it ought to be assigned to a variable but is not (which would result in a secondary failure). 

This PR is very limited in scope.

## Testing

Despite the limited scope of the changes, I ran the updated script on surtur just to make sure no new problems were introduced.

## Risks and Mitigations

Riskier not to include these fixes.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
