### PR TITLE
CASMINST-5312: Enable logging of additional tests

### DIFF
--- a/goss-testing/tests/common/goss-unbound-dns-entries.yaml
+++ b/goss-testing/tests/common/goss-unbound-dns-entries.yaml
@@ -22,15 +22,23 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Variable set: unbound_hostnames
+{{ $kubectl := .Vars.kubectl }}
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  {{range $hostname := index .Vars "unbound_hostnames"}}
-  unbound_hostname_{{$hostname}}:
-    title: Unbound Hostname '{{$hostname}}' Exists
-    meta:
-      desc: Validates the Unbound DNS hostname '{{$hostname}}' exists in the service configmap.
-      sev: 0
-    exec: "kubectl get cm -n services cray-dns-unbound -o yaml | grep '\"hostname\": \"{{$hostname}}\"'"
-    exit-status: 0
-    timeout: 20000
-    skip: false
-  {{end}}
+    {{range $hostname := index .Vars "unbound_hostnames"}}
+    {{ $testlabel := $hostname | printf "unbound_hostname_%s" }}
+    {{$testlabel}}:
+        title: Unbound Hostname '{{$hostname}}' Exists
+        meta:
+            desc: Validates the Unbound DNS hostname '{{$hostname}}' exists in the service configmap.
+            sev: 0
+        exec: |-
+            # The test should fail if the kubectl command fails
+            set -o pipefail
+            # The logrun command will log the output of the kubectl command, pre-grep
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$kubectl}}" get cm -n services cray-dns-unbound -o yaml | grep '"hostname": "{{$hostname}}"'
+        exit-status: 0
+        timeout: 20000
+        skip: false
+    {{end}}

--- a/goss-testing/tests/ncn/goss-k8s-nexus-pods-running.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-nexus-pods-running.yaml
@@ -21,13 +21,21 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+{{ $kubectl := .Vars.kubectl }}
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  k8s_service_nexus_running:
-    title: Kubernetes Service 'nexus' Is Running
-    meta:
-      desc: If this test fails, look at the state of the nexus pods (kubectl get po -n nexus) to investigate.
-      sev: 0
-    exec: kubectl get pods -n nexus -l app=nexus | awk '{ print $3 }' | grep Running
-    exit-status: 0
-    timeout: 20000
-    skip: false
+    {{ $testlabel := "k8s_service_nexus_running" }}
+    {{$testlabel}}:
+        title: Kubernetes Service 'nexus' Is Running
+        meta:
+            desc: If this test fails, look at the state of the nexus pods (kubectl get po -n nexus) to investigate.
+            sev: 0
+        exec: |-
+            # The test should fail if the kubectl command fails
+            set -o pipefail
+            # The logrun command will log the output of the kubectl command, pre-grep
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$kubectl}}" get pods -n nexus -l app=nexus | awk '{ print $3 }' | grep Running
+        exit-status: 0
+        timeout: 20000
+        skip: false

--- a/goss-testing/tests/ncn/goss-k8s-velero-backup-storage-locations-available.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-velero-backup-storage-locations-available.yaml
@@ -21,13 +21,21 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+{{ $kubectl := .Vars.kubectl }}
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  k8s_velero_backupstoragelocations:
-    title: Kubernetes Velero Backup Storage Locations Ready
-    meta:
-      desc: Validates All Velero Backup Storage Locations are Ready
-      sev: 0
-    exec: "kubectl get backupstoragelocation -A -o json | jq '.items[].status | select(.phase==\"Unavailable\")' | wc -l"
-    stdout:
-    - "/^0$/"
-    exit-status: 0
+    {{ $testlabel := "k8s_velero_backupstoragelocations" }}
+    {{$testlabel}}:
+        title: Kubernetes Velero Backup Storage Locations Ready
+        meta:
+            desc: Validates All Velero Backup Storage Locations are Ready
+            sev: 0
+        exec: |-
+            # The test should fail if the kubectl command fails
+            set -o pipefail
+            # The logrun command will log the output of the kubectl command, pre-jq and pre-wc
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$kubectl}}" get backupstoragelocation -A -o json | jq '.items[].status | select(.phase=="Unavailable")' | wc -l
+        stdout:
+        - "/^0$/"
+        exit-status: 0

--- a/goss-testing/tests/ncn/goss-k8s-velero-backup-vault-schedule-exists.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-velero-backup-vault-schedule-exists.yaml
@@ -21,13 +21,21 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+{{ $kubectl := .Vars.kubectl }}
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  k8s_velero_vault_daily_schedule:
-    title: Kubernetes Velero Daily Vault Backup Schedule Exists
-    meta:
-      desc: Kubernetes Velero Daily Vault Backup Schedule Exists
-      sev: 0
-    exec: "kubectl get schedule -A -o json | jq '.items[].metadata.name | contains(\"vault-daily-backup\")'"
-    stdout:
-    - "/^true$/"
-    exit-status: 0
+    {{ $testlabel := "k8s_velero_vault_daily_schedule" }}
+    {{$testlabel}}:
+        title: Kubernetes Velero Daily Vault Backup Schedule Exists
+        meta:
+            desc: Kubernetes Velero Daily Vault Backup Schedule Exists
+            sev: 0
+        exec: |-
+            # The test should fail if the kubectl command fails
+            set -o pipefail
+            # The logrun command will log the output of the kubectl command, pre-jq
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$kubectl}}" get schedule -A -o json | jq '.items[].metadata.name | contains("vault-daily-backup")'
+        stdout:
+        - "/^true$/"
+        exit-status: 0

--- a/goss-testing/tests/ncn/goss-spire-bss-metadata-exist.yaml
+++ b/goss-testing/tests/ncn/goss-spire-bss-metadata-exist.yaml
@@ -21,13 +21,17 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  spire_in_bss_cloudinit:
-    title: Kubernetes Query BSS Cloud-init for spire meta data
-    meta:
-      desc: If this test fails, then recreate the spire-update-bss-# job in the spire namespace. The job will add the Spire information to the meta-data service.
-      sev: 0
-    exec: |-
-      set -eo pipefail
-      curl api-gw-service-nmn.local:8888/meta-data | jq -e '.Global.spire.fqdn'
-    exit-status: 0
+    {{ $testlabel := "spire_in_bss_cloudinit" }}
+    {{$testlabel}}:
+        title: Kubernetes Query BSS Cloud-init for spire meta data
+        meta:
+            desc: If this test fails, then recreate the spire-update-bss-# job in the spire namespace. The job will add the Spire information to the meta-data service.
+            sev: 0
+        exec: |-
+            set -eo pipefail
+            # The logrun command will log the output of the curl command, pre-jq
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                curl api-gw-service-nmn.local:8888/meta-data | jq -e '.Global.spire.fqdn'
+        exit-status: 0

--- a/goss-testing/tests/ncn/goss-unbound-ip.yaml
+++ b/goss-testing/tests/ncn/goss-unbound-ip.yaml
@@ -22,15 +22,22 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Variable set: unbound_ip
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  unbound_ip_in_resolveconf:
-    title: Unbound Nameserver In resolv.conf
-    meta:
-      desc: Validates whether Unbound nameserver IP exists in resolv.conf.
-      sev: 0
-    # The fancy grep argument is to ensure that we don't have an IP in there which 
-    # contains the Unbound IP address as a substring.
-    exec: grep -E '^nameserver[[:space:]][[:space:]]*{{.Vars.unbound_ip}}([[:space:]]|$)' /etc/resolv.conf
-    exit-status: 0
-    timeout: 20000
-    skip: false
+    {{ $testlabel := "unbound_ip_in_resolveconf" }}
+    {{$testlabel}}:
+        title: Unbound Nameserver In resolv.conf
+        meta:
+            desc: Validates whether Unbound nameserver IP address exists in resolv.conf.
+            sev: 0
+        exec: |-
+            # We want the test to fail if the cat command fails
+            set -o pipefail
+            # We cat and pipe to grep so that we can save the contents of resolv.conf to the log, and also grep it.
+            # The fancy grep argument is to ensure that we don't have an IP in there which 
+            # contains the Unbound IP address as a substring.
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                cat /etc/resolv.conf | grep -E '^nameserver[[:space:]][[:space:]]*{{.Vars.unbound_ip}}([[:space:]]|$)' 
+        exit-status: 0
+        timeout: 20000
+        skip: false


### PR DESCRIPTION
## Summary and Scope

Add logging (using the existing logrun framework) to 6 additional tests:
* `common/goss-unbound-dns-entries.yaml`
* `ncn/goss-k8s-nexus-pods-running.yaml`
* `ncn/goss-k8s-velero-backup-storage-locations-available.yaml`
* `ncn/goss-k8s-velero-backup-vault-schedule-exists.yaml`
* `ncn/goss-spire-bss-metadata-exist.yaml`
* `ncn/goss-unbound-ip.yaml`

## Testing

I ran the updated tests on starlord and verified that they ran and logged correctly.

## Risks and Mitigations

Very low risk. The logrun tool is deliberately transparent, invisibly passing through the input, output, and return code, while logging to a file.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
