### PR TITLE
CASMINST-5838: Use CMN for Keycloak access, use DNS query vs. ping for test

### DIFF
--- a/goss-testing/tests/ncn/goss-k8s-resolve-external-dns.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-resolve-external-dns.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -35,20 +35,28 @@ command:
           # Fail if the LDAP providerId is configured but the LDAP connectionURL is not.
           # Pass/Fail based on exit code from ping of the LDAP server.
 
+          # Get the SYSTEM_DOMAIN from cloud-init
+          SYSTEM_NAME=$(craysys metadata get system-name)
+          SITE_DOMAIN=$(craysys metadata get site-domain)
+          SYSTEM_DOMAIN=${SYSTEM_NAME}.${SITE_DOMAIN}
+
+          # Use the CMN LB/Ingress
+          INGRESS="https://auth.cmn.${SYSTEM_DOMAIN}"
+
           function get_master_token {
 
               MASTER_USERNAME=$(kubectl get secret -n services keycloak-master-admin-auth -ojsonpath='{.data.user}' | base64 -d)
               MASTER_PASSWORD=$(kubectl get secret -n services keycloak-master-admin-auth -ojsonpath='{.data.password}' | base64 -d)
 
               curl -ks -d client_id=admin-cli -d username=$MASTER_USERNAME --data-urlencode password="$MASTER_PASSWORD" \
-                   -d grant_type=password https://api-gw-service-nmn.local/keycloak/realms/master/protocol/openid-connect/token | jq -r '.access_token'; 
+                   -d grant_type=password ${INGRESS}/keycloak/realms/master/protocol/openid-connect/token | jq -r '.access_token'; 
            }
    
            FORWARD_ADDR=$(kubectl -n services get cm cray-dns-unbound -o jsonpath='{.data.unbound\.conf}' \
                           | grep "forward-zone:" -A 5 | yq r  - '"forward-zone"."forward-addr"')
 
            LDAP_PROVIDER=$(curl -s -H "Authorization: Bearer $(get_master_token)" \
-                          https://api-gw-service-nmn.local/keycloak/admin/realms/shasta/components | jq -r '.[] | select(.providerId=="ldap")')
+                          ${INGRESS}/keycloak/admin/realms/shasta/components | jq -r '.[] | select(.providerId=="ldap")')
 
            if [[ ! $FORWARD_ADDR ]]; then 
               echo "Unbound must be configured for this test."
@@ -62,14 +70,15 @@ command:
 
            echo "Unbound and LDAP are configured" 
            CONNECTION_URL=$(curl -s -H "Authorization: Bearer $(get_master_token)" \
-                        https://api-gw-service-nmn.local/keycloak/admin/realms/shasta/components \
-                        | jq -r '.[] | select(.providerId=="ldap").config.connectionUrl[]' | cut -d / -f 3)
+                        ${INGRESS}/keycloak/admin/realms/shasta/components \
+                        | jq -r '.[] | select(.providerId=="ldap").config.connectionUrl[]' | cut -d / -f 3  | cut -d: -f 1)
 
            if [[ ! $CONNECTION_URL ]]; then
               echo "LDAP provider is configured, but the connectionURL is missing from LDAP configuration."
               exit 1
            else
-              ping -q -c 1 $CONNECTION_URL
+              echo "Attempting to resolve (A record) ${CONNECTION_URL}"
+              host -4 -t A ${CONNECTION_URL}
            fi 
 
     exit-status: 0


### PR DESCRIPTION
Forward port from release/1.3: Use CMN for Keycloak access, use DNS query vs. ping for test

(cherry picked from commit 98eaf915080f6ee3ab08678144d9741af3d1b0fc)

Tested on Wasp (1.4.0-beta.36) by patching test in place on m002, restarting `goss-servers` on m002, and then running `/opt/cray/tests/install/ncn/automated/ncn-k8s-combined-healthcheck` on the PIT. 

See: https://github.com/Cray-HPE/csm-testing/pull/422

