### PR TITLE
CASMINST-6080 Fix goss-server configuration on PIT node

### DIFF
--- a/goss-testing/automated/python/lib/common.py
+++ b/goss-testing/automated/python/lib/common.py
@@ -45,7 +45,7 @@ import traceback
 # To help with function annotations
 StringList = List[str]
 
-NCN_TYPES = [ "master", "storage", "worker" ]
+NCN_TYPES = [ "master", "storage", "worker", "livecd" ]
 
 DEFAULT_LOG_LEVEL = "INFO"
 # For automated scripts with parallel execution, set the max number of parallel jobs.
@@ -236,7 +236,7 @@ ncn_storage_re_prog = re.compile(ncn_storage_pattern)
 ncn_worker_re_prog = re.compile(ncn_worker_pattern)
 
 def is_ncn_name(n: str) -> bool:
-    if ncn_re_prog.match(n):
+    if ncn_re_prog.match(n) or n == "pit":
         return True
     return False
 
@@ -255,6 +255,9 @@ def is_worker_ncn_name(n: str) -> bool:
         return True
     return False
 
+def is_livecd_ncn_name(n: str) -> bool:
+    return (n == "pit")
+
 def get_ncn_type(ncn_name: str) -> str:
     if is_master_ncn_name(ncn_name):
         return "master"
@@ -262,6 +265,8 @@ def get_ncn_type(ncn_name: str) -> str:
         return "storage"
     elif is_worker_ncn_name(ncn_name):
         return "worker"
+    elif is_livecd_ncn_name(ncn_name):
+        return "livecd"
     raise ScriptException(f"Unexpected NCN name format: {ncn_name}")
 
 def my_ncn_type() -> str:

--- a/goss-testing/dat/goss-servers.cfg
+++ b/goss-testing/dat/goss-servers.cfg
@@ -14,6 +14,7 @@
 8997       ncn-healthcheck-master.yaml                             master
 8997       ncn-healthcheck-storage.yaml                            storage
 8997       ncn-healthcheck-worker.yaml                             worker
+8997       livecd-healthcheck.yaml                                 livecd
 
 8998       ncn-healthcheck-master-single.yaml                      master
 8998       ncn-healthcheck-worker-single.yaml                      worker
@@ -26,6 +27,7 @@
 
 9001       ncn-kubernetes-tests-master.yaml                        master
 9001       ncn-kubernetes-tests-worker.yaml                        worker
+9001       livecd-preflight-tests.yaml                             livecd
 
 9002       ncn-kubernetes-tests-master-single.yaml                 master
 


### PR DESCRIPTION
## Summary and Scope

The `goss-servers` RPM package is currently installed on PIT node and systemd service is configured to start. However, it fails to start due to multiple misconfigurations. This PR is to address misconfigurations, and allow test execution on pit node by querying URL (similar to other nodes).

## Issues and Related PRs

* Resolves [CASMINST-6080](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6080)

## Testing
### Tested on:

  * Virtual Shasta

### Test description:

Installed package on vShasta pit node and restarted `goss-server` service. Server came up as expected, tests can now be executed:
    
    pit:~ # curl http://pit:9001/livecd-preflight-tests
    <?xml version="1.0" encoding="UTF-8"?>
    <testsuite name="goss" errors="0" tests="162" failures="3" skipped="27" time="1.543" timestamp="2023-03-14T19:11:00Z">
      <testcase name="Command check_interface_ip_bond0.nmn0 exit-status" time="0.000">
        <skipped/>
      </testcase>
      <testcase name="Command check_interface_ip_bond0.nmn0 stdout" time="0.000">
        <skipped/>
      </testcase>
    ...
    
    pit:~ # curl -Ss http://pit:8997/livecd-healthcheck
    <?xml version="1.0" encoding="UTF-8"?>
    <testsuite name="goss" errors="0" tests="42" failures="12" skipped="10" time="6.615" timestamp="2023-03-14T19:11:08Z">
      <testcase name="Command ncns_have_dnsmasq_lease exit-status" time="0.000">
        <skipped/>
      </testcase>
      <testcase name="Command ncns_have_dnsmasq_lease stdout" time="0.000">
        <skipped/>
      </testcase>
      <testcase name="Command podman_container_nexus exit-status" time="0.000">
        <system-out>CONTAINER ID  IMAGE                                                           COMMAND               CREATED       STATUS                   PORTS       NAMES&#xA;af46253b3b23  artifactory.algol60.net/csm-docker/stable/metal-basecamp:1.2.5                        14 hours ago  Up 14 hours ago                      basecamp&#xA;6eed9d473c50  artifactory.algol60.net/csm-docker/stable/nexus3:3.37.0         sh -c ${SONATYPE_...  14 hours ago  Exited (0) 12 hours ago              nexus</system-out>
        <system-err></system-err>
      </testcase>
    ...

## Risks and Mitigations

Low - test suite only
