### PR TITLE
CASMINST-5088

### DIFF
--- a/goss-testing/scripts/k8s_kyverno_pods_running.sh
+++ b/goss-testing/scripts/k8s_kyverno_pods_running.sh
@@ -53,20 +53,23 @@ error_flag=0
 
 # checks if all kyverno pods are running. Total 3 pods.
 
-running_pods=$(kubectl get poda -n kyverno -o json | jq '[.items[] | select(.metadata.labels.app == "kyverno").status.containerStatuses[0].state.running] | length') || err_exit 10 "Command pipeline failed with return code $?: kubectl get pods -n kyverno -o json | jq '[.items[] | select(.metadata.labels.app == "kyverno").status.containerStatuses[0].state.running] | length'"
-if [[ $running_pods != 3 ]] && [[ $print_results -eq 1 ]]
+running_pods=$(kubectl get poda -n kyverno -o json | jq '[.items[] | select(.metadata.labels.app == "kyverno").status.containerStatuses[0].state.running] | length') || err_exit 10 "Command pipeline failed with return code $?: kubectl get pods -n kyverno -o json | jq '[.items[] | select(.metadata.labels.app == \"kyverno\").status.containerStatuses[0].state.running] | length'"
+if [[ $running_pods != 3 ]]
 then
-        error_flag=1;
+    error_flag=1
+    if [[ $print_results -eq 1 ]]
+    then
         echo "Error: $running_pods out of 3 pods are running."
         echo "For high availability the recommended Kyverno pod replica count is 3."
         echo "Check the logs, restart Kyverno and ensure all 3 Kyverno pods are running."
-
+    fi
 fi
-if [[ $running_pods != 3 ]]
+
+if [[ $error_flag -eq 0 ]]
 then
-        error_flag=1;
+    echo "PASS"
+    exit 0
 fi
 
-if [[ $error_flag -eq 0 ]]; then echo "PASS"; exit 0;
-else echo "FAIL"; exit 1;
-fi
+echo "FAIL"
+exit 1

--- a/goss-testing/scripts/k8s_kyverno_pods_running.sh
+++ b/goss-testing/scripts/k8s_kyverno_pods_running.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+print_results=0
+while getopts ph stack
+do
+    case "${stack}" in
+          p) print_results=1;;
+          h) echo "usage: k8s_kyverno_pods_running.sh           # Only print 'PASS' upon success"
+             echo "       k8s_kyverno_pods_running.sh -p        # Print all results and errors if found. Use for manual check."
+             exit 3;;
+         \?) echo "usage: k8s_kyverno_pods_running.sh           # Only print 'PASS' upon success"
+             echo "       k8s_kyverno_pods_running.sh -p        # Print all results and errors if found. Use for manual check."
+             exit 3;;
+    esac
+done
+
+error_flag=0
+
+# checks if all kyverno pods are running. Total 3 pods.
+
+running_pods=$(kubectl get pods -n kyverno -o wide -A |  awk '$1 ~ "kyverno"' | awk '$4 == "Running"' | wc | awk '{print $1}')
+if [[ $running_pods != 3 ]] && [[ $print_results -eq 1 ]]
+then
+        error_flag=1;
+        echo "Error: $running_pods out of 3 pods are running."
+        echo "For high availability the recommended Kyverno pod replica count is 3."
+        echo "Check the logs, restart Kyverno and ensure all 3 Kyverno pods are running."
+
+fi
+if [[ $running_pods != 3 ]]
+then
+        error_flag=1;
+fi
+
+if [[ error_flag -eq 0 ]]; then echo "PASS"; exit 0;
+else echo "FAIL"; exit 1;
+fi

--- a/goss-testing/scripts/k8s_kyverno_pods_running.sh
+++ b/goss-testing/scripts/k8s_kyverno_pods_running.sh
@@ -54,6 +54,6 @@ then
         error_flag=1;
 fi
 
-if [[ error_flag -eq 0 ]]; then echo "PASS"; exit 0;
+if [[ $error_flag -eq 0 ]]; then echo "PASS"; exit 0;
 else echo "FAIL"; exit 1;
 fi

--- a/goss-testing/scripts/k8s_kyverno_pods_running.sh
+++ b/goss-testing/scripts/k8s_kyverno_pods_running.sh
@@ -39,7 +39,7 @@ do
     esac
 done
 
-# checks if all kyverno pods are running. Total 3 pods.
+# Checks if all kyverno pods are running. There should be a total of 3 running pods.
 
 running_pods=$(kubectl get poda -n kyverno -o json | jq '[.items[] | select(.metadata.labels.app == "kyverno").status.containerStatuses[0].state.running] | length')
 rc=$?

--- a/goss-testing/scripts/k8s_kyverno_pods_running.sh
+++ b/goss-testing/scripts/k8s_kyverno_pods_running.sh
@@ -41,7 +41,7 @@ done
 
 # Checks if all kyverno pods are running. There should be a total of 3 running pods.
 
-running_pods=$(kubectl get poda -n kyverno -o json | jq '[.items[] | select(.metadata.labels.app == "kyverno").status.containerStatuses[0].state.running] | length')
+running_pods=$(kubectl get pods -n kyverno -o json | jq '[.items[] | select(.metadata.labels.app == "kyverno").status.containerStatuses[0].state.running] | length')
 rc=$?
 if [[ ${rc} -ne 0 ]]
 then

--- a/goss-testing/scripts/k8s_kyverno_polr_list.sh
+++ b/goss-testing/scripts/k8s_kyverno_polr_list.sh
@@ -81,6 +81,6 @@ then
         error_flag=1;
 fi
 
-if [[ error_flag -eq 0 ]]; then echo "PASS"; exit 0;
+if [[ $error_flag -eq 0 ]]; then echo "PASS"; exit 0;
 else echo "FAIL"; exit 1;
 fi

--- a/goss-testing/scripts/k8s_kyverno_polr_list.sh
+++ b/goss-testing/scripts/k8s_kyverno_polr_list.sh
@@ -40,10 +40,10 @@ error_flag=0
 
 # checks if kyverno policy reports are available
 
-failures=$(kubectl get polr -A | awk '(NR>1)' | awk '{sum+=$4} END {print sum}')
-warnings=$(kubectl get polr -A | awk '(NR>1)' | awk '{sum+=$5} END {print sum}')
-errors=$(kubectl get polr -A | awk '(NR>1)' | awk '{sum+=$6} END {print sum}')
-skipped=$(kubectl get polr -A | awk '(NR>1)' | awk '{sum+=$7} END {print sum}')
+failures=$(kubectl get polr -A -o json | jq '[.items[].summary.fail] | add')
+warnings=$(kubectl get polr -A -o json | jq '[.items[].summary.warn] | add')
+errors=$(kubectl get polr -A -o json | jq '[.items[].summary.error] | add')
+skipped=$(kubectl get polr -A -o json | jq '[.items[].summary.skip] | add')
 if [[ $failures > 0 ]]
 then
         if [[ $print_results -eq 1 ]]

--- a/goss-testing/scripts/k8s_kyverno_polr_list.sh
+++ b/goss-testing/scripts/k8s_kyverno_polr_list.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+print_results=0
+while getopts ph stack
+do
+    case "${stack}" in
+          p) print_results=1;;
+          h) echo "usage: k8s_kyverno_polr_list.sh           # Only print 'PASS' upon success"
+             echo "       k8s_kyverno_polr_list.sh -p        # Print all results and errors if found. Use for manual check."
+             exit 3;;
+         \?) echo "usage: k8s_kyverno_polr_list.sh           # Only print 'PASS' upon success"
+             echo "       k8s_kyverno_polr_list.sh -p        # Print all results and errors if found. Use for manual check."
+             exit 3;;
+    esac
+done
+
+error_flag=0
+
+# checks if kyverno policy reports are available
+
+failures=$(kubectl get polr -A | awk '(NR>1)' | awk '{sum+=$4} END {print sum}')
+warnings=$(kubectl get polr -A | awk '(NR>1)' | awk '{sum+=$5} END {print sum}')
+errors=$(kubectl get polr -A | awk '(NR>1)' | awk '{sum+=$6} END {print sum}')
+skipped=$(kubectl get polr -A | awk '(NR>1)' | awk '{sum+=$7} END {print sum}')
+if [[ $failures > 0 ]]
+then
+        if [[ $print_results -eq 1 ]]
+        then
+                echo "Error: There are $failures failures in policy report."
+                echo "Look into the Kyverno policy management document to address the failures/warnings/errors/skipped"
+        fi
+        error_flag=1;
+fi
+if [[ $warnings > 0 ]]
+then
+        if [[ $print_results -eq 1 ]]
+        then
+                echo "Error: There are $warnings warnings in policy report."
+                echo "Look into the Kyverno policy management document to address the failures/warnings/errors/skipped"
+        fi
+        error_flag=1;
+fi
+if [[ $errors > 0 ]]
+then
+        if [[ $print_results -eq 1 ]]
+        then
+                echo "Error: There are $errors errors in policy report."
+                echo "Look into the Kyverno policy management document to address the failures/warnings/errors/skipped"
+        fi
+        error_flag=1;
+fi
+if [[ $skipped > 0 ]]
+then
+        if [[ $print_results -eq 1 ]]
+        then
+                echo "Error: Policy report shows $skipped policies are skipped."
+                echo "Look into the Kyverno policy management document to address the failures/warnings/errors/skipped"
+        fi
+        error_flag=1;
+fi
+
+if [[ error_flag -eq 0 ]]; then echo "PASS"; exit 0;
+else echo "FAIL"; exit 1;
+fi


### PR DESCRIPTION
## Summary and Scope

There was a typo "poda"  which had to be changed to "pods"

## Issues and Related PRs

"poda" was used for negative test case scenario of kubectl command failure. Correct word is "pods"

## Testing

Tested the script and it is working.

ncn-m001:/tmp # ./k8s_kyverno_pods_running.sh -p
PASS
ncn-m001:/tmp #


### Tested on:

drax system

### Test description:

Script is used to check if 3 kyverno pods are running if not appropriate error messages are displayed when executed manually for debugging.

