### PR TITLE
MTL-1708 Part 2 - Publish `goss-servers`

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -106,7 +106,14 @@ pipeline {
                                         component: env.NAME,
                                         isStable: isStable,
                                         os: "sle-${sles_major}sp${sles_minor}",
-                                        pattern: "dist/rpmbuild/RPMS/noarch/*.rpm",
+                                        pattern: "dist/rpmbuild/RPMS/noarch/${env.NAME}-*.rpm",
+                                )
+                                publishCsmRpms(
+                                        arch: "noarch",
+                                        component: 'goss-servers',
+                                        isStable: isStable,
+                                        os: "sle-${sles_major}sp${sles_minor}",
+                                        pattern: "dist/rpmbuild/RPMS/noarch/goss-servers-*.rpm",
                                 )
                                 publishCsmRpms(
                                         arch: "src",


### PR DESCRIPTION
`goss-servers` needs a different name for the `component` field when invoking the csm-shared-library function.
