### PR TITLE
CASMPET-6420 1.5 : fix test to not fail when LDAP server not configured

### DIFF
--- a/goss-testing/tests/ncn/goss-k8s-resolve-external-dns.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-resolve-external-dns.yaml
@@ -25,13 +25,12 @@ command:
   resolve_external_dns:
     title: Resolve external DNS
     meta:
-      desc: Validates external DNS name resolves. If the test fails, the configured LDAP server was not pingable. Refer to 'operations/network/dns/Troubleshoot_Common_DNS_Issues.md' in the CSM documentation to troubleshoot external DNS issues.
+      desc: Validates external DNS name resolves. The test fails if it is unable to DNS lookup the configured LDAP server. Refer to 'operations/network/dns/Troubleshoot_Common_DNS_Issues.md' in the CSM documentation to troubleshoot external DNS issues.
       sev: 0
     exec: |-
           # External DNS resolution is best tested by checking if the configured LDAP server is pingable.
-          # Fail if the test requirements are not met:
-          # - Unbound forward-addr is not configured.
-          # - LDAP providerId is not configured.
+          # Pass if LDAP are not configured.
+          # Fail if Unbound is not configured.
           # Fail if the LDAP providerId is configured but the LDAP connectionURL is not.
           # Pass/Fail based on exit code from ping of the LDAP server.
 
@@ -64,8 +63,8 @@ command:
            fi
 
            if [[ ! $LDAP_PROVIDER ]]; then 
-              echo "LDAP must be configured for this test."
-              exit 1
+              echo "LDAP is not configured so unable to test external DNS."
+              exit 0
            fi
 
            echo "Unbound and LDAP are configured" 


### PR DESCRIPTION
## Summary and Scope

This test now checks to see whether an LDAP server has been configured and does not FAIL when no LDAP server is configured.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6420](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6420)
* Change will also be needed in `release/1.3 and release/1.4`
* Future work required by NA
* Documentation changes required in [NA
* Merge with/before/after `TBD`

## Testing

### Tested on:

  * groot (airgpapped)
  * wasp (not airgapped)
  
  

### Test description:

Original test vs fixed version
* groot - air gapped where LDAP is not configured
```
ncn-m001:~ # GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-resolve-external-dns.yaml validate
F

Failures/Skipped:

Title: Resolve external DNS
Meta:
    desc: Validates external DNS name resolves. If the test fails, the configured LDAP server was not pingable. Refer to 'operations/network/dns/Troubleshoot_Common_DNS_Issues.md' in the CSM documentation to troubleshoot external DNS issues.
    sev: 0
Command: resolve_external_dns: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0

Total Duration: 1.566s
Count: 1, Failed: 1, Skipped: 0

ncn-m001:/opt/cray/tests/install/ncn/tests # GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-resolve-external-dns-fix.yaml validate
.

Total Duration: 1.544s
Count: 1, Failed: 0, Skipped: 0
```
* wasp - non airgapped where LDAP is configured
```
 # GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-resolve-external-dns.yaml validate
.

Total Duration: 3.149s
Count: 1, Failed: 0, Skipped: 0

# GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-resolve-external-dns-fix.yaml validate
.

Total Duration: 3.194s
Count: 1, Failed: 0, Skipped: 0
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

