### PR TITLE
CASMINST-5677: print_goss_json_results: Produce log file consumable by grok-exporter

### DIFF
--- a/goss-testing/automated/python/lib/common.py
+++ b/goss-testing/automated/python/lib/common.py
@@ -167,18 +167,32 @@ def goss_env_variables() -> dict:
         "GOSS_SERVERS_CONFIG": goss_servers_config()
     }
 
-def log_dir(script_name: str) -> str:
+def timestamp_string() -> str:
+    return datetime.now().strftime('%Y%m%d_%H%M%S.%f')
+
+def strip_path_and_extension(filepath: str) -> str:
+    """
+    Given the pathname to a file, strip off the path (if any)
+    and the extension (if any)
+    """
+    return filepath.split('/')[-1]
+
+def time_pid_unique_string() -> str:
+    mypid = os.getpid()
+    timestamp = timestamp_string()
+    randstring = ''.join(random.choices(string.ascii_lowercase + string.digits + string.ascii_uppercase, k=8))
+    return f"{timestamp}-{mypid}-{randstring}"
+
+def log_dir(script_name: str, sub_directory_basename: str=None) -> str:
     # Strip off path and .py, if present, in script name
-    script_name = script_name.split('/')[-1]
+    script_name = strip_path_and_extension(script_name)
     if script_name[-3:] == ".py":
         script_name = script_name[:-3]
 
-    mypid = os.getpid()
-    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S.%f')
-    randstring = ''.join(random.choices(string.ascii_lowercase + string.digits + string.ascii_uppercase, k=8))
-
+    if sub_directory_basename is None:
+        sub_directory_basename = time_pid_unique_string()
     glbd = goss_log_base_dir()
-    return f"{glbd}/{script_name}/{timestamp}-{mypid}-{randstring}"
+    return f"{glbd}/{script_name}/{sub_directory_basename}"
 
 def log_values(logmethod: Callable, **kwargs) -> None:
     for k, v in kwargs.items():


### PR DESCRIPTION
## Summary and Scope

This modifies print_goss_json_results.py so that it creates an additional log file, suitable for consumption by grok-exporter. Specifically, this new log file meets the two requirements that the current log files fail to:
1) Its directory name is static, not dynamic (it logs to `/opt/cray/tests/install/logs/grok_exporter/`)
2) Its log entries do not span multiple lines (data that would normally span multiple lines is converted into a JSON string with newlines (if any) escaped).

No existing function of the tool has changed -- only this additional thing added.

## Issues and Related PRs

- Resolves [CASMINST-5677](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5677)
- Needed as part of epic [CASM-3373](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3373)

## Testing

I tested this on frigg and verified that it works and produced the expected log files.

## Risks and Mitigations

Minor risk. The changes were only to limited parts of the script, which were covered by the testing I performed.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

