### PR TITLE
Fix error return code in check_interface_mac_matches_bond

### DIFF
--- a/goss-testing/scripts/check_interface_mac_matches_bond.sh
+++ b/goss-testing/scripts/check_interface_mac_matches_bond.sh
@@ -70,15 +70,16 @@ echo "Checking that MAC address of interface '$INTERFACE' matches MAC address of
 echo
 
 # if the interface does not show, it might be the option CAN
-if ! eval ip addr show dev "$INTERFACE" 1>/dev/null; then
+rc=0
+ip addr show dev "$INTERFACE" 1>/dev/null || rc=$?
+if [ $rc -ne 0 ]; then
   if [[ "$INTERFACE" == "bond0.can0" ]]; then
     echo "$INTERFACE is optional...skipping"
     # so we can skip the rest of the loop here
     break
   # otherwise, it's a legit failure
   else
-    # shellcheck disable=SC2319
-    error 30 $? "ip addr show dev $INTERFACE"
+    error 30 $rc "ip addr show dev $INTERFACE"
   fi
 # if the interface does exist, continue checking if it matches bond0
 else


### PR DESCRIPTION
## Summary and Scope

As pointed out by `shellcheck`, the return code reported to `error` function was from `if` statement, not from original `ip addr show` command. This small change fixes the issue.
