### PR TITLE
CASMINST-5311: Run clock skew tests on worker and storage NCNs during CSM health validation

### DIFF
--- a/goss-testing/suites/ncn-healthcheck-storage.yaml
+++ b/goss-testing/suites/ncn-healthcheck-storage.yaml
@@ -32,6 +32,7 @@ gossfile:
   ../tests/goss-bond-members-have-correct-mtu.yaml: {}
   ../tests/goss-bond-members-have-links.yaml: {}
   ../tests/goss-ceph-status.yaml: {}
+  ../tests/goss-check-clock-skew.yaml: {}
   ../tests/goss-check-static-routes.yaml: {}
   ../tests/goss-command-available.yaml: {}
   ../tests/goss-default-gateway-points-to-CMN-gateway.yaml: {}

--- a/goss-testing/suites/ncn-healthcheck-worker.yaml
+++ b/goss-testing/suites/ncn-healthcheck-worker.yaml
@@ -29,6 +29,7 @@ gossfile:
   ../tests/goss-bond-members-have-correct-mtu.yaml: {}
   ../tests/goss-bond-members-have-links.yaml: {}
   ../tests/goss-cfs-state-reporter.yaml: {}
+  ../tests/goss-check-clock-skew.yaml: {}
   ../tests/goss-check-static-routes.yaml: {}
   ../tests/goss-command-available.yaml: {}
   ../tests/goss-default-gateway-points-to-CMN-gateway.yaml: {}


### PR DESCRIPTION
1.3 backport of https://github.com/Cray-HPE/csm-testing/pull/388