### PR TITLE
CASMTRIAGE-4185 edit number of expected osds in check for unused drives

### DIFF
--- a/goss-testing/scripts/python/check_for_unused_drives.py
+++ b/goss-testing/scripts/python/check_for_unused_drives.py
@@ -102,19 +102,21 @@ def parse_args():
     args = parser.parse_args()
 
     hw_type = hw_type_map[args.hw_type]
-    n_storage_nodes = args.num_storage_nodes
     min_expected_osds = min_osds_per_storage_node[hw_type] * args.num_storage_nodes
     max_expected_osds = max_osds_per_storage_node[hw_type] * args.num_storage_nodes
     logger.info("Based on hardware type ({}) and number of storage nodes ({}): min_expected_osds = {}, max_expected_osds = {}".format(hw_type, args.num_storage_nodes, min_expected_osds, max_expected_osds))
-    return min_expected_osds, max_expected_osds, n_storage_nodes
+    return min_expected_osds, max_expected_osds, args.num_storage_nodes
 
 def get_num_osds():
     logger.debug("Loading Ceph")
     ceph = rados.Rados(conffile=CEPH_CONFIG_FILE)
     logger.debug("Connecting to Ceph")
+    # connect to cluster
     ceph.connect()
     logger.info("Running ceph osd stat command")
     cmd_rc, cmd_out_bytes, cmd_opt_str = ceph.mon_command('{"prefix": "osd stat", "format": "json-pretty"}', b'')
+    #disconnect from cluster
+    ceph.shutdown()
     logger.info("Command return code = {}".format(cmd_rc))
     if cmd_opt_str:
         logger.info("Optional output string: {}".format(cmd_opt_str))


### PR DESCRIPTION
## Summary and Scope

In goss test "Check for unused drives on utility storage nodes", allow check to pass if #osds / #storage-nodes has no remainder. 

Previously, this check only allowed the following number of osds per storage node based on hardware:
    "gigabyte": 12,
    "hpe": 8,
    "intel": 1 or more

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-4185](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4185)
* Change will be backported to  `release/1.3`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * mug

### Test description:
 
- Tested script to directly on mug. Script runs well 
- Was unable to test goss test that calls this script as that goss test is only run on a pit node

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

