### PR TITLE
CASMINST-5874: Update Goss tests for CRUS removal

### DIFF
--- a/goss-testing/scripts/etcd_backups_check.sh
+++ b/goss-testing/scripts/etcd_backups_check.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -72,7 +72,7 @@ check_backup_within_day() {
 }
 
 error_flag=0
-for cluster in cray-bos cray-bss cray-crus cray-fas
+for cluster in cray-bos cray-bss cray-fas
 do
     # look at age of cluster
     age=$(kubectl get etcd ${cluster}-etcd -n services -o jsonpath='{.metadata.creationTimestamp}')


### PR DESCRIPTION
## Summary and Scope

CRUS is being removed from CSM 1.6. Only one Goss test is affected by this -- a script which validates etcd cluster backups. This PR removes the CRUS cluster from the list of clusters being backed up. No other changes.

## Issues and Related PRs

* Part of the [CRUS removal](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8396) epic.

## Testing

None -- the change is so limited that the impact is obvious -- the CRUS cluster is no longer included in the checks.

## Risks and Mitigations

Very low risk, but without this change, this script will always fail.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

