### PR TITLE
CASMTRIAGE-4269 - less restrictive boot param

### DIFF
--- a/goss-testing/scripts/data-validator.py
+++ b/goss-testing/scripts/data-validator.py
@@ -231,7 +231,7 @@ def boot_params(data):
 	"hostname=",
 	"ifname=mgmt0",
 	"ifname=mgmt1",
-	"initrd=initrd.img.xz",
+	"initrd=",
 	"iommu=pt",
 	"log_buf_len=1",
 	"metal.server=",


### PR DESCRIPTION
## Summary and Scope

The boot param test was too restrictive for **initrd**.

backwards compatible: yes

## Issues and Related PRs

https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4269

## Testing


### Tested on:

  * Rocket

## Risks and Mitigations

No known risks.


## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

