### PR TITLE
MTL-2085 `rd.live.overlay.thin` is now `0`

### DIFF
--- a/goss-testing/scripts/data-validator.py
+++ b/goss-testing/scripts/data-validator.py
@@ -241,7 +241,7 @@ def boot_params(data):
 	"rd.bootif=0",
 	"rd.dm=0",
 	"rd.live.overlay.overlayfs=1",
-	"rd.live.overlay.thin=1",
+	"rd.live.overlay.thin=0",
 	"rd.live.overlay=LABEL=ROOTRAID",
 	"rd.live.ram=0",
 	"rd.live.squashimg=",


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

`rd.live.overlay.thin` is now set to `0` to prevent the extraneous error messages from printing.

See: https://github.com/Cray-HPE/metal-ipxe/pull/56
