### PR TITLE
VSHA-503 modify tests for use on vshasta

### DIFF
--- a/goss-testing/automated/run-ncn-tests.sh
+++ b/goss-testing/automated/run-ncn-tests.sh
@@ -48,7 +48,7 @@ function is_pit_node {
 function is_vshasta_node {
     # This is the best check for an image specifically booted to vshasta
     if [[ -f /etc/google_system ]]; then
-      return $?
+      return 0
     # metal images can still be booted on GCP, so check if there are any disks vendored by Google
     elif lsblk --noheadings -o vendor | grep Google >/dev/null; then
       return $?

--- a/goss-testing/automated/run-ncn-tests.sh
+++ b/goss-testing/automated/run-ncn-tests.sh
@@ -613,6 +613,10 @@ function add_local_vars {
 
     local this_node_name this_node_manufacturer var_string node nodes
 
+    if is_vshasta_node; then
+      var_string+="\nvshasta: true\n"
+    fi
+
     # Add local nodename as variable
     this_node_name=$(hostname -s | grep -Eo '(ncn-[msw][0-9]{3}|.*-pit)$')
     var_string="\n\nthis_node_name: \"${this_node_name}\"\n"

--- a/goss-testing/automated/run-ncn-tests.sh
+++ b/goss-testing/automated/run-ncn-tests.sh
@@ -47,17 +47,13 @@ function is_pit_node {
  
 function is_vshasta_node {
     # This is the best check for an image specifically booted to vshasta
-    if [[ -f /etc/google_system ]]; then
-      return 0
-    # metal images can still be booted on GCP, so check if there are any disks vendored by Google
-    elif lsblk --noheadings -o vendor | grep Google >/dev/null; then
-      return $?
-    else
-      # if the above conditions do not match, it is not running on GCP
-      return 1
-    fi
-}
+    [[ -f /etc/google_system ]] && return 0
 
+    # metal images can still be booted on GCP, so check if there are any disks vendored by Google
+    # if not, we conclude that this is not GCP
+    lsblk --noheadings -o vendor | grep -q Google
+    return $?
+}
 
 # Set some default variables here, both because we use them in this library, and also to save
 # scripts from having to set them if they source this library.
@@ -614,19 +610,25 @@ function add_local_vars {
     local this_node_name this_node_manufacturer var_string node nodes
 
     if is_vshasta_node; then
-      var_string+="\nvshasta: true\n"
+        # vshasta
+        var_string+="\nvshasta: true\n"
+
+        # Since we know this is vshasta, we directly set the node manufacturer variable, rather
+        # than the usual call to ipmitool
+        this_node_manufacturer=vshasta
+    else
+        # Not vshasta -- call ipmitool to determine node manufacturer
+        this_node_manufacturer=$(ipmitool mc info | 
+            grep -E "^Manufacturer Name[[:space:]]{1,}:[[:space:]]*[^[:space:]]" |
+            sed -e 's/^Manufacturer Name[[:space:]]*:[[:space:]]*//' -e 's/[[:space:]]*$//')
     fi
+    # Add hardware manufacturer as variable
+    var_string+="\nthis_node_manufacturer: \"${this_node_manufacturer}\"\n"
 
     # Add local nodename as variable
     this_node_name=$(hostname -s | grep -Eo '(ncn-[msw][0-9]{3}|.*-pit)$')
     var_string="\n\nthis_node_name: \"${this_node_name}\"\n"
     
-    # Add hardware manufacturer as variable
-    this_node_manufacturer=$(ipmitool mc info | 
-        grep -E "^Manufacturer Name[[:space:]]{1,}:[[:space:]]*[^[:space:]]" |
-        sed -e 's/^Manufacturer Name[[:space:]]*:[[:space:]]*//' -e 's/[[:space:]]*$//')
-    var_string+="\nthis_node_manufacturer: \"${this_node_manufacturer}\"\n"
-
     # Get NCN list
     nodes=$(get_ncns)
 

--- a/goss-testing/automated/run-ncn-tests.sh
+++ b/goss-testing/automated/run-ncn-tests.sh
@@ -44,6 +44,20 @@ function is_pit_node {
     [[ -f /etc/pit-release ]]
     return $?
 }
+ 
+function is_vshasta_node {
+    # This is the best check for an image specifically booted to vshasta
+    if [[ -f /etc/google_system ]]; then
+      return $?
+    # metal images can still be booted on GCP, so check if there are any disks vendored by Google
+    elif lsblk --noheadings -o vendor | grep Google >/dev/null; then
+      return $?
+    else
+      # if the above conditions do not match, it is not running on GCP
+      return 1
+    fi
+}
+
 
 # Set some default variables here, both because we use them in this library, and also to save
 # scripts from having to set them if they source this library.

--- a/goss-testing/scripts/python/check_for_unused_drives.py
+++ b/goss-testing/scripts/python/check_for_unused_drives.py
@@ -76,17 +76,20 @@ logger.addHandler(stderr_handler)
 hw_type_map = {
     "GIGA-BYTE TECHNOLOGY CO., LTD": "gigabyte",
     "Hewlett Packard Enterprise": "hpe",
-    "Intel Corporation": "intel" }
+    "Intel Corporation": "intel",
+    "vshasta": "vshasta" }
 
 min_osds_per_storage_node = {
     "gigabyte": 12,
     "hpe": 8,
-    "intel": 1 }
+    "intel": 1,
+    "vshasta": 2 }
 
 max_osds_per_storage_node = {
     "gigabyte": 12,
     "hpe": 8,
-    "intel": 0 }
+    "intel": 0,
+    "vshasta": 0 }
 
 def num_storage_nodes(string):
     num = int(string)

--- a/goss-testing/tests/common/goss-interface-has-ip.yaml
+++ b/goss-testing/tests/common/goss-interface-has-ip.yaml
@@ -22,7 +22,10 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Variable set: network_interfaces
+
 command:
+# set a var for vshasta
+{{ $vs := .Vars.vshasta}}
 {{range $interface := index .Vars "network_interfaces"}}
   check_interface_ip_{{$interface}}:
     title: Interface '{{$interface}}' Has IP
@@ -39,5 +42,9 @@ command:
     stdout:
     - PASS
     timeout: 20000
+    {{ if eq true $vs }}
+    skip: true
+    {{ else }}
     skip: false
+    {{ end }}
 {{end}}

--- a/goss-testing/tests/common/goss-interfaces-have-same-mac.yaml
+++ b/goss-testing/tests/common/goss-interfaces-have-same-mac.yaml
@@ -21,6 +21,8 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+# set a var for vshasta
+{{ $vs := .Vars.vshasta}}
 # Variable set: network_interfaces
 {{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
 {{ $logrun := $scripts | printf "%s/log_run.sh" }}
@@ -36,4 +38,8 @@ command:
         {{.Env.GOSS_BASE}}/scripts/check_interface_mac_matches_bond.sh {{range.Vars.network_interfaces}}{{.}} {{end}}
     exit-status: 0
     timeout: 20000
+    {{ if eq true $vs }}
+    skip: true
+    {{ else }}
     skip: false
+    {{ end }}

--- a/goss-testing/tests/common/goss-ncns-in-dnsmasq-leases.yaml
+++ b/goss-testing/tests/common/goss-ncns-in-dnsmasq-leases.yaml
@@ -32,4 +32,9 @@ command:
     - PASS
     exit-status: 0
     timeout: 20000
+    # skip this test on vshasta 
+    {{ if eq true .Vars.vshasta }}
+    skip: true
+    {{ else }}
     skip: false
+    {{ end }}

--- a/goss-testing/tests/common/goss-network-interfaces.yaml
+++ b/goss-testing/tests/common/goss-network-interfaces.yaml
@@ -23,6 +23,8 @@
 #
 # Variable set: network_interfaces
 
+# set a var for vshasta
+{{ $vs := .Vars.vshasta}}
 {{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
 {{ $logrun := $scripts | printf "%s/log_run.sh" }}
 {{ $check_network_interface := $scripts | printf "%s/check_network_interface.sh" }}
@@ -39,5 +41,9 @@ command:
                     "{{$check_network_interface}}" "{{$interface}}"
             exit-status: 0
             timeout: 20000
+            {{ if eq true $vs }}
+            skip: true
+            {{ else }}
             skip: false
+            {{ end }}
     {{end}}

--- a/goss-testing/tests/livecd/goss-net-dhcp-pools-in-dnsmasq_d-are-correctly-defined.yaml
+++ b/goss-testing/tests/livecd/goss-net-dhcp-pools-in-dnsmasq_d-are-correctly-defined.yaml
@@ -32,4 +32,9 @@ command:
     stdout:
       - "!FAIL"
     timeout: 20000
+    # skip this test on vshasta 
+    {{ if eq true .Vars.vshasta }}
+    skip: true
+    {{ else }}
     skip: false
+    {{ end }}

--- a/goss-testing/tests/livecd/goss-rgw-cert-valid.yaml
+++ b/goss-testing/tests/livecd/goss-rgw-cert-valid.yaml
@@ -30,4 +30,9 @@ command:
     exec: 'curl --insecure -vvI https://rgw-vip.nmn 2>&1 | grep "expire date:"'
     exit-status: 0
     timeout: 20000
+    # skip this test on vshasta 
+    {{ if eq true .Vars.vshasta }}
+    skip: true
+    {{ else }}
     skip: false
+    {{ end }}

--- a/goss-testing/tests/ncn/goss-weave-health.yaml
+++ b/goss-testing/tests/ncn/goss-weave-health.yaml
@@ -42,3 +42,8 @@ command:
         stdout:
             - "!IP allocation was seeded by different peers"
         timeout: 20000
+        {{ if eq true .Vars.vshasta }}
+        skip: true
+        {{ else }}
+        skip: false
+        {{ end }}

--- a/goss-testing/vars/variables-common.yaml
+++ b/goss-testing/vars/variables-common.yaml
@@ -66,3 +66,5 @@ k8s_ceph_csi_secrets:
   - csi-sma-secret
 
 kubectl: "/usr/bin/kubectl"
+# false by default--overriden when vshasta is deployed
+vshasta: false

--- a/start-goss-servers.sh
+++ b/start-goss-servers.sh
@@ -87,21 +87,13 @@ goss_suites_endpoints_ports | while read suite endpoint port ; do
         continue
     fi
 
-    if is_vshasta_node; then 
-      # Use junit for vshasta
-      echo "starting ${endpoint} in background on port ${port} (vshasta detected)"
-      /usr/bin/goss -g "${suite}" --vars "${tmpvars}" serve \
-          --format junit --max-concurrent 4 \
-          --endpoint "/${endpoint}" \
-          --listen-addr "${ip}:${port}" &
-    else
-      # Start Goss server for this entry.
-      echo "starting ${endpoint} in background on port ${port}"
-      /usr/bin/goss -g "${suite}" --vars "${tmpvars}" serve \
-          --format json --max-concurrent 4 \
-          --endpoint "/${endpoint}" \
-          --listen-addr "${ip}:${port}" &
-    fi
+    # Start Goss server for this entry.
+    echo "starting ${endpoint} in background on port ${port}"
+    /usr/bin/goss -g "${suite}" --vars "${tmpvars}" serve \
+        --format "${results_format}" \
+        --max-concurrent 4 \
+        --endpoint "/${endpoint}" \
+        --listen-addr "${ip}:${port}" &
 done
 echo "Goss servers started in background"
 

--- a/start-goss-servers.sh
+++ b/start-goss-servers.sh
@@ -61,11 +61,19 @@ while true ; do
 done
 
 if is_vshasta_node; then
-  # on vshasta there is only one network and no hmn
-  ip=$(host "$(hostname)" | grep -Po '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
+    echo "vshasta detected."
+
+    # Use junit for vshasta
+    results_format=junit
+
+    # on vshasta there is only one network and no hmn
+    ip=$(host "$(hostname)" | grep -Po '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
 else
-  # for security reasons we only want to run the servers on the HMN network, which is not connected to open Internet
-  ip=$(host "$(hostname).hmn" | grep -Po '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
+    # for security reasons we only want to run the servers on the HMN network, which is not connected to open Internet
+    ip=$(host "$(hostname).hmn" | grep -Po '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
+    
+    # Return results in JSON format outside of vshasta
+    results_format=json
 fi
 [[ -z ${ip} ]] && exit 2
 


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

Add vshasta support to some existing tests by adding a conditional.

Adds a `is_vshasta_node` function.



## Issues and Related PRs


* Partially resolves VSHA-503
* Works with https://github.com/Cray-HPE/livecd-gcp-infrastructure/pull/174

## Testing

### Tested on:

  * `#redbull`
  * Virtual Shasta

### Test description:

Executed the tests on a vshasta environment and saw the tests were skipped.

The function works on a vshasta pit node:

```
pit:~ # is_vshasta_node ; echo $?
+ [[ -f /etc/google_system ]]
+ return 0
+ echo 0
0
pit:~ #
```

a metal image booted to vshasta:

```
ncn-m002:~ # is_vshasta_node ; echo $?
+ [[ -f /etc/google_system ]]
+ grep --color=auto Google
+ lsblk --noheadings -o vendor
+ return 0
+ echo 0
0
```

and a metal node:

```
redbull-ncn-m001-pit:~ # is_vshasta_node ; echo $?
+ [[ -f /etc/google_system ]]
+ grep Google
+ lsblk --noheadings -o vendor
+ return 1
+ echo 1
1
```

## Risks and Mitigations

Low


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

