### PR TITLE
CASMINST-5213: Run local tests in parallel with remote endpoint tests

### DIFF
--- a/goss-testing/automated/python/lib/endpoints.py
+++ b/goss-testing/automated/python/lib/endpoints.py
@@ -32,14 +32,15 @@ These functions relate to the Goss server endpoints.
 from .common import argparse_yaml_file_name,     \
                     goss_servers_config,         \
                     NCN_TYPES,                   \
-                    ScriptException
+                    ScriptException,             \
+                    StringList
 
 from typing import Dict, List, Tuple
 
 import argparse
 import re
 
-StringList = List[str]
+# To help with function annotations
 EndpointTuple = Tuple[str, str, int]
 
 # We assume our Goss server ports will be between 1000 and 65535 (the maximum TCP port number)


### PR DESCRIPTION
## Summary and Scope

This PR's primary purpose is to have local Goss tests run in parallel alongside the remote Goss tests. My previous changes made the remote tests run in parallel, but the local tests were still run before or after those tests. This PR puts them all into the same parallel execution pool.

Right now this doesn't reap huge performance benefits. However, I noticed some areas of improvement in some of our test scripts that I think I can combine with this change to make some of our automated scripts execute more quickly.

## Issues and Related PRs

This is a continuation of the various recent Goss testing performance enhancements we've been making. Most notably:
- [CASMINST-5162](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5162)
- [CASMINST-5195](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5195)
- [CASMINST-5161](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5161)
- [CASMINST-5171](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5171)
- [CASMINST-5159](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5159)
- [CASMINST-5025](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5025)

## Testing

In the testing below, some of the tests failed. However, that's unrelated to this PR. This PR is only making sure that the Goss framework is still running the correct tests, using the correct variable files, and that the tests are not causing problems by running in parallel. All of the failures observed existed without this PR in place.

### NCN tests

These were run on fanta, installed with CSM 1.3.0-beta.44

#### ncn-healthcheck

```text
# /opt/cray/tests/install/ncn/automated/ncn-healthcheck
NCN Run-Time Checks
-------------------

Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20220822_162605.906366-188963-xCb64bqH/out

Running tests

Checking test results
Only errors will be printed to the screen

Result: FAIL
Source: http://ncn-w001.hmn:8998/ncn-healthcheck-worker-single
Test Name: Precaching of Docker Images on Workers is Healthy
Description: This test verifies the precache pods are successfully pulling the images referenced in the configmap (cray-precache-images) in the nexus namespace.  If this test fails, execute the following command to inspect the images that are failing to get pulled - 'kubectl -n nexus logs -l app.kubernetes.io/name=cray-precache-images --tail=100 | grep failed'.
Test Summary: Command: precache-images-health: stdout: patterns not found: [0]
Execution Time: 0.00001632 seconds
Node: ncn-w001


GRAND TOTAL: 537 passed, 1 failed
ERROR: There was at least one test failure

FAILED
```

#### ncn-healthcheck-master

```text
# /opt/cray/tests/install/ncn/automated/ncn-healthcheck-master
NCN Master Run-Time Checks
-------------------

Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20220822_162827.176738-195547-Y3HEPukl/out

Running tests

Checking test results
Only errors will be printed to the screen

GRAND TOTAL: 178 passed, 0 failed

PASSED
```

#### ncn-healthcheck-storage

```text
# /opt/cray/tests/install/ncn/automated/ncn-healthcheck-storage
NCN Storage Run-Time Checks
-------------------

Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20220822_162836.837455-200194-MW5HEuDv/out

Running tests

Checking test results
Only errors will be printed to the screen

GRAND TOTAL: 163 passed, 0 failed

PASSED
```

#### ncn-healthcheck-worker

```text
# /opt/cray/tests/install/ncn/automated/ncn-healthcheck-worker
NCN Worker Run-Time Checks
-------------------

Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20220822_162841.576361-201004-0B8Dhb01/out

Running tests

Checking test results
Only errors will be printed to the screen

Result: FAIL
Source: http://ncn-w001.hmn:8998/ncn-healthcheck-worker-single
Test Name: Precaching of Docker Images on Workers is Healthy
Description: This test verifies the precache pods are successfully pulling the images referenced in the configmap (cray-precache-images) in the nexus namespace.  If this test fails, execute the following command to inspect the images that are failing to get pulled - 'kubectl -n nexus logs -l app.kubernetes.io/name=cray-precache-images --tail=100 | grep failed'.
Test Summary: Command: precache-images-health: stdout: patterns not found: [0]
Execution Time: 0.00002098 seconds
Node: ncn-w001


GRAND TOTAL: 196 passed, 1 failed
ERROR: There was at least one test failure

FAILED
```

#### ncn-k8s-combined-healthcheck

```text
# /opt/cray/tests/install/ncn/automated/ncn-k8s-combined-healthcheck
NCN and Kubernetes Checks
------------------------------

Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20220822_162911.131099-201614-VLBubgP2/out

Running tests

Checking test results
Only errors will be printed to the screen

Result: FAIL
Source: http://ncn-w001.hmn:8998/ncn-healthcheck-worker-single
Test Name: Precaching of Docker Images on Workers is Healthy
Description: This test verifies the precache pods are successfully pulling the images referenced in the configmap (cray-precache-images) in the nexus namespace.  If this test fails, execute the following command to inspect the images that are failing to get pulled - 'kubectl -n nexus logs -l app.kubernetes.io/name=cray-precache-images --tail=100 | grep failed'.
Test Summary: Command: precache-images-health: stdout: patterns not found: [0]
Execution Time: 0.00002098 seconds
Node: ncn-w001


GRAND TOTAL: 657 passed, 1 failed
ERROR: There was at least one test failure

FAILED
```

#### ncn-kubernetes-checks

```text
# /opt/cray/tests/install/ncn/automated/ncn-kubernetes-checks
Kubernetes Checks
------------------------------

Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20220822_162921.560268-209785-TABq3UhA/out

Running tests

Checking test results
Only errors will be printed to the screen

GRAND TOTAL: 120 passed, 0 failed

PASSED
```

#### ncn-spire-healthchecks

```text
# /opt/cray/tests/install/ncn/automated/ncn-spire-healthchecks
Spire Health Checks
-------------------
Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20220822_162923.212710-211575-K0f9AAKN/out

Running tests

Checking test results
Only errors will be printed to the screen

Result: FAIL
Source: http://ncn-s002.hmn:8996/ncn-spire-healthchecks
Test Name: Spire Pods
Description: Kubernetes spire namespace pods are running.
Test Summary: Command: k8s_verify_spire_pods: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0
Execution Time: 0.12059153 seconds
Node: ncn-s002

Result: FAIL
Source: http://ncn-s002.hmn:8996/ncn-spire-healthchecks
Test Name: Spire Pods
Description: Kubernetes spire namespace pods are running.
Test Summary: Command: k8s_verify_spire_pods: stdout: patterns not found: [/^request-ncn-join-token-.*Running/, /^spire-agent-.*Running/, /^spire-jwks-.*Running/, /^spire-postgres-.*Running/, /^spire-server-.*Running/]
Execution Time: 0.00016597 seconds
Node: ncn-s002

Result: FAIL
Source: http://ncn-s002.hmn:8996/ncn-spire-healthchecks
Test Name: Validate token key ID exists in spire jwks
Description: Validate token key ID exists in spire jwks. If this fails, try running kubectl rollout restart -n spire daemonset spire-agent and kubectl rollout restart -n spire deployment spire-jwks
Test Summary: Command: spire_check_key_id_in_jwks: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0
Execution Time: 0.33428316 seconds
Node: ncn-s002


Result: FAIL
Source: http://ncn-s003.hmn:8996/ncn-spire-healthchecks
Test Name: Spire Pods
Description: Kubernetes spire namespace pods are running.
Test Summary: Command: k8s_verify_spire_pods: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0
Execution Time: 0.12063621 seconds
Node: ncn-s003

Result: FAIL
Source: http://ncn-s003.hmn:8996/ncn-spire-healthchecks
Test Name: Spire Pods
Description: Kubernetes spire namespace pods are running.
Test Summary: Command: k8s_verify_spire_pods: stdout: patterns not found: [/^request-ncn-join-token-.*Running/, /^spire-agent-.*Running/, /^spire-jwks-.*Running/, /^spire-postgres-.*Running/, /^spire-server-.*Running/]
Execution Time: 0.00013690 seconds
Node: ncn-s003

Result: FAIL
Source: http://ncn-s003.hmn:8996/ncn-spire-healthchecks
Test Name: Validate token key ID exists in spire jwks
Description: Validate token key ID exists in spire jwks. If this fails, try running kubectl rollout restart -n spire daemonset spire-agent and kubectl rollout restart -n spire deployment spire-jwks
Test Summary: Command: spire_check_key_id_in_jwks: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0
Execution Time: 0.28915199 seconds
Node: ncn-s003


Result: FAIL
Source: http://ncn-s004.hmn:8996/ncn-spire-healthchecks
Test Name: Spire Pods
Description: Kubernetes spire namespace pods are running.
Test Summary: Command: k8s_verify_spire_pods: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0
Execution Time: 0.10835255 seconds
Node: ncn-s004

Result: FAIL
Source: http://ncn-s004.hmn:8996/ncn-spire-healthchecks
Test Name: Spire Pods
Description: Kubernetes spire namespace pods are running.
Test Summary: Command: k8s_verify_spire_pods: stdout: patterns not found: [/^request-ncn-join-token-.*Running/, /^spire-agent-.*Running/, /^spire-jwks-.*Running/, /^spire-postgres-.*Running/, /^spire-server-.*Running/]
Execution Time: 0.00013591 seconds
Node: ncn-s004

Result: FAIL
Source: http://ncn-s004.hmn:8996/ncn-spire-healthchecks
Test Name: Validate token key ID exists in spire jwks
Description: Validate token key ID exists in spire jwks. If this fails, try running kubectl rollout restart -n spire daemonset spire-agent and kubectl rollout restart -n spire deployment spire-jwks
Test Summary: Command: spire_check_key_id_in_jwks: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0
Execution Time: 0.34176571 seconds
Node: ncn-s004


GRAND TOTAL: 79 passed, 9 failed
ERROR: There was at least one test failure

FAILED

---------------
NCN Spire Postgres Pods Running
Test Name: goss-k8s-postgres-pods-running
Description: Validate that spire postgres pods are running.
Title: Kubernetes Postgres Clusters have the  Correct Number of Pods 'Running'
Meta:
    desc: If this test fails, run the script "/opt/cray/tests/install/ncn/scripts/postgres_pods_running.sh -p" to see a  printed description of errors. Refer to 'operations/kubernetes/Troubleshoot_Postgres_Database.md' in the CSM documentation for more information on diagnosing and fixing pods not in a running state.
    sev: 0
Command: k8s_postgres_pods_per_cluster: exit-status: matches expectation: [0]
Command: k8s_postgres_pods_per_cluster: stdout: matches expectation: [PASS]


Total Duration: 8.328s
Count: 2, Failed: 0, Skipped: 0

---------------
NCN Spire Postgres Pods Have a Leader
Test Name: goss-k8s-postgres-leader
Description: Validate that spire postgres pods have a leader.
Title: Kubernetes Postgres Clusters Have Leaders
Meta:
    desc: If this test fails, run the script "/opt/cray/tests/install/ncn/scripts/postgres_clusters_leader.sh -p" to see printed descriptions of errors. Refer to 'operations/kubernetes/Troubleshoot_Postgres_Database.md' in the CSM documentation for more information on diagnosing and fixing postgres clusters without a leader.
    sev: 0
Command: k8s_postgres_clusters_have_leaders: exit-status: matches expectation: [0]
Command: k8s_postgres_clusters_have_leaders: stdout: matches expectation: [PASS]


Total Duration: 8.787s
Count: 2, Failed: 0, Skipped: 0

-------------------
Spire Health Checks Completed
```

### PIT tests

These were run on redbull.

#### livecd-preflight-checks

```text
Running LiveCD preflight checks (may take a few minutes to complete)...
WARNING: The PITDATA environment variable is not set.
Writing full output to ./opt/cray/tests/install/logs/print_goss_json_results/20220822_171023.970796-79910-bEDMuZIq/out

Running tests

Checking test results
Only errors will be printed to the screen

Result: FAIL
Source: ./opt/cray/tests/install/livecd/suites/livecd-preflight-tests.yaml
Test Name: Firmware and BIOS versions and baseline
Description: Validates the correct versions of BIOS and firmware; Validates BIOS settings (when available; dependent on vendor). If this test fails, run "./opt/cray/tests/install/livecd/scripts/check_bios_firmware_versions.sh -b" for more information on the failure. On GigaByte NCNs, a value of "null" may indicate that the BIOS/Firmware needs to be reflashed or that a hard AC power cycle is needed.
Test Summary: Command: firmware_bios_versions: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0
Execution Time: 0.11157006 seconds
Node: redbull-ncn-m001-pit

Result: FAIL
Source: ./opt/cray/tests/install/livecd/suites/livecd-preflight-tests.yaml
Test Name: Squashfs Image Has Been Modified
Description: Validates that the squashfs image filename has secure- prefix, indicating the ncn-image-modification.sh script has been run.
Test Summary: Command: ncn-w002_secure_squashfs: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0
Execution Time: 0.09400104 seconds
Node: redbull-ncn-m001-pit

Result: FAIL
Source: ./opt/cray/tests/install/livecd/suites/livecd-preflight-tests.yaml
Test Name: Squashfs Image Has Been Modified
Description: Validates that the squashfs image filename has secure- prefix, indicating the ncn-image-modification.sh script has been run.
Test Summary: Command: ncn-m002_secure_squashfs: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0
Execution Time: 0.04715167 seconds
Node: redbull-ncn-m001-pit

Result: FAIL
Source: ./opt/cray/tests/install/livecd/suites/livecd-preflight-tests.yaml
Test Name: Squashfs Image Has Been Modified
Description: Validates that the squashfs image filename has secure- prefix, indicating the ncn-image-modification.sh script has been run.
Test Summary: Command: ncn-m003_secure_squashfs: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0
Execution Time: 0.14491919 seconds
Node: redbull-ncn-m001-pit

Result: FAIL
Source: ./opt/cray/tests/install/livecd/suites/livecd-preflight-tests.yaml
Test Name: Squashfs Image Has Been Modified
Description: Validates that the squashfs image filename has secure- prefix, indicating the ncn-image-modification.sh script has been run.
Test Summary: Command: ncn-w001_secure_squashfs: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0
Execution Time: 0.14718063 seconds
Node: redbull-ncn-m001-pit

Result: FAIL
Source: ./opt/cray/tests/install/livecd/suites/livecd-preflight-tests.yaml
Test Name: Squashfs Image Has Been Modified
Description: Validates that the squashfs image filename has secure- prefix, indicating the ncn-image-modification.sh script has been run.
Test Summary: Command: ncn-w003_secure_squashfs: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0
Execution Time: 0.10846691 seconds
Node: redbull-ncn-m001-pit


GRAND TOTAL: 169 passed, 6 failed
ERROR: There was at least one test failure

FAILED
```

#### livecd-provisioning-checks

```text
Running LiveCD provisioning checks (may take a few minutes to complete)...
WARNING: The PITDATA environment variable is not set.
Writing full output to ./opt/cray/tests/install/logs/print_goss_json_results/20220822_171110.600367-80753-aaDWCh0y/out

Running tests

Checking test results
Only errors will be printed to the screen

GRAND TOTAL: 9 passed, 0 failed

PASSED
```

## Risks and Mitigations

Fairly low risk, given that it mostly builds on changes that have been out in the release for a while now, without problems being discovered. This is a "more of the same" type of PR.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [ ] Testing is appropriate and complete, if applicable
