### PR TITLE
CASMINST-5371: Add logging to k8s_psp_enabled Goss test

### DIFF
--- a/goss-testing/scripts/k8s_psp_enabled_check.sh
+++ b/goss-testing/scripts/k8s_psp_enabled_check.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #
 # MIT License
 #

--- a/goss-testing/scripts/k8s_psp_enabled_check.sh
+++ b/goss-testing/scripts/k8s_psp_enabled_check.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Validate that PodSecurityPolicy is enabled for all kube-apiserver pods in the kube-system namespace
+# Return 0 if the check passes, non-0 otherwise
+
+# This script accepts no arguments
+if [[ $# -ne 0 ]]; then
+    echo "usage: k8s_psp_enabled_check.sh" 1>&2
+    exit 2
+fi
+
+# By running with these options, it will cut down on the amount of code devoted to error-checking and logging.
+# -e -> exit script in failure if any command fails
+# -u -> exit script in failure if any unset variable is referenced
+# -x -> print the commands that are being run
+# -o pipefail -> if any command in a command pipeline fails, the entire pipeline fails
+set -euxo pipefail
+
+# Get temporary file to use for storing command output, so that we can run commands, show their output, and also
+# parse the output with subsequent commands.
+TMPFILE=$(mktemp /tmp/.k8s_psp_enabled.$$.XXXXXX.tmp)
+
+# TMPFILE should now point to our temporary file
+[[ -n ${TMPFILE} ]]
+[[ -f ${TMPFILE} ]]
+
+# Write the list of kube-apiserver pod names to the screen and the temporary file
+kubectl get pods -n kube-system -l component=kube-apiserver -o custom-columns=:metadata.name --no-headers=true | tee "${TMPFILE}"
+
+# We will count the pods as we check them. The test will fail if no pods were found
+COUNT=0
+
+for PODNAME in $(cat "${TMPFILE}"); do
+    let COUNT+=1
+    
+    # Describe the pod, writing to the screen and the temporary file
+    kubectl describe -n kube-system pod "${PODNAME}" | tee "${TMPFILE}"
+
+    # Check for string we expect to see if PodSecurityPolicy is enabled. This grep command will fail if the string is absent, causing the test to fail.
+    grep -E '\-\-enable-admission-plugins=.*PodSecurityPolicy' "${TMPFILE}"
+done
+
+# We expect to have checked at least one pod (probably the actual expected number is higher, but for the purposes of this test, we just want to make sure we
+# actually checked something
+[[ $COUNT -gt 0 ]]
+
+# Remove the temporary file. On the off chance that this command fails, we do not want to fail the test. Hence the || true.
+rm "${TMPFILE}" || true
+
+# If we make it here, it means that no problems were found
+echo "PASS"
+exit 0

--- a/goss-testing/scripts/k8s_psp_enabled_check.sh
+++ b/goss-testing/scripts/k8s_psp_enabled_check.sh
@@ -63,12 +63,12 @@ for PODNAME in $(cat "${TMPFILE}"); do
     grep -E '\-\-enable-admission-plugins=.*PodSecurityPolicy' "${TMPFILE}"
 done
 
+# Remove the temporary file. On the off chance that this command fails, we do not want to fail the test. Hence the || true.
+rm "${TMPFILE}" || true
+
 # We expect to have checked at least one pod (probably the actual expected number is higher, but for the purposes of this test, we just want to make sure we
 # actually checked something
 [[ $COUNT -gt 0 ]]
-
-# Remove the temporary file. On the off chance that this command fails, we do not want to fail the test. Hence the || true.
-rm "${TMPFILE}" || true
 
 # If we make it here, it means that no problems were found
 echo "PASS"

--- a/goss-testing/tests/ncn/goss-k8s-psp-enabled.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-psp-enabled.yaml
@@ -21,13 +21,20 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
+{{ $logrun := $scripts | printf "%s/log_run.sh" }}
+{{ $k8s_psp_enabled_check := $scripts | printf "%s/k8s_psp_enabled_check.sh" }}
 command:
-  k8s_nodes_ready:
-    title: Validate PodSecurityPolicy is enabled
-    meta:
-      desc: If this test fails run the enable-psp.sh script to enable PodSecurityPolicy.
-      sev: 0
-    exec: "for pod in $(kubectl get pods -n kube-system -l component=kube-apiserver -o custom-columns=:metadata.name --no-headers=true); do if ! kubectl describe -n kube-system pod $pod | grep -Eq -- '--enable-admission-plugins=.*PodSecurityPolicy'; then exit 1; fi; done"
-    exit-status: 0
-    timeout: 20000
-    skip: false
+    {{ $testlabel := "k8s_psp_enabled" }}
+    {{$testlabel}}:
+        title: Validate that PodSecurityPolicy is enabled
+        meta:
+            desc: If this test fails, then run '/usr/share/doc/csm/upgrade/scripts/k8s/enable-psp.sh' to enable PodSecurityPolicy.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$k8s_psp_enabled_check}}"
+        exit-status: 0
+        timeout: 20000
+        skip: false


### PR DESCRIPTION
## Summary and Scope

Make the following modifications to the k8s_psp_enabled test:
- Change its Goss name field from "k8s_nodes_ready" to "k8s_psp_enabled"
- Move its checking logic into a separate shell script file (k8s_psp_enabled_check.sh)
- Enhance the checking logic by more carefully checking for command failures and unexpected situations
- Provide additional output when performing the checks, to make it clear what exactly happened
- Enable logging of the test using the logrun tool

Despite that being a long-ish list of changes, fundamentally it is still the same test using the same core logic.

If there is approval, I'll backport this into 1.3 as well. Otherwise it will be 1.4 only.

## Issues and Related PRs

This is part of an ongoing series of tickets in which I am adding test logging to those tests which still lack it.

## Testing

I ran the new test (both the script by itself and the updated Goss test) on rocket and verified that they worked as expected.

## Risks and Mitigations

Very low risk. It's still a pretty simple test. The logging is being done using the existing logrun tool.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
