### PR TITLE
VSHA-477 add conditional check for tests that do not apply to vshasta

### DIFF
--- a/goss-testing/tests/common/goss-bond-members-have-correct-mtu.yaml
+++ b/goss-testing/tests/common/goss-bond-members-have-correct-mtu.yaml
@@ -38,4 +38,10 @@ command:
                 "{{$check_bond_members_have_correct_mtu}}" "{{$bond_member_mtu}}"
         exit-status: 0
         timeout: 20000
+        # skip this test on vshasta
+        {{ if eq true .Vars.vshasta }}
+        skip: true
+        {{ else }}
         skip: false
+        {{ end }}
+

--- a/goss-testing/tests/common/goss-services-enabled.yaml
+++ b/goss-testing/tests/common/goss-services-enabled.yaml
@@ -23,6 +23,8 @@
 #
 # Variable set: services_enabled
 service:
+  # set a var for vshasta
+  {{ $vs := .Vars.vshasta}}
   {{range $service := index .Vars "services_enabled"}}
   {{$service}}:
     title: Service '{{$service}}' Enabled
@@ -31,4 +33,12 @@ service:
       sev: 0
     enabled: true
     running: false
+    # skip testing conman on vshasta
+    {{ if eq $service "conman" }}
+    {{ if eq true $vs }}
+    skip: true
+    {{ else }}
+    skip: false
+    {{ end }}
+    {{ end }}
   {{end}}

--- a/goss-testing/tests/common/goss-services-running.yaml
+++ b/goss-testing/tests/common/goss-services-running.yaml
@@ -23,6 +23,8 @@
 #
 # Variable set: services_running
 service:
+  # set a var for vshasta
+  {{ $vs := .Vars.vshasta}}
   {{range $service := index .Vars "services_running"}}
   {{$service}}:
     title: Service '{{$service}}' Running
@@ -31,4 +33,12 @@ service:
       sev: 0
     running: true
     enabled: true
+   # skip testing conman on vshasta
+    {{ if eq $service "conman" }}
+    {{ if eq true $vs }}
+    skip: true
+    {{ else }}
+    skip: false
+    {{ end }}
+    {{ end }}
   {{end}}

--- a/goss-testing/tests/livecd/goss-bmc-check.yaml
+++ b/goss-testing/tests/livecd/goss-bmc-check.yaml
@@ -35,4 +35,9 @@ command:
                 ipmitool chassis status
         exit-status: 0
         timeout: 20000
+        # skip this test on vshasta 
+        {{ if eq true .Vars.vshasta }}
+        skip: true
+        {{ else }}
         skip: false
+        {{ end }}

--- a/goss-testing/tests/livecd/goss-chrony-config.yaml
+++ b/goss-testing/tests/livecd/goss-chrony-config.yaml
@@ -31,3 +31,9 @@ file:
     owner: root
     group: root
     filetype: file
+    # skip this test on vshasta
+    {{ if eq true .Vars.vshasta }}
+    skip: true
+    {{ else }}
+    skip: false
+    {{ end }}

--- a/goss-testing/tests/livecd/goss-firmware-bios-baseline.yaml
+++ b/goss-testing/tests/livecd/goss-firmware-bios-baseline.yaml
@@ -39,4 +39,9 @@ command:
         exit-status: 0
         stdout:
             - "!Unsupported"
+        # skip this test on vshasta (the HPC string is not found in this file)
+        {{ if eq true .Vars.vshasta }}
+        skip: true
+        {{ else }}
         skip: false
+        {{ end }}

--- a/goss-testing/vars/variables-livecd.yaml
+++ b/goss-testing/vars/variables-livecd.yaml
@@ -98,3 +98,5 @@ unbound_hostnames:
 bond_member_mtu: 1500
 
 pit_node: true
+# false by default--overriden when vshasta is deployed
+vshasta: false

--- a/goss-testing/vars/variables-ncn.yaml
+++ b/goss-testing/vars/variables-ncn.yaml
@@ -161,3 +161,5 @@ storage_fs_labels:
   - CONTAIN
 
 pit_node: false
+# false by default--overriden when vshasta is deployed
+vshasta: false


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

- Adds conditionals to skip a small subset of tests when a non-metal environment is detected such as vshasta.
- For metal installs, nothing changes besides the addition of a `vshasta: false` variable
- For `vshasta` installs, this value is overridden to `true` so that the irrelevant tests are skipped

Several tests are not applicable in vshasta, so this adds a simple check by checking for 'HPC' in the `/etc/os-release` file, which is not present on the nodes we deploy to GCP.

Using this logic, the tests still run on metal, but are skipped in a vshasta environment

## Issues and Related PRs

* Partially resolves VSHA-477
* Merge before https://github.com/Cray-HPE/livecd-gcp-infrastructure/pull/163

## Testing

### Tested on:

  * vshasta2
  * `#redbull`

### Test description:

#### on vshasta2

```
# installed the csm-testing and goss-servers rpm from my csm-testing branch
pit:~ # goss -g /opt/cray/tests/install/livecd/suites/livecd-preflight-tests.yaml --vars <(cat /opt/cray/tests/install/livecd/vars/variables-livecd.yaml <(if [ -f /etc/google_system ]; then echo "vshasta: true" | cat -; else echo "vshasta: false" | cat -; fi)) validate
S..S.....SS..SS....SSSS..................................

Failures/Skipped:

Title: BMC Connectivity
Meta:
    desc: Validates connectivity of the BMCs from the PIT node.
    sev: 0
Command: bmc_connectivity: exit-status: skipped

Title: Bond Members Have Correct MTU
Meta:
    desc: Validates that the bond0 interface members have an MTU of 1500. If the test fails, you may get more information by running it manually: /opt/cray/tests/install/livecd/scripts/check_bond_members_have_correct_mtu.sh 1500
    sev: 0
Command: bond_members_have_correct_mtu: exit-status: skipped

Title: Firmware and BIOS versions and baseline
Meta:
    desc: Validates the correct versions of BIOS and firmware; Validates BIOS settings (when available; dependent on vendor). If this test fails, run "/opt/cray/tests/install/livecd/scripts/check_bios_firmware_versions.sh -b" for more information on the failure. On GigaByte NCNs, a value of "null" may indicate that the BIOS/Firmware needs to be reflashed or that a hard AC power cycle is needed.
    sev: 0
Command: firmware_bios_versions: exit-status: skipped
Command: firmware_bios_versions: stdout: skipped

Title: Service 'conman' Running
Meta:
    desc: Checks whether service 'conman' is running.
    sev: 0
Service: conman: enabled: skipped
Service: conman: running: skipped
...
...
```

#### on `#redbuill`

Installed the same rpm, and ran the same command.  Also ran `csi pit validate --livecd-preflight` and verified it worked there as well.

```
Running LiveCD preflight checks (may take a few minutes to complete)...
WARNING: The PITDATA environment variable is not set.
Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20221012_163111.371052-113298-sxHZdBms/out

Running tests

Checking test results
Only errors will be printed to the screen

Node: redbull-ncn-m001-pit


GRAND TOTAL: 175 passed, 0 failed
```

## Risks and Mitigations

Low.  This adds a conditional on several tests that are not applicable in a vshasta environment.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

