### PR TITLE
CASMINST-5316: Fix typo in k8s_kyverno_pods_running.sh

### DIFF
--- a/goss-testing/scripts/k8s_kyverno_pods_running.sh
+++ b/goss-testing/scripts/k8s_kyverno_pods_running.sh
@@ -41,7 +41,7 @@ done
 
 # Checks if all kyverno pods are running. There should be a total of 3 running pods.
 
-running_pods=$(kubectl get poda -n kyverno -o json | jq '[.items[] | select(.metadata.labels.app == "kyverno").status.containerStatuses[0].state.running] | length')
+running_pods=$(kubectl get pods -n kyverno -o json | jq '[.items[] | select(.metadata.labels.app == "kyverno").status.containerStatuses[0].state.running] | length')
 rc=$?
 if [[ ${rc} -ne 0 ]]
 then


### PR DESCRIPTION
## Summary and Scope

Fix the typo in the kubectl command noted in this PR comment:
https://github.com/Cray-HPE/csm-testing/pull/378#discussion_r964373353

## Risks and Mitigations

Very low risk -- the command does not work without correcting this typo.

```text
ncn-m001:~ # running_pods=$(kubectl get poda -n kyverno -o json | jq '[.items[] | select(.metadata.labels.app == "kyverno").status.containerStatuses[0].state.running] | length')
error: the server doesn't have a resource type "poda"
ncn-m001:~ # running_pods=$(kubectl get pods -n kyverno -o json | jq '[.items[]                                                                                          | select(.metadata.labels.app == "kyverno").status.containerStatuses[0].state.ru                                                                                         nning] | length')
ncn-m001:~ # echo $running_pods
3
```

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
