### PR TITLE
Point to cray bss as alternative to setting wipe flag w/out csi (CASMTRIAGE-4095)

### DIFF
--- a/goss-testing/tests/ncn/goss-boot-parameter-check-no-wipe.yaml
+++ b/goss-testing/tests/ncn/goss-boot-parameter-check-no-wipe.yaml
@@ -29,7 +29,7 @@ command:
     {{$testlabel}}:
         title: Check Boot Parameter is Set to Not Wipe the Disk (metal.no-wipe=1)
         meta:
-            desc: If this test fails, run `csi handoff bss-update-param --set metal.no-wipe=1 --limit <SERVER_XNAME>` to set metal.no-wipe to 1. This test is not meant to be run if the PIT has not been rebooted into m001 or if metal.no-wipe has been set to 0 for a node image upgrade.
+            desc: If this test fails, follow instructions at https://github.com/Cray-HPE/docs-csm/blob/main/operations/node_management/Rebuild_NCNs/Identify_Nodes_and_Update_Metadata.md to set metal.no-wipe to 1. This test is not meant to be run if the PIT has not been rebooted into m001 or if metal.no-wipe has been set to 0 for a node image upgrade.
             sev: 0
         exec: |-
             "{{$logrun}}" -l "{{$testlabel}}" \


### PR DESCRIPTION
## Summary and Scope

Fix for https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4095 -- point to cray bss command if wipe flag test fails.

## Issues and Related PRs

* Resolves [CASMTRIAGE-4095](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4095)

## Testing

Not a functional change

### Tested on:

N/A

### Test description:

N/A

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

