### PR TITLE
CASMINST-5224: handle special password character and fix exit code

### DIFF
--- a/goss-testing/tests/ncn/goss-k8s-resolve-external-dns.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-resolve-external-dns.yaml
@@ -29,7 +29,7 @@ command:
       sev: 0
     exec: |-
           # External DNS resolution is best tested by checking if the configured LDAP server is pingable.
-          # Pass if the test requirements are not met:
+          # Fail if the test requirements are not met:
           # - Unbound forward-addr is not configured.
           # - LDAP providerId is not configured.
           # Fail if the LDAP providerId is configured but the LDAP connectionURL is not.
@@ -40,7 +40,7 @@ command:
               MASTER_USERNAME=$(kubectl get secret -n services keycloak-master-admin-auth -ojsonpath='{.data.user}' | base64 -d)
               MASTER_PASSWORD=$(kubectl get secret -n services keycloak-master-admin-auth -ojsonpath='{.data.password}' | base64 -d)
 
-              curl -ks -d client_id=admin-cli -d username=$MASTER_USERNAME -d password=$MASTER_PASSWORD \
+              curl -ks -d client_id=admin-cli -d username=$MASTER_USERNAME --data-urlencode password="$MASTER_PASSWORD" \
                    -d grant_type=password https://api-gw-service-nmn.local/keycloak/realms/master/protocol/openid-connect/token | jq -r '.access_token'; 
            }
    
@@ -52,12 +52,12 @@ command:
 
            if [[ ! $FORWARD_ADDR ]]; then 
               echo "Unbound must be configured for this test."
-              exit 0
+              exit 1
            fi
 
            if [[ ! $LDAP_PROVIDER ]]; then 
               echo "LDAP must be configured for this test."
-              exit 0
+              exit 1
            fi
 
            echo "Unbound and LDAP are configured" 


### PR DESCRIPTION
## Summary and Scope

The original keycloak token generation api call does not handle special character password appropriately, nor emits error when DNS test requirements are not met. The PR fixes both issues.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-5224](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5224)
* Change will also be needed in `release/1.3 and release/1.2`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `mug` (1.2)
  * `fanta` (1.3)

### Test description:

Verified that the goss-k8s-resolve-external-dns test now passes with the fix.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

