### PR TITLE
VSHA-503 fix tmp vars not creating correctly

### DIFF
--- a/goss-testing/automated/run-ncn-tests.sh
+++ b/goss-testing/automated/run-ncn-tests.sh
@@ -607,16 +607,16 @@ function add_local_vars {
         return 1
     fi
 
-    local this_node_name this_node_manufacturer var_string node nodes
+    local this_node_name this_node_manufacturer var_string node nodes is_vshasta
 
     if is_vshasta_node; then
         # vshasta
-        var_string+="\nvshasta: true\n"
-
+        is_vshasta="\nvshasta: true\n"
         # Since we know this is vshasta, we directly set the node manufacturer variable, rather
         # than the usual call to ipmitool
         this_node_manufacturer=vshasta
     else
+        is_vshasta="\nvshasta: false\n"
         # Not vshasta -- call ipmitool to determine node manufacturer
         this_node_manufacturer=$(ipmitool mc info | 
             grep -E "^Manufacturer Name[[:space:]]{1,}:[[:space:]]*[^[:space:]]" |
@@ -649,6 +649,8 @@ function add_local_vars {
     for node in $(echo "${nodes}" | grep -oE "ncn-s[0-9]{3}") ; do
         var_string+="  - ${node}\n"
     done
+
+    var_string+="\n${is_vshasta}\n"
 
     echo -e "${var_string}" >> "$1"
     return $?

--- a/goss-testing/tests/ncn/goss-ceph-status.yaml
+++ b/goss-testing/tests/ncn/goss-ceph-status.yaml
@@ -47,4 +47,9 @@ command:
                     /usr/bin/ceph -s
             exit-status: 0
             timeout: 20000
+            {{ if eq true .Vars.vshasta }}
+            skip: true
+            {{ else }}
+            skip: false
+            {{ end }}
     {{end}}


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>

## Summary and Scope

- #414 did not actually create the temporary variables correctly.  This adjusts that.
- required by https://github.com/Cray-HPE/livecd-gcp-infrastructure/pull/174

## Issues and Related PRs

* Resolves VSHA-503
## Testing

Ran the weave test, known to fail without the var, and watched it pass.

### Tested on:

  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

