### PR TITLE
VSHA-542:  Adjust the goss test skips for vshasta

### DIFF
--- a/goss-testing/suites/ncn-healthcheck-master-single.yaml
+++ b/goss-testing/suites/ncn-healthcheck-master-single.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2014-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -33,6 +33,7 @@ gossfile:
   ../tests/goss-k8s-etcd-endpoint-health.yaml: {}
   ../tests/goss-k8s-etcd-members.yaml: {}
   ../tests/goss-k8s-kea-has-active-dhcp-leases.yaml: {}
+  ../tests/goss-k8s-kea-pod-running.yaml: {}
   ../tests/goss-k8s-psp-enabled.yaml: {}
   ../tests/goss-k8s-resolve-external-dns.yaml: {}
   ../tests/goss-k8s-monitoring-url.yaml: {}

--- a/goss-testing/suites/ncn-kubernetes-tests-master.yaml
+++ b/goss-testing/suites/ncn-kubernetes-tests-master.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2014-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -38,3 +38,4 @@ gossfile:
   ../tests/goss-k8s-etcd-service.yaml: {}
   ../tests/goss-ncn-xname.yaml: {}
   ../tests/goss-weave-health.yaml: {}
+  ../tests/goss-weave-status-daemon-sets.yaml: {}

--- a/goss-testing/suites/ncn-kubernetes-tests-worker.yaml
+++ b/goss-testing/suites/ncn-kubernetes-tests-worker.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -33,3 +33,4 @@ gossfile:
   ../tests/goss-dedicated-drive-worker.yaml: {}
   ../tests/goss-ncn-xname.yaml: {}
   ../tests/goss-weave-health.yaml: {}
+  ../tests/goss-weave-status-daemon-sets.yaml: {}

--- a/goss-testing/tests/common/goss-rgw-cert-valid.yaml
+++ b/goss-testing/tests/common/goss-rgw-cert-valid.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2014-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -30,9 +30,4 @@ command:
     exec: 'curl --insecure -vvI https://rgw-vip.nmn 2>&1 | grep "expire date:"'
     exit-status: 0
     timeout: 20000
-    # skip this test on vshasta 
-    {{ if eq true .Vars.vshasta }}
-    skip: true
-    {{ else }}
     skip: false
-    {{ end }}

--- a/goss-testing/tests/ncn/goss-bss-basecamp-valid.yaml
+++ b/goss-testing/tests/ncn/goss-bss-basecamp-valid.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -38,3 +38,9 @@ command:
         # The command should succeed
         exit-status: 0
         timeout: 20000
+        # skip this test on vshasta
+        {{ if eq true .Vars.vshasta }}
+        skip: true
+        {{ else }}
+        skip: false
+        {{ end }}

--- a/goss-testing/tests/ncn/goss-ceph-status.yaml
+++ b/goss-testing/tests/ncn/goss-ceph-status.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,8 +21,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# set a var for vshasta
-{{ $vs := .Vars.vshasta}}
 {{ $this_node_name := .Vars.this_node_name }}
 {{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 package:
@@ -48,9 +46,5 @@ command:
                     /usr/bin/ceph -s
             exit-status: 0
             timeout: 20000
-            {{ if eq true $vs }}
-            skip: true
-            {{ else }}
             skip: false
-            {{ end }}
     {{end}}

--- a/goss-testing/tests/ncn/goss-cfs-state-reporter.yaml
+++ b/goss-testing/tests/ncn/goss-cfs-state-reporter.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -39,4 +39,9 @@ command:
         stdout:
             - PASS
         timeout: 20000
+        # skip this test on vshasta
+        {{ if eq true .Vars.vshasta }}
+        skip: true
+        {{ else }}
         skip: false
+        {{ end }}

--- a/goss-testing/tests/ncn/goss-check-static-routes.yaml
+++ b/goss-testing/tests/ncn/goss-check-static-routes.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -40,4 +40,9 @@ command:
             - "!FAIL"
         exit-status: 0
         timeout: 20000
+        # skip this test on vshasta
+        {{ if eq true .Vars.vshasta }}
+        skip: true
+        {{ else }}
         skip: false
+        {{ end }}

--- a/goss-testing/tests/ncn/goss-default-gateway-points-to-CMN-gateway.yaml
+++ b/goss-testing/tests/ncn/goss-default-gateway-points-to-CMN-gateway.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2014-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -32,4 +32,9 @@ command:
     stdout:
       - "!FAIL"
     timeout: 20000
+    # skip this test on vshasta
+    {{ if eq true .Vars.vshasta }}
+    skip: true
+    {{ else }}
     skip: false
+    {{ end }}

--- a/goss-testing/tests/ncn/goss-k8s-kea-has-active-dhcp-leases.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-kea-has-active-dhcp-leases.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -50,4 +50,9 @@ command:
     stdout:
       - PASS
     timeout: 20000
+    # skip this test on vshasta
+    {{ if eq true .Vars.vshasta }}
+    skip: true
+    {{ else }}
     skip: false
+    {{ end }}

--- a/goss-testing/tests/ncn/goss-k8s-monitoring-url.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-monitoring-url.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -37,4 +37,9 @@ command:
                 "{{$monitoring_check}}"
         exit-status: 0
         timeout: 20000
+        # skip this test on vshasta
+        {{ if eq true .Vars.vshasta }}
+        skip: true
+        {{ else }}
         skip: false
+        {{ end }}

--- a/goss-testing/tests/ncn/goss-k8s-resolve-external-dns.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-resolve-external-dns.yaml
@@ -83,4 +83,9 @@ command:
 
     exit-status: 0
     timeout: 20000
+    # skip this test on vshasta
+    {{ if eq true .Vars.vshasta }}
+    skip: true
+    {{ else }}
     skip: false
+    {{ end }}

--- a/goss-testing/tests/ncn/goss-weave-health.yaml
+++ b/goss-testing/tests/ncn/goss-weave-health.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2014-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -42,8 +42,4 @@ command:
         stdout:
             - "!IP allocation was seeded by different peers"
         timeout: 20000
-        {{ if eq true .Vars.vshasta }}
-        skip: true
-        {{ else }}
         skip: false
-        {{ end }}


### PR DESCRIPTION
## Summary and Scope

I took a look at the goss tests that are getting skipped on vshasta during the CI testing.   I found a few that do not need to be skipped anymore.

  * goss-rgw-cert-valid.yaml
  * goss-ceph-status.yaml
  * goss-weave-health.yaml


I am also adding in healthcheck tests to the pipeline in VSHA-541 and that requires a few more tests to be skipped on vshasta.

	* goss-bss-basecamp-valid.yaml - the bootparameters are not setup in vshasta
	* goss-cfs-state-reporter.yaml - cfs-state-reporter doesn't start up properly on vshasta
	* goss-check-static-routes.yaml - there is no ipam configuration in basecamp/bss on vshasta
	* goss-default-gateway-points-to-CMN-gateway.yaml - there is no ipam configuration in basecamp/bss on vshasta
	* goss-k8s-kea-has-active-dhcp-leases.yaml - there are no BMCs to DHCP and get leases on vshasta
	* goss-k8s-monitoring-url.yaml - this won't work because are using "local" for the site-domain on vshasta
	* goss-k8s-resolve-external-dns.yaml - there is no functional CMN on vshasta

While analyzing the tests I also found that there are no suites running these two tests.   I added them to the appropriate suites.
   * goss-k8s-kea-pod-running.yaml
   * goss-weave-status-daemon-sets.yaml

## Issues and Related PRs

* Resolves [VSHA-542](https://jira-pro.its.hpecorp.net:8443/browse/VSHA-542)

## Testing

### Tested on:

  * Virtual Shasta `beau`

### Test description:

I ran both the preflight and healthcheck tests on beau and verified that there are no failures and only the expected tests are skipped.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

