### PR TITLE
CASMTRIAGE-4994 Turn off goss-bond-members-have-links on vShasta

### DIFF
--- a/goss-testing/tests/common/goss-bond-members-have-links.yaml
+++ b/goss-testing/tests/common/goss-bond-members-have-links.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2014-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -32,4 +32,10 @@ command:
     exec: "awk -F '=' '/BONDING_SLAVE/{print $2}' /etc/sysconfig/network/ifcfg-bond0 | tr -d \\' | while read member ; do ip link show dev $member ; done"
     exit-status: 0
     timeout: 20000
+    # skip this test on vshasta
+    {{ if eq true .Vars.vshasta }}
+    skip: true
+    {{ else }}
     skip: false
+    {{ end }}
+


### PR DESCRIPTION
## Summary and Scope

For vShasta installation, a test named `goss-bond-members-have-links`, executed on PIT node during pre-flight check, should be disabled - similar to other bond members pre-flight checks on vShasta.

## Issues and Related PRs

* Resolves [CASMTRIAGE-4994](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4994)

## Testing
### Tested on:

  * Virtual Shasta

### Test description:

Applied modified test suite directly on vShasta system. Test which was previously failing is ow skipped.

## Risks and Mitigations

Low - turning off single test.