### PR TITLE
CASMINST-5373: Add logging to k8s-precache-images-health test

### DIFF
--- a/goss-testing/tests/ncn/goss-k8s-precache-images-health.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-precache-images-health.yaml
@@ -21,15 +21,24 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $kubectl := .Vars.kubectl }}
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  precache-images-health:
-    title: Precaching of Docker Images on Workers is Healthy
-    meta:
-      desc: This test verifies the precache pods are successfully pulling the images referenced in the configmap (cray-precache-images) in the nexus namespace.  If this test fails, execute the following command to inspect the images that are failing to get pulled - 'kubectl -n nexus logs -l app.kubernetes.io/name=cray-precache-images --tail=100 | grep failed'.
-      sev: 0
-    exec: 'kubectl -n nexus logs -l app.kubernetes.io/name=cray-precache-images --tail=100 | grep failed | wc -l'
-    stdout:
-      - "0"
-    exit-status: 0
-    timeout: 20000
-    skip: false
+    {{ $testlabel := "k8s_precache_images_health" }}
+    {{$testlabel}}:
+        title: Precaching of Docker images on workers is healthy
+        meta:
+            desc: |-
+                This test verifies the precache pods are successfully pulling the images referenced in the configmap (cray-precache-images) in the nexus namespace.
+                If this test fails, then execute the following command to inspect the images that are failing to get pulled:
+                "kubectl -n nexus logs -l app.kubernetes.io/name=cray-precache-images --tail=100 | grep failed"
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$kubectl}}" -n nexus logs -l app.kubernetes.io/name=cray-precache-images --tail=100
+        exit-status: 0
+        stdout:
+        - "!failed"
+        timeout: 20000
+        skip: false


### PR DESCRIPTION
## Summary and Scope

This simplifies the k8s-precache-images-health test (by removing unnecessary grep and wc commands) and adds logrun logging of the kubectl command being run.

If there is approval, I'll backport this into 1.3 as well. Otherwise it will be 1.4 only.

## Issues and Related PRs

This is part of a series of tickets I'm using to add logging to the Goss tests which still lack it.

## Testing

I executed the updated test on rocket and verified that it still worked as expected.

## Risks and Mitigations

Very low risk. Test still checks the same thing, just in a simpler way. The logging was added using the existing logrun tool.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
