### PR TITLE
CASMINST-5239: Fix occasional failure in goss_check_static_routes test

### DIFF
--- a/goss-testing/scripts/check_static_routes.sh
+++ b/goss-testing/scripts/check_static_routes.sh
@@ -140,6 +140,11 @@ done
 
 get_token
 
+echo_stdout "---------------- Route Table ----------------"
+rttbl=$(ip route)
+echo_stdout "$rttbl"
+echo_stdout "---------------------------------------------"
+
 # Get the NMN gateway
 nmngw=$(craysys metadata get --level node ipam | jq .nmn.gateway | tr -d '\"')
 echo_stdout "INFO: NMN gateway is $nmngw"
@@ -159,31 +164,31 @@ fi
 # Check for NMNLB static route
 nmnlb_cidr=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks/NMNLB | jq -r '.ExtraProperties.Subnets[0].CIDR')
 nmnlb_passed=false
-ip route | grep -q "$nmnlb_cidr via $nmngw dev bond0.nmn0" && nmnlb_passed=true
+echo $rttbl | grep -q "$nmnlb_cidr via $nmngw dev bond0.nmn0" && nmnlb_passed=true
 echo_stdout "INFO: NMNLB CIDR is $nmnlb_cidr - route found = $nmnlb_passed"
 
 # Check for NMN_RVR static route
 nmnrvr_cidr=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks/NMN_RVR | jq -r '.ExtraProperties.Subnets[0].CIDR')
 nmnrvr_passed=false
-ip route | grep -q "$nmnrvr_cidr via $nmngw dev bond0.nmn0" && nmnrvr_passed=true
+echo $rttbl | grep -q "$nmnrvr_cidr via $nmngw dev bond0.nmn0" && nmnrvr_passed=true
 echo_stdout "INFO: NMNLB CIDR is $nmnrvr_cidr - route found = $nmnrvr_passed"
 
 # Check for HMNLB static route
 hmnlb_cidr=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks/HMNLB | jq -r '.ExtraProperties.Subnets[0].CIDR')
 hmnlb_passed=false
-ip route | grep -q "$hmnlb_cidr via $hmngw dev bond0.hmn0" && hmnlb_passed=true
+echo $rttbl | grep -q "$hmnlb_cidr via $hmngw dev bond0.hmn0" && hmnlb_passed=true
 echo_stdout "INFO: HMNLB CIDR is $hmnlb_cidr - route found = $hmnlb_passed"
 
 # Check for HMN_RVR static route
 hmnrvr_cidr=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks/HMN_RVR | jq -r '.ExtraProperties.Subnets[0].CIDR')
 hmnrvr_passed=false
-ip route | grep -q "$hmnrvr_cidr via $hmngw dev bond0.hmn0" && hmnrvr_passed=true
+echo $rttbl | grep -q "$hmnrvr_cidr via $hmngw dev bond0.hmn0" && hmnrvr_passed=true
 echo_stdout "INFO: HMNLB CIDR is $hmnrvr_cidr - route found = $hmnrvr_passed"
 
 # Check for MTL static route
 mtl_cidr=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks/MTL | jq -r '.ExtraProperties.Subnets[0].CIDR')
 mtl_passed=false
-ip route | grep -q "$mtl_cidr via $nmngw dev bond0.nmn0" && mtl_passed=true
+echo $rttbl | grep -q "$mtl_cidr via $nmngw dev bond0.nmn0" && mtl_passed=true
 echo_stdout "INFO: MTL CIDR is $mtl_cidr - route found = $mtl_passed"
 
 if $nmnlb_passed && $hmnlb_passed && $mtl_passed && $nmnrvr_passed && $hmnrvr_passed; then


### PR DESCRIPTION
## Summary and Scope

The goss-check-static-routes.yaml failed on w001 on fanta.   The logs from that test run showed this:

```
log_run argument(s): -l check_static_routes
Executable: '/opt/cray/tests/install/ncn/scripts/check_static_routes.sh'
1 argument(s) to executable: '-p'

## 20220817_060122_698825734 ##                      executable starting ##
###########################################################################
INFO: NMN gateway is 10.252.0.1
INFO: HMN gateway is 10.254.0.1
INFO: NMNLB CIDR is 10.92.100.0/24 - route found = true
INFO: NMNLB CIDR is 10.106.0.0/22 - route found = true
INFO: HMNLB CIDR is 10.94.100.0/24 - route found = true
INFO: HMNLB CIDR is 10.107.0.0/22 - route found = true
INFO: MTL CIDR is 10.1.0.0/16 - route found = false
FAIL
###########################################################################
## 20220817_060124_566479988 ##       executable completed (exit code=1) ##
```

The MTL CIDR and NMN gateway look correct so it looks like the only thing that could have failed here is finding those values in the `ip route` output.  To get more information when this happens again, I added the route table to the log output for this test.  

It will now look something like this:

```
ncn-w001:/opt/cray/tests/install/ncn/tests # ../scripts/check_static_routes.sh -p
---------------- Route Table ----------------
default via 10.102.4.1 dev bond0.cmn0 
10.1.0.0/16 via 10.252.0.1 dev bond0.nmn0 
10.32.0.0/12 dev weave proto kernel scope link src 10.36.0.0 
10.92.100.0/24 via 10.252.0.1 dev bond0.nmn0 
10.94.100.0/24 via 10.254.0.1 dev bond0.hmn0 
10.102.4.0/25 dev bond0.cmn0 proto kernel scope link src 10.102.4.29 
10.102.4.128/26 dev bond0.can0 proto kernel scope link src 10.102.4.143 
10.106.0.0/22 via 10.252.0.1 dev bond0.nmn0 
10.107.0.0/22 via 10.254.0.1 dev bond0.hmn0 
10.252.0.0/17 dev bond0.nmn0 proto kernel scope link src 10.252.1.14 
10.254.0.0/17 dev bond0.hmn0 proto kernel scope link src 10.254.1.24 
---------------------------------------------
INFO: NMN gateway is 10.252.0.1
INFO: HMN gateway is 10.254.0.1
INFO: NMNLB CIDR is 10.92.100.0/24 - route found = true
INFO: NMNLB CIDR is 10.106.0.0/22 - route found = true
INFO: HMNLB CIDR is 10.94.100.0/24 - route found = true
INFO: HMNLB CIDR is 10.107.0.0/22 - route found = true
INFO: MTL CIDR is 10.1.0.0/16 - route found = true
PASS
```

While testing out this change I did reproduce the problem again and the route table in the output looked correct.   However, the `ip route` is executed for EACH CHECK.   So I changed the script to only get the route table once at the beginning and then use that output when checking each of the routes.

When I ran the original script 150 times in row (with a 2 second pause between runs) I hit the failure 4 times.

When I ran the script that only did the `ip route` once, I did not hit a single failure in 200 runs.

Therefore, I was able to find method to reproduce the problem and then prove that the problem was no longer reproduced with the fix.

## Issues and Related PRs

* Resolves CASMINST-5239

## Testing

### Tested on:

  * `fanta`

### Test description:

I ran the modified script on w001 both with and without the -p.
I ran the GOSS test to make sure the script change doesn't cause any problems with goss.
I ran the script 200 times without reproducing the failure.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

