### PR TITLE
CASMINST-5793: print_goss_json_results: Do not use scientific notation when logging test duration in seconds; minor bug fixes

### DIFF
--- a/goss-testing/automated/python/lib/grok_exporter_logger.py
+++ b/goss-testing/automated/python/lib/grok_exporter_logger.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -36,7 +36,7 @@ import json
 import logging
 from typing import Any, Dict, TextIO, Tuple
 
-from .common import timestamp_string
+from .common import fmt_exc, stderr_print, timestamp_string
 
 
 # Simplified type hints to use for JSON-able dicts.
@@ -44,10 +44,41 @@ JSONDict = Dict[str, Any]
 
 GROK_EXPORTER_LOG_DIR = "/opt/cray/tests/install/logs/grok_exporter"
 
+def data_to_json(obj) -> str:
+    """
+    We want to be able to override the formatting that is used by default by the
+    Python json module. In particular, we want to avoid use of scientific notation for
+    some floating point numbers (test duration in seconds, specifically). Unfortunately,
+    the JSON module does not offer this as an option. Instead, this function will
+    generate a JSON string from any object passed into it.
+    """
+    # Use the to_json method if it exists
+    try:
+        return obj.to_json()
+    except (AttributeError, TypeError):
+        # The custom method does not exist or is not callable
+        pass
+    # For dicts and lists we cannot call json.dumps on them, because that would not handle the case
+    # where items in those containers had custom to_json methods. Fortunately, since
+    # dicts and lists are the only containers supported by JSON, we just need to add some simple
+    # code here to handle those.
+    if isinstance(obj, dict):
+        items_json_list = [f"{data_to_json(key)}: {data_to_json(value)}"
+                           for key, value in obj.items()]
+        return "{%s}" % ", ".join(items_json_list)
+    elif isinstance(obj, list):
+        items_json_list = [data_to_json(item) for item in obj]
+        return "[%s]" % ", ".join(items_json_list)
+    # Otherwise, just call regular json.dumps on it, since this should mean it is a primitive
+    # type like int, float, str, or bool. If it is not, then the json module will raise an
+    # exception, which is what we want.
+    return json.dumps(obj)
+
 class LogEntry:
     field_position = { "log_timestamp": 1, "Product": 2, "log_script": 3, "log_message": 4 }
 
-    def field_order_key(field_name) -> Tuple[int, str]:
+    @classmethod
+    def field_order_key(cls, field_name: str) -> Tuple[int, str]:
         """
         Class method that returns a value used to sort the log entry field keys.
         The first four fields are (in order) log_timestamp, Product, log_script, and log_message
@@ -57,7 +88,7 @@ class LogEntry:
         # For the fixed fields, the integer in the tuple will be set to the position for that field.
         # Otherwise, the integer will be set to a fixed higher value. Thus, for these fields, their
         # names will end up being how they are sorted.
-        return (LogEntry.field_position.get(field_name, len(LogEntry.field_position)+1), field_name)
+        return (cls.field_position.get(field_name, len(cls.field_position)+1), field_name)
 
 
     def __init__(self, message: str, script_name: str, product: str, data: JSONDict=None
@@ -82,9 +113,9 @@ class LogEntry:
                             "log_message": message }
         for field_name, field_value in updated_fields.items():
             if field_name in logdata:
-                logger.warning(f"grok_exporter_logger.set_data_field: Field '{field_name}' "
-                               f"already set to '{logdata[field_name]}'; "
-                               f"overwriting it to '{field_value}'")
+                logging.warning(f"grok_exporter_logger.set_data_field: Field '{field_name}' "
+                                f"already set to '{logdata[field_name]}'; "
+                                f"overwriting it to '{field_value}'")
             logdata[field_name] = field_value
 
         # Generate ordered dict of the data
@@ -93,7 +124,7 @@ class LogEntry:
 
         # Generate the log string
         try:
-            self.json_string = json.dumps(ordered_data)
+            self.json_string = data_to_json(ordered_data)
         except TypeError as exc:
             msg = f"Error encoding data for grok-exporter log. {fmt_exc(exc)}"
             logging.error(msg)


### PR DESCRIPTION
## Summary and Scope

Sumith R B requested that print_goss_json_results not use scientific notation for test durations in the log file consumed by grok exporter. This PR makes that change, and also fixes some small bugs that I found while coding and testing this change.

## Issues and Related PRs

[CASMINST-5793](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5793)

## Testing

The change is not large, but the code path is one which is hit a lot, since every test result that is parsed is also logged. However, because of this, it was easy to do extensive testing of this. I did so on wasp. To the end user, there is no change. The only external difference is in the format of the grok exporter log file.

Sumith also tested the new code on mug and verified that it produced logs that could be consumed by grok exporter.

## Risks and Mitigations

If this is omitted, then not only will the grok exporter not be able to consume the logs properly, but the bugs I fixed will remain. They were in error paths in the code, but they would make problems harder to debug when they occur (since they relate to the script logging exceptions). I think the risk of not including this is worse than the risk of including it.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
