### PR TITLE
CASMINST-5352: Improve description and provide correct doc link for goss-unused-drives-on-storage-nodes test

### DIFF
--- a/goss-testing/tests/ncn/goss-unused-drives-on-storage-nodes.yaml
+++ b/goss-testing/tests/ncn/goss-unused-drives-on-storage-nodes.yaml
@@ -32,7 +32,11 @@ command:
     {{$testlabel}}:
         title: Check for unused drives on utility storage nodes
         meta:
-            desc: Validate that the Ceph cluster contains the expected number of OSDs based on the hardware type and number of storage nodes. If the test fails, refer to 'install/deploy_management_nodes.md' for remediation steps.
+            desc: |-
+                This test validates that the Ceph cluster contains the expected number of OSDs based on the hardware type and number of storage nodes.
+                If the test fails, then see "install/troubleshooting_unused_drives_on_storage_nodes.md" in the CSM documentation for remediation steps.
+                The test can be executed manually on any master NCN or the first three storage NCNs with the following command:
+                "{{$check_for_unused_drives}}" "{{$num_storage_nodes}}" "{{$this_node_manufacturer}}"
             sev: 0
         exec: |-
             "{{$logrun}}" -l "{{$testlabel}}" \


### PR DESCRIPTION
## Summary and Scope

The doc link provided in this test no longer existed. This PR updates it, as well as providing instructions on how to manually run the test.

## Issues and Related PRs

Associated docs PRs:
https://github.com/Cray-HPE/docs-csm/pull/2498
https://github.com/Cray-HPE/docs-csm/pull/2499

## Testing

I tested the updated test on surtur:
```text
Failures/Skipped:

Title: Check for unused drives on utility storage nodes
Meta:
    desc: This test validates that the Ceph cluster contains the expected number of OSDs based on the hardware type and number of storage nodes.
If the test fails, then see "install/troubleshooting_unused_drives_on_storage_nodes.md" in the CSM documentation for remediation steps.
The test can be executed manually on any master NCN or the first three storage NCNs with the following command:
"/opt/cray/tests/install/ncn/scripts/python/check_for_unused_drives.py" "3" "Hewlett Packard Enterprise"
    sev: 0
Command: unused_drives_on_storage_nodes: exit-status:
Expected
    <int>: 6
to equal
    <int>: 0
```

## Risks and Mitigations

Very low risk. Only changing the text description field of the test. No change to the test itself.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
