### PR TITLE
CASMINST-5850:  Make check_static_routes.sh handle undefined RVR networks and also test MTN networks

### DIFF
--- a/goss-testing/scripts/check_static_routes.sh
+++ b/goss-testing/scripts/check_static_routes.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -168,10 +168,28 @@ echo $rttbl | grep -q "$nmnlb_cidr via $nmngw dev bond0.nmn0" && nmnlb_passed=tr
 echo_stdout "INFO: NMNLB CIDR is $nmnlb_cidr - route found = $nmnlb_passed"
 
 # Check for NMN_RVR static route
-nmnrvr_cidr=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks/NMN_RVR | jq -r '.ExtraProperties.Subnets[0].CIDR')
-nmnrvr_passed=false
-echo $rttbl | grep -q "$nmnrvr_cidr via $nmngw dev bond0.nmn0" && nmnrvr_passed=true
-echo_stdout "INFO: NMNLB CIDR is $nmnrvr_cidr - route found = $nmnrvr_passed"
+nmnrvr_exists=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks | jq '.[].Name | select(match("NMN_RVR"))')
+if [ -n "$nmnrvr_exists" ]; then
+    nmnrvr_cidr=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks/NMN_RVR | jq -r '.ExtraProperties.Subnets[0].CIDR')
+    nmnrvr_passed=false
+    echo $rttbl | grep -q "$nmnrvr_cidr via $nmngw dev bond0.nmn0" && nmnrvr_passed=true
+    echo_stdout "INFO: NMN_RVR CIDR is $nmnrvr_cidr - route found = $nmnrvr_passed"
+else
+    echo_stdout "INFO: NMN_RVR network does not exist in SLS"
+    nmnrvr_passed=true
+fi
+
+# Check for NMN_MTN static route
+nmnmtn_exists=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks | jq '.[].Name | select(match("NMN_MTN"))')
+if [ -n "$nmnmtn_exists" ]; then
+    nmnmtn_cidr=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks/NMN_MTN | jq -r '.ExtraProperties.Subnets[0].CIDR')
+    nmnmtn_passed=false
+    echo $rttbl | grep -q "$nmnmtn_cidr via $nmngw dev bond0.nmn0" && nmnmtn_passed=true
+    echo_stdout "INFO: NMN_MTN CIDR is $nmnmtn_cidr - route found = $nmnmtn_passed"
+else
+    echo_stdout "INFO: NMN_MTN network does not exist in SLS"
+    nmnmtn_passed=true
+fi
 
 # Check for HMNLB static route
 hmnlb_cidr=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks/HMNLB | jq -r '.ExtraProperties.Subnets[0].CIDR')
@@ -180,10 +198,29 @@ echo $rttbl | grep -q "$hmnlb_cidr via $hmngw dev bond0.hmn0" && hmnlb_passed=tr
 echo_stdout "INFO: HMNLB CIDR is $hmnlb_cidr - route found = $hmnlb_passed"
 
 # Check for HMN_RVR static route
-hmnrvr_cidr=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks/HMN_RVR | jq -r '.ExtraProperties.Subnets[0].CIDR')
-hmnrvr_passed=false
-echo $rttbl | grep -q "$hmnrvr_cidr via $hmngw dev bond0.hmn0" && hmnrvr_passed=true
-echo_stdout "INFO: HMNLB CIDR is $hmnrvr_cidr - route found = $hmnrvr_passed"
+hmnrvr_exists=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks | jq '.[].Name | select(match("HMN_RVR"))')
+if [ -n "$hmnrvr_exists" ]; then
+    hmnrvr_cidr=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks/HMN_RVR | jq -r '.ExtraProperties.Subnets[0].CIDR')
+    hmnrvr_passed=false
+    echo $rttbl | grep -q "$hmnrvr_cidr via $hmngw dev bond0.hmn0" && hmnrvr_passed=true
+    echo_stdout "INFO: HMN_RVR CIDR is $hmnrvr_cidr - route found = $hmnrvr_passed"
+else
+    echo_stdout "INFO: HMN_RVR network does not exist in SLS"
+    hmnrvr_passed=true
+fi
+
+
+# Check for HMN_MTN static route
+hmnmtn_exists=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks | jq '.[].Name | select(match("NMN_MTN"))')
+if [ -n "$hmnmtn_exists" ]; then
+    hmnmtn_cidr=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks/HMN_MTN | jq -r '.ExtraProperties.Subnets[0].CIDR')
+    hmnmtn_passed=false
+    echo $rttbl | grep -q "$hmnmtn_cidr via $hmngw dev bond0.hmn0" && hmnmtn_passed=true
+    echo_stdout "INFO: HMN_MTN CIDR is $hmnmtn_cidr - route found = $hmnmtn_passed"
+else
+    echo_stdout "INFO: HMN_MTN network does not exist in SLS"
+    hmnmtn_passed=true
+fi
 
 # Check for MTL static route
 mtl_cidr=$(curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks/MTL | jq -r '.ExtraProperties.Subnets[0].CIDR')
@@ -191,7 +228,7 @@ mtl_passed=false
 echo $rttbl | grep -q "$mtl_cidr via $nmngw dev bond0.nmn0" && mtl_passed=true
 echo_stdout "INFO: MTL CIDR is $mtl_cidr - route found = $mtl_passed"
 
-if $nmnlb_passed && $hmnlb_passed && $mtl_passed && $nmnrvr_passed && $hmnrvr_passed; then
+if $nmnlb_passed && $hmnlb_passed && $mtl_passed && $nmnrvr_passed && $hmnrvr_passed && $nmnmtn_passed && $hmnmtn_passed; then
     echo "PASS"
     status=0
 else


### PR DESCRIPTION
## Summary and Scope

While running the "NCNs Have All Required Static Routes" test in the ncn-k8s-combined-healthcheck on baldar, the test failed because baldar has an EX2500 cabinet with no river nodes.  Therefore, no NMN_RVR or HMN_RVR subnets were allocated in SLS.   Additionaly, the test was not checking static routes for the MTN networks.   The test has been changed to first check if the RVR and MTN networks are defined and then only check for the static routes if they are defined.   The test also now added checks for the MNT networks.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-5850](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5850)

## Testing

### Tested on:

  * `baldar` and `surtur`

### Test description:

Ran the test on balder where there are MTN networks and no RVR networks:

```
ncn-m002:~ # /opt/cray/tests/install/ncn/scripts/check_static_routes.sh -p
---------------- Route Table ----------------
default via 10.102.98.1 dev bond0.cmn0 
10.1.0.0/16 via 10.252.0.1 dev bond0.nmn0 
10.32.0.0/12 dev weave proto kernel scope link src 10.36.0.0 
10.88.0.0/16 dev cni-podman0 proto kernel scope link src 10.88.0.1 linkdown 
10.92.100.0/24 via 10.252.0.1 dev bond0.nmn0 
10.94.100.0/24 via 10.254.0.1 dev bond0.hmn0 
10.100.0.0/22 via 10.252.0.1 dev bond0.nmn0 
10.102.98.0/25 dev bond0.cmn0 proto kernel scope link src 10.102.98.20 
10.102.98.128/25 dev bond0.can0 proto kernel scope link src 10.102.98.134 
10.104.0.0/22 via 10.254.0.1 dev bond0.hmn0 
10.252.0.0/17 dev bond0.nmn0 proto kernel scope link src 10.252.1.5 
10.254.0.0/17 dev bond0.hmn0 proto kernel scope link src 10.254.1.6 
---------------------------------------------
INFO: NMN gateway is 10.252.0.1
INFO: HMN gateway is 10.254.0.1
INFO: NMNLB CIDR is 10.92.100.0/24 - route found = true
INFO: NMN_RVR network does not exist in SLS
INFO: NMN_MTN CIDR is 10.100.0.0/22 - route found = true
INFO: HMNLB CIDR is 10.94.100.0/24 - route found = true
INFO: HMN_RVR network does not exist in SLS
INFO: HMN_MTN CIDR is 10.104.0.0/22 - route found = true
INFO: MTL CIDR is 10.1.0.0/16 - route found = true
PASS
```

Ran on surtur where there are RVR networks and no MTN networks.

```
ncn-m001:~/johren # ./check_static_routes.sh -p
---------------- Route Table ----------------
default via 10.100.254.1 dev lan0 
10.1.0.0/16 via 10.252.0.1 dev bond0.nmn0 
10.32.0.0/12 dev weave proto kernel scope link src 10.32.0.1 
10.88.0.0/16 dev cni-podman0 proto kernel scope link src 10.88.0.1 
10.92.100.0/24 via 10.252.0.1 dev bond0.nmn0 
10.94.100.0/24 via 10.254.0.1 dev bond0.hmn0 
10.100.254.0/24 dev lan0 proto kernel scope link src 10.100.254.78 
10.103.11.0/25 dev bond0.cmn0 proto kernel scope link src 10.103.11.27 
10.103.11.128/26 dev bond0.can0 proto kernel scope link src 10.103.11.141 
10.106.0.0/22 via 10.252.0.1 dev bond0.nmn0 
10.107.0.0/22 via 10.254.0.1 dev bond0.hmn0 
10.252.0.0/17 dev bond0.nmn0 proto kernel scope link src 10.252.1.12 
10.254.0.0/17 dev bond0.hmn0 proto kernel scope link src 10.254.1.20 
---------------------------------------------
INFO: NMN gateway is 10.252.0.1
INFO: HMN gateway is 10.254.0.1
INFO: NMNLB CIDR is 10.92.100.0/24 - route found = true
INFO: NMN_RVR CIDR is 10.106.0.0/22 - route found = true
INFO: NMN_MTN network does not exist in SLS
INFO: HMNLB CIDR is 10.94.100.0/24 - route found = true
INFO: HMN_RVR CIDR is 10.107.0.0/22 - route found = true
INFO: HMN_MTN network does not exist in SLS
INFO: MTL CIDR is 10.1.0.0/16 - route found = true
PASS
```

Removed one of the static routes temporarily on surtur and verified that the test fails.
```
ncn-m001:~/johren # ./check_static_routes.sh -p
---------------- Route Table ----------------
default via 10.100.254.1 dev lan0 
10.1.0.0/16 via 10.252.0.1 dev bond0.nmn0 
10.32.0.0/12 dev weave proto kernel scope link src 10.32.0.1 
10.88.0.0/16 dev cni-podman0 proto kernel scope link src 10.88.0.1 
10.92.100.0/24 via 10.252.0.1 dev bond0.nmn0 
10.94.100.0/24 via 10.254.0.1 dev bond0.hmn0 
10.100.254.0/24 dev lan0 proto kernel scope link src 10.100.254.78 
10.103.11.0/25 dev bond0.cmn0 proto kernel scope link src 10.103.11.27 
10.103.11.128/26 dev bond0.can0 proto kernel scope link src 10.103.11.141 
10.106.0.0/22 via 10.252.0.1 dev bond0.nmn0 
10.252.0.0/17 dev bond0.nmn0 proto kernel scope link src 10.252.1.12 
10.254.0.0/17 dev bond0.hmn0 proto kernel scope link src 10.254.1.20 
---------------------------------------------
INFO: NMN gateway is 10.252.0.1
INFO: HMN gateway is 10.254.0.1
INFO: NMNLB CIDR is 10.92.100.0/24 - route found = true
INFO: NMN_RVR CIDR is 10.106.0.0/22 - route found = true
INFO: NMN_MTN network does not exist in SLS
INFO: HMNLB CIDR is 10.94.100.0/24 - route found = true
INFO: HMN_RVR CIDR is 10.107.0.0/22 - route found = false
INFO: HMN_MTN network does not exist in SLS
INFO: MTL CIDR is 10.1.0.0/16 - route found = true
FAIL
```


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

