### PR TITLE
CASMCMS-8473: Run cmsdev tftp test on a single NCN worker during health checks

### DIFF
--- a/goss-testing/tests/ncn/goss-cray-tftp-check.yaml
+++ b/goss-testing/tests/ncn/goss-cray-tftp-check.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,15 +22,28 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-# During health validation, these tests are executed on a single worker node
-# in the cluster. Tests that are executed on every worker node are in the
-# corresponding suite file without the -single suffix.
-gossfile:
-  ../tests/goss-cray-service-etcd-health-check.yaml: {}
-  ../tests/goss-cray-tftp-check.yaml: {}
-  ../tests/goss-k8s-postgres-backups.yaml: {}
-  ../tests/goss-k8s-postgres-clusters-running.yaml: {}
-  ../tests/goss-k8s-postgres-leader.yaml: {}
-  ../tests/goss-k8s-postgres-pods-running.yaml: {}
-  ../tests/goss-k8s-postgres-replication-lag.yaml: {}
-  ../tests/goss-k8s-precache-images-health.yaml: {}
+{{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
+{{ $logrun := $scripts | printf "%s/log_run.sh" }}
+{{ $cmsdev := "/usr/local/bin/cmsdev" }}
+command:
+    {{ $testlabel := "cray_tftp_check" }}
+    {{$testlabel}}:
+        title: cray-tftp service is healthy
+        meta:
+            desc: If this test fails, run `{{$cmsdev}} test tftp` on the target node for more information
+            sev: 0
+        # Run test in verbose mode, since we're capturing the output
+        exec: |-            
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$cmsdev}}" test -v tftp
+        exit-status: 0
+        stdout:
+            - SUCCESS
+        # 3 minute test timeout
+        timeout: 180000
+        # skip this test on vshasta
+        {{ if eq true .Vars.vshasta }}
+        skip: true
+        {{ else }}
+        skip: false
+        {{ end }}


### PR DESCRIPTION
## Summary and Scope

[CASMTRIAGE-5071](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5071) was opened because the cmsdev tftp get file subtest fails when it is run on a master NCN. This was an unforeseen consequence of [CASMCMS-8450](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8450). However, the solution is that this subtest should not be run on master NCNs.

The cmsdev test tool has been updated so that it will skip that subtest when run on masters. And this PR creates a new Goss test to run the cmsdev tftp test on a worker node, and adds that new test to the single worker healthcheck suite (so that it will run on a single worker during NCN health checks).

This will ensure that running cmsdev on master nodes will continue to work, but that this test coverage will not be lost, and will instead be covered by the Goss test.

## Issues and Related PRs

- [main branch backport PR](https://github.com/Cray-HPE/csm-testing/pull/461)
- Resolves [CASMCMS-8473](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8473)
- Problem created by the change made in [CASMCMS-8450](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8450)
- Problem reported by [CASMTRIAGE-5071](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5071)
- [cmsdev test tool PR](https://github.com/Cray-HPE/cms-tools/pull/73)
- I will have an additional PR to update the CSM health check docs to note that the cmsdev test tool behaves differently when run on masters and workers. That PR is not yet ready, but it is independent of this PR -- neither one is dependent on the other.

## Testing

I tested the new Goss test and suite on starlord and verified that they worked as expected.

## Risks and Mitigations

Low risk. Creating a new Goss test that just runs an existing test, and adding that new Goss test to an existing Goss suite.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
