### PR TITLE
CASMCMS-8475: Enable tftp cmsdev Goss test on vshasta

### DIFF
--- a/goss-testing/tests/ncn/goss-cray-tftp-check.yaml
+++ b/goss-testing/tests/ncn/goss-cray-tftp-check.yaml
@@ -41,9 +41,4 @@ command:
             - SUCCESS
         # 3 minute test timeout
         timeout: 180000
-        # skip this test on vshasta
-        {{ if eq true .Vars.vshasta }}
-        skip: true
-        {{ else }}
         skip: false
-        {{ end }}


### PR DESCRIPTION
## Summary and Scope

Jeanne tested that the new tftp Goss test works on vshasta, so this PR enables it to run on vshasta.

## Issues and Related PRs

- Modifies test created by [CASMCMS-8473](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8473)

## Testing

Jeanne ran the new test on dorian.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
