### PR TITLE
CASMINST-5819: Add test to check for taints on master nodes

### DIFF
--- a/goss-testing/automated/run-ncn-tests.sh
+++ b/goss-testing/automated/run-ncn-tests.sh
@@ -1,6 +1,6 @@
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -641,6 +641,12 @@ function add_local_vars {
     # add list of k8s nodes
     var_string+="\nk8s_nodes:\n"
     for node in $(echo "${nodes}" | grep -oE "ncn-[mw][0-9]{3}") ; do
+        var_string+="  - ${node}\n"
+    done
+
+    # add list of master nodes
+    var_string+="\nk8s_master_nodes:\n"
+    for node in $(echo "${nodes}" | grep -oE "ncn-[m][0-9]{3}") ; do
         var_string+="  - ${node}\n"
     done
     

--- a/goss-testing/tests/common/goss-k8s-nodes-master-taint.yaml
+++ b/goss-testing/tests/common/goss-k8s-nodes-master-taint.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,21 +22,23 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-#
-# This suite is run:
-# * During CSM installs before CSM services have been deployed,
-# * During CSM Health Validation (after CSM services have been deployed), both
-#   before and after PIT redeployment
-#
-
-# During health validation, these tests are executed on a single master node
-# in the cluster. Tests that are executed on every master node are in the
-# corresponding suite file without the -single suffix.
-gossfile:
-  ../tests/goss-ceph-csi-k8s-requirements.yaml: {}
-  ../tests/goss-k8s-certmanager-certs-ready.yaml: {}
-  ../tests/goss-k8s-certmanager-issuers-ready.yaml: {}
-  ../tests/goss-k8s-pods-ips-in-nmn-pool.yaml: {}
-  ../tests/goss-k8s-verify-cluster.yaml: {}
-  ../tests/goss-unbound-dns-entries.yaml: {}
-  ../tests/goss-k8s-nodes-master-taint.yaml: {}
+{{ $kubectl := .Vars.kubectl }}
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
+command:
+  {{range $node := index .Vars "k8s_master_nodes"}}
+  {{ $testlabel := $node | printf "k8s_node_%s_master_taint" }}
+  {{$testlabel}}:
+        title: Kubernetes Node '{{$node}}' Master Taint 
+        meta:
+            desc: Validates that Kubernetes node '{{$node}}' has master taint.
+            sev: 0
+        exec: |-
+            # The test should fail if the kubectl command fails
+            set -o pipefail
+            # The logrun command will log the output of the kubectl command, pre-grep and pre-awk
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$kubectl}}" get nodes -o custom-columns=NAME:.metadata.name,TAINTS:.spec.taints --no-headers {{$node}} | grep "effect:NoSchedule key:node-role.kubernetes.io/master" 
+        exit-status: 0
+        timeout: 20000
+        skip: false
+  {{end}}


### PR DESCRIPTION
## Summary and Scope

If the master NoSchedule taints are not defined, then may pods will be scheduled to the masters nodes when they should only be scheduled on worker nodes.   This is particularly an issue with the sonar-job-watcher CronJob.   That job mounts a volume with a subPath.   As shown in https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4827, this causes kubelet to become very bogged down to the point that pods take a very long time to move from Pending to Running.

Bottom line is that we only want a certain small set of pods to be scheduled on the master nodes.   This test makes sure that the master taints are defined to prevent any other pods from being scheduled on the master nodes.   The test gets run as part of the CSM health checks.

## Issues and Related PRs

* Resolves [CASMINST-5819](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5819)

## Testing

### Tested on:

  * `surtur`

### Test description:

I ran this test individually on surtur to make sure that it passes as expected.   I also ran ncn-k8s-combined-healthcheck to make sure that it gets run as part of that set of suites.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

