### PR TITLE
CASMINST-5766: Use CMN for Keycloak access, use DNS query vs. ping for test

### DIFF
--- a/goss-testing/tests/ncn/goss-k8s-resolve-external-dns.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-resolve-external-dns.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/goss-testing/tests/ncn/goss-k8s-resolve-external-dns.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-resolve-external-dns.yaml
@@ -77,7 +77,7 @@ command:
               echo "LDAP provider is configured, but the connectionURL is missing from LDAP configuration."
               exit 1
            else
-              echo "Attempting to resolved (A record) ${CONNECTION_URL}"
+              echo "Attempting to resolve (A record) ${CONNECTION_URL}"
               host -4 -t A ${CONNECTION_URL}
            fi 
 

--- a/goss-testing/tests/ncn/goss-k8s-resolve-external-dns.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-resolve-external-dns.yaml
@@ -71,7 +71,7 @@ command:
            echo "Unbound and LDAP are configured" 
            CONNECTION_URL=$(curl -s -H "Authorization: Bearer $(get_master_token)" \
                         ${INGRESS}/keycloak/admin/realms/shasta/components \
-                        | jq -r '.[] | select(.providerId=="ldap").config.connectionUrl[]' | cut -d / -f 3)
+                        | jq -r '.[] | select(.providerId=="ldap").config.connectionUrl[]' | cut -d / -f 3  | cut -d: -f 1)
 
            if [[ ! $CONNECTION_URL ]]; then
               echo "LDAP provider is configured, but the connectionURL is missing from LDAP configuration."

--- a/goss-testing/tests/ncn/goss-k8s-resolve-external-dns.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-resolve-external-dns.yaml
@@ -35,20 +35,28 @@ command:
           # Fail if the LDAP providerId is configured but the LDAP connectionURL is not.
           # Pass/Fail based on exit code from ping of the LDAP server.
 
+          # Get the SYSTEM_DOMAIN from cloud-init
+          SYSTEM_NAME=$(craysys metadata get system-name)
+          SITE_DOMAIN=$(craysys metadata get site-domain)
+          SYSTEM_DOMAIN=${SYSTEM_NAME}.${SITE_DOMAIN}
+
+          # Use the CMN LB/Ingress
+          INGRESS="https://auth.cmn.${SYSTEM_DOMAIN}"
+
           function get_master_token {
 
               MASTER_USERNAME=$(kubectl get secret -n services keycloak-master-admin-auth -ojsonpath='{.data.user}' | base64 -d)
               MASTER_PASSWORD=$(kubectl get secret -n services keycloak-master-admin-auth -ojsonpath='{.data.password}' | base64 -d)
 
               curl -ks -d client_id=admin-cli -d username=$MASTER_USERNAME --data-urlencode password="$MASTER_PASSWORD" \
-                   -d grant_type=password https://api-gw-service-nmn.local/keycloak/realms/master/protocol/openid-connect/token | jq -r '.access_token'; 
+                   -d grant_type=password ${INGRESS}/keycloak/realms/master/protocol/openid-connect/token | jq -r '.access_token'; 
            }
    
            FORWARD_ADDR=$(kubectl -n services get cm cray-dns-unbound -o jsonpath='{.data.unbound\.conf}' \
                           | grep "forward-zone:" -A 5 | yq r  - '"forward-zone"."forward-addr"')
 
            LDAP_PROVIDER=$(curl -s -H "Authorization: Bearer $(get_master_token)" \
-                          https://api-gw-service-nmn.local/keycloak/admin/realms/shasta/components | jq -r '.[] | select(.providerId=="ldap")')
+                          ${INGRESS}/keycloak/admin/realms/shasta/components | jq -r '.[] | select(.providerId=="ldap")')
 
            if [[ ! $FORWARD_ADDR ]]; then 
               echo "Unbound must be configured for this test."
@@ -62,14 +70,15 @@ command:
 
            echo "Unbound and LDAP are configured" 
            CONNECTION_URL=$(curl -s -H "Authorization: Bearer $(get_master_token)" \
-                        https://api-gw-service-nmn.local/keycloak/admin/realms/shasta/components \
+                        ${INGRESS}/keycloak/admin/realms/shasta/components \
                         | jq -r '.[] | select(.providerId=="ldap").config.connectionUrl[]' | cut -d / -f 3)
 
            if [[ ! $CONNECTION_URL ]]; then
               echo "LDAP provider is configured, but the connectionURL is missing from LDAP configuration."
               exit 1
            else
-              ping -q -c 1 $CONNECTION_URL
+              echo "Attempting to resolved (A record) ${CONNECTION_URL}"
+              host -4 -t A ${CONNECTION_URL}
            fi 
 
     exit-status: 0


### PR DESCRIPTION
## Summary and Scope

Update load-balancer ingress path to use for Keycloak interaction, given the master realm admin auth is being requested. This as the CMN LB, specifically the `auth.cmn.*` ingress paths are now supported for master realm administration. 

Use a DNS A record query instead of ping, this to address CAST-31571 as a tangent. 

This should be backward compatible with all releases that included CMN. 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-5766](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5766)
* Resolves [CAST-31571](https://jira-pro.its.hpecorp.net:8443/browse/CAST-31571)
* Caused by [CASMSEC-371](https://jira-pro.its.hpecorp.net:8443/browse/CASMSEC-371)

## Testing

Tested by editing test in place on Fanta, running CSM 1.3.1, beta 8, restarting goss servers on m001, and verifying successful test. Negative case verified by altering the host to use a nonsensical sub-domain. 

### Tested on:

  * Fanta

## Pull Request Checklist

- [X] Copyrights updated
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

