### PR TITLE
Update pause version for nexus test (CASMTRIAGE-4057)

### DIFF
--- a/goss-testing/tests/ncn/goss-k8s-nexus-can-pull.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-nexus-can-pull.yaml
@@ -32,7 +32,7 @@ command:
             sev: 0
         exec: |-
             "{{$logrun}}" -l "{{$testlabel}}" \
-                crictl pull registry.local/k8s.gcr.io/pause:3.2
+                crictl pull artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/pause:3.4.1
         exit-status: 0
         timeout: 20000
         skip: false


### PR DESCRIPTION
## Summary and Scope

Update nexus test to pull correct pause image.

## Issues and Related PRs

* Resolves [CASMTRIAGE-4057](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4057)

## Testing

Tested fix on fanta:

```
ncn-m001:~ # export GOSS_BASE=/opt/cray/tests/install/ncn; goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-nexus-can-pull.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml v

Total Duration: 0.153s
Count: 1, Failed: 0, Skipped: 0
```

### Tested on:

  * `fanta`

### Test description:

Tested on fanta

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

