### PR TITLE
CASMTRIAGE-4018 use rootfs instead of the deprecated filesystem.squashfs

### DIFF
--- a/goss-testing/tests/livecd/goss-artifacts-in-place.yaml
+++ b/goss-testing/tests/livecd/goss-artifacts-in-place.yaml
@@ -77,7 +77,7 @@ command:
                     # The readlink command is used to accomplish this.
                     set -eo pipefail
                     "{{$logrun}}" -l "{{$testlabel}}" \
-                        basename "$(readlink /var/www/{{ $dir }}/filesystem.squashfs)" | 
+                        basename "$(readlink /var/www/{{ $dir }}/rootfs)" | 
                             grep "^secure-"
                 exit-status: 0
                 timeout: 20000

--- a/goss-testing/vars/variables-livecd.yaml
+++ b/goss-testing/vars/variables-livecd.yaml
@@ -82,7 +82,7 @@ commands:
   - 'cray --version'
 
 artifact_symlinks:
-  - filesystem.squashfs
+  - rootfs
   - initrd.img.xz
   - kernel
 


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

`filesystem.squashfs` has been renamed to `rootfs` so this test needs to be updated to align with that change.

## Issues and Related PRs

* Resolves CASMTRIAGE-4018

## Testing

### Tested on:

  * `#starlord`

### Test description:

Installed RPMs.  Ran both `csi pit validate --livecd-preflight` and `/opt/cray/tests/install/livecd/automated/livecd-preflight-checks`.  Validated that the test no longer failed.

## Risks and Mitigations

Low.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

