### PR TITLE
CASMPET-6283 1.5 : Rework postgres backup goss tests

### DIFF
--- a/goss-testing/tests/ncn/goss-k8s-postgres-backups.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-postgres-backups.yaml
@@ -30,7 +30,7 @@ command:
     {{$testlabel}}:
         title: Kubernetes Postgresql Check that Automated Backups are Working
         meta:
-            desc: If this test fails, run the script "{{$postgresql_backups_check}} -p" to see a printed description of the errors. Check that cron jobs are running and creating postgresql backups periodically with the command "kubectl get cronjob -A | grep postgresql". To see a last scheduled time, run the command "kubectl -n <namespace> get cronjob <cron_job_name> -o jsonpath='{.status}'".
+            desc: If this test fails, run the script "{{$postgresql_backups_check}} -p" to see a printed description of the errors. Check that cron jobs are running and creating postgresql logical backups periodically with the command "kubectl get cronjob -A | grep logical-backup". To see a last scheduled time, run the command "kubectl -n <namespace> get cronjob <cron_job_name> -o jsonpath='{.status}'".
             sev: 0
         exec: |-
             "{{$logrun}}" -l "{{$testlabel}}" \


### PR DESCRIPTION
## Summary and Scope

With the latest upstream postgres-operator, we are changing from our home-grown backup solution to the logical-backup solution provided by the operator. 
This change updates the postgresql backup check - for those clusters with logical backups enabled; the test will pass unless the latest logical-backup job has failed or the logical-backup completed but no backup exists in s3.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6283](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6283)
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

### Tested on:

  * Virtual Shasta v2 - dorian

### Test description:

* Passes if none of the clusters have enabled logical backups
```
pit:~ # ./postgres-backup.sh -p
cray-nls-postgres -- Logical backups are not enabled for this cluster (pass)
cfs-ara-postgres -- Logical backups are not enabled for this cluster (pass)
cray-console-data-postgres -- Logical backups are not enabled for this cluster (pass)
cray-dns-powerdns-postgres -- Logical backups are not enabled for this cluster (pass)
cray-sls-postgres -- Logical backups are not enabled for this cluster (pass)
cray-smd-postgres -- Logical backups are not enabled for this cluster (pass)
gitea-vcs-postgres -- Logical backups are not enabled for this cluster (pass)
keycloak-postgres -- Logical backups are not enabled for this cluster (pass)
spire-postgres -- Logical backups are not enabled for this cluster (pass)
PASS
```
* Fails if the Job fails (keycloak-postgres & bad AWS creds)
```
pit:~ # ./postgres-backup.sh -p
cray-nls-postgres -- Logical backups are not enabled for this cluster (pass)
cfs-ara-postgres -- Logical backups are not enabled for this cluster (pass)
cray-console-data-postgres -- Logical backups are not enabled for this cluster (pass)
cray-dns-powerdns-postgres -- Logical backups are not enabled for this cluster (pass)
cray-sls-postgres -- Logical backups are not enabled for this cluster (pass)
cray-smd-postgres -- Logical backups are not enabled for this cluster (pass)
gitea-vcs-postgres -- Logical backups are not enabled for this cluster (pass)
keycloak-postgres -- Latest logical-backup-keycloak-postgres-27981660 job failed (fail)
spire-postgres -- Logical backups are not enabled for this cluster (pass)
FAIL
```
* Passes if Job completes and backup exists in s3 (keycloak-postgres)
```
pit:~ # ./postgres-backup.sh -p
cray-nls-postgres -- Logical backups are not enabled for this cluster (pass)
cfs-ara-postgres -- Logical backups are not enabled for this cluster (pass)
cray-console-data-postgres -- Logical backups are not enabled for this cluster (pass)
cray-dns-powerdns-postgres -- Logical backups are not enabled for this cluster (pass)
cray-sls-postgres -- Logical backups are not enabled for this cluster (pass)
cray-smd-postgres -- Logical backups are not enabled for this cluster (pass)
gitea-vcs-postgres -- Logical backups are not enabled for this cluster (pass)
keycloak-postgres -- Latest logical-backup-keycloak-postgres-27981600 job completed
  Most recent backup spilo/keycloak-postgres/1aec5161-1766-4a45-8ebd-1bf7221b3a95/logical_backups/1678896006.sql.gz at 2023-03-15T16:00:07.443000+00:00 (pass)
spire-postgres -- Logical backups are not enabled for this cluster (pass)
PASS
```
* Fails if Job completes but backup missing from s3 (keycloak-postgres)
```
pit:~ # ./postgres-backup.sh -p
cray-nls-postgres -- Logical backups are not enabled for this cluster (pass)
cfs-ara-postgres -- Logical backups are not enabled for this cluster (pass)
cray-console-data-postgres -- Logical backups are not enabled for this cluster (pass)
cray-dns-powerdns-postgres -- Logical backups are not enabled for this cluster (pass)
cray-sls-postgres -- Logical backups are not enabled for this cluster (pass)
cray-smd-postgres -- Logical backups are not enabled for this cluster (pass)
gitea-vcs-postgres -- Logical backups are not enabled for this cluster (pass)
keycloak-postgres -- Latest logical-backup-keycloak-postgres-27981600 job completed
 Postgres backup(s) are missing from s3 (fail)
spire-postgres -- Logical backups are not enabled for this cluster (pass)
FAIL
```
* Passes if Job initially fails but on retries it succeeds and backup exists in s3
```
pit:~ # ./postgres-backup.sh -p
cray-nls-postgres -- Logical backups are not enabled for this cluster (pass)
cfs-ara-postgres -- Logical backups are not enabled for this cluster (pass)
cray-console-data-postgres -- Logical backups are not enabled for this cluster (pass)
cray-dns-powerdns-postgres -- Logical backups are not enabled for this cluster (pass)
cray-sls-postgres -- Logical backups are not enabled for this cluster (pass)
cray-smd-postgres -- Logical backups are not enabled for this cluster (pass)
gitea-vcs-postgres -- Logical backups are not enabled for this cluster (pass)
keycloak-postgres -- Latest logical-backup-keycloak-postgres-27981770 job is running - neither failed or completed at this point in time (pass)
spire-postgres -- Logical backups are not enabled for this cluster (pass)
PASS

<fix s3 while the job continues to re-try> 

pit:~ # ./postgres-backup.sh -p
cray-nls-postgres -- Logical backups are not enabled for this cluster (pass)
cfs-ara-postgres -- Logical backups are not enabled for this cluster (pass)
cray-console-data-postgres -- Logical backups are not enabled for this cluster (pass)
cray-dns-powerdns-postgres -- Logical backups are not enabled for this cluster (pass)
cray-sls-postgres -- Logical backups are not enabled for this cluster (pass)
cray-smd-postgres -- Logical backups are not enabled for this cluster (pass)
gitea-vcs-postgres -- Logical backups are not enabled for this cluster (pass)
keycloak-postgres -- Latest logical-backup-keycloak-postgres-27981770 job completed
  Most recent backup spilo/keycloak-postgres/1aec5161-1766-4a45-8ebd-1bf7221b3a95/logical_backups/1678906428.sql.gz at 2023-03-15T18:53:50.016000+00:00 (pass)
spire-postgres -- Logical backups are not enabled for this cluster (pass)
PASS
```
* Passes if Logical backup enabled but cronjob has not been run yet (spire-postgres)
```
pit:~ # ./postgres-backup.sh -p
cray-nls-postgres -- Logical backups are not enabled for this cluster (pass)
cfs-ara-postgres -- Logical backups are not enabled for this cluster (pass)
cray-console-data-postgres -- Logical backups are not enabled for this cluster (pass)
cray-dns-powerdns-postgres -- Logical backups are not enabled for this cluster (pass)
cray-sls-postgres -- Logical backups are not enabled for this cluster (pass)
cray-smd-postgres -- Logical backups are not enabled for this cluster (pass)
gitea-vcs-postgres -- Logical backups are not enabled for this cluster (pass)
keycloak-postgres -- Latest logical-backup-keycloak-postgres-27981600 job completed
  Most recent backup spilo/keycloak-postgres/1aec5161-1766-4a45-8ebd-1bf7221b3a95/logical_backups/1678896006.sql.gz at 2023-03-15T16:00:07.443000+00:00 (pass)
spire-postgres -- No logical backup jobs have run at this point in time (pass)
PASS
```
* Passes if Newly enabled logical backup for initial run succeeded and backup exists in s3 (spire-postgres)
```
pit:~ # ./postgres-backup.sh -p
cray-nls-postgres -- Logical backups are not enabled for this cluster (pass)
cfs-ara-postgres -- Logical backups are not enabled for this cluster (pass)
cray-console-data-postgres -- Logical backups are not enabled for this cluster (pass)
cray-dns-powerdns-postgres -- Logical backups are not enabled for this cluster (pass)
cray-sls-postgres -- Logical backups are not enabled for this cluster (pass)
cray-smd-postgres -- Logical backups are not enabled for this cluster (pass)
gitea-vcs-postgres -- Logical backups are not enabled for this cluster (pass)
keycloak-postgres -- Latest logical-backup-keycloak-postgres-27981600 job completed
  Most recent backup spilo/keycloak-postgres/1aec5161-1766-4a45-8ebd-1bf7221b3a95/logical_backups/1678896006.sql.gz at 2023-03-15T16:00:07.443000+00:00 (pass)
spire-postgres -- Latest logical-backup-spire-postgres-27981620 job completed
  Most recent backup spilo/spire-postgres/68796ab4-d4aa-4f60-84bf-7452754ab3ac/logical_backups/1678897207.sql.gz at 2023-03-15T16:20:08.346000+00:00 (pass)
PASS
```
* Passes if the job is still running (spire-postgres)
```
pit:~ # kubectl get pods -A | grep logical-backup-spire
spire            logical-backup-spire-postgres-27981630-gmcz5                      1/2     NotReady    0          30s

pit:~ # ./postgres-backup.sh -p
cray-nls-postgres -- Logical backups are not enabled for this cluster (pass)
cfs-ara-postgres -- Logical backups are not enabled for this cluster (pass)
cray-console-data-postgres -- Logical backups are not enabled for this cluster (pass)
cray-dns-powerdns-postgres -- Logical backups are not enabled for this cluster (pass)
cray-sls-postgres -- Logical backups are not enabled for this cluster (pass)
cray-smd-postgres -- Logical backups are not enabled for this cluster (pass)
gitea-vcs-postgres -- Logical backups are not enabled for this cluster (pass)
keycloak-postgres -- Latest logical-backup-keycloak-postgres-27981600 job completed
  Most recent backup spilo/keycloak-postgres/1aec5161-1766-4a45-8ebd-1bf7221b3a95/logical_backups/1678896006.sql.gz at 2023-03-15T16:00:07.443000+00:00 (pass)
spire-postgres -- Latest logical-backup-spire-postgres-27981630 job is running - neither failed or completed at this point in time (pass)
PASS
```
* Fails if s3 is down
```
pit:~ # ./postgres-backup.sh -p
cray-nls-postgres -- Logical backups are not enabled for this cluster (pass)
cfs-ara-postgres -- Logical backups are not enabled for this cluster (pass)
cray-console-data-postgres -- Logical backups are not enabled for this cluster (pass)
cray-dns-powerdns-postgres -- Logical backups are not enabled for this cluster (pass)
cray-sls-postgres -- Logical backups are not enabled for this cluster (pass)
cray-smd-postgres -- Logical backups are not enabled for this cluster (pass)
gitea-vcs-postgres -- Logical backups are not enabled for this cluster (pass)
keycloak-postgres -- Latest logical-backup-keycloak-postgres-27981760 job completed
Usage: cray artifacts list [OPTIONS] BUCKET
Try 'cray artifacts list --help' for help.

Error: Internal Server Error: The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.
 Postgres backup(s) are missing from s3 (fail)
spire-postgres -- Logical backups are not enabled for this cluster (pass)
FAIL
```
* Run the script thru the goss framework for pass case
```
pit:~ # GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-postgres-backups.yaml validate
..

Total Duration: 4.183s
Count: 2, Failed: 0, Skipped: 0
```
* Run the script thru the goss framework for fail case
```
pit:~ # GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-postgres-backups.yaml validate
FF

Failures/Skipped:

Title: Kubernetes Postgresql Check that Automated Backups are Working
Meta:
    desc: If this test fails, run the script "/opt/cray/tests/install/ncn/scripts/postgresql_backups_check.sh -p" to see a printed description of the errors. Check that cron jobs are running and creating postgresql backups periodically with the command "kubectl get cronjob -A | grep logical-backup". To see a last scheduled time, run the command "kubectl -n <namespace> get cronjob <cron_job_name> -o jsonpath='{.status}'".
    sev: 0
Command: k8s_postgresql_backups_check: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0
Command: k8s_postgresql_backups_check: stdout: patterns not found: [PASS]

Total Duration: 1.637s
Count: 2, Failed: 2, Skipped: 0

pit:~ # /opt/cray/tests/install/ncn/scripts/postgresql_backups_check.sh -p
cray-nls-postgres -- Logical backups are not enabled for this cluster (pass)
cfs-ara-postgres -- Logical backups are not enabled for this cluster (pass)
cray-console-data-postgres -- Logical backups are not enabled for this cluster (pass)
cray-dns-powerdns-postgres -- Logical backups are not enabled for this cluster (pass)
cray-sls-postgres -- Logical backups are not enabled for this cluster (pass)
cray-smd-postgres -- Logical backups are not enabled for this cluster (pass)
gitea-vcs-postgres -- Logical backups are not enabled for this cluster (pass)
keycloak-postgres -- Latest logical-backup-keycloak-postgres-27981820 job failed (fail)
spire-postgres -- Logical backups are not enabled for this cluster (pass)
FAIL
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

