### PR TITLE
CASMPET-6425-1.5 : csm-vshasta-deploy test failure - k8s_postgres_clusters_have_leaders

### DIFF
--- a/goss-testing/scripts/postgres_clusters_leader.sh
+++ b/goss-testing/scripts/postgres_clusters_leader.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -57,12 +57,12 @@ do
             echo
         else exit 1; fi
     else
-        lock=$(kubectl logs -n $c_ns $leader postgres | awk '{$1="";$2=""; print $line}' | sort -u | grep 'i am the leader with the lock')
+        lock=$(kubectl logs -n $c_ns $leader postgres | awk '{$1="";$2=""; print $line}' | sort -u | grep 'the leader with the lock')
         if [[ -z $lock ]]
         then
             if [[ $print_results -eq 1 ]]
             then 
-                echo "${c_name}'s leader's logs do not contain 'i am the leader with the lock'."
+                echo "${c_name}'s leader's logs do not contain 'the leader with the lock'."
                 failFlag=1
             else exit 2; fi
         fi


### PR DESCRIPTION
## Summary and Scope

With the latest postgres operator and spilo image upgrade in CSM 1.5 , the logs message has changed somewhat and the test leader check needs to be adjusted

## Issues and Related PRs

* Resolves [CASMPET-6425](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6425)
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after TBD

## Testing

### Tested on:

  * Virtual Shasta v2 - dorian

### Test description:

Prior to CSM 1.5, the postgres logs contained
```
2023-03-16 18:47:16,660 INFO: no action. I am the leader with the lock
```
But with CSM 1.5, this changed to 
```
2023-03-16 18:47:16,660 INFO: no action. I am (keycloak-postgres-0), the leader with the lock
```

Before the fix
```
# ./postgres_clusters_leader.sh -p
cray-nls-postgres's leader's logs do not contain 'i am the leader with the lock'.
cfs-ara-postgres's leader's logs do not contain 'i am the leader with the lock'.
cray-console-data-postgres's leader's logs do not contain 'i am the leader with the lock'.
cray-dns-powerdns-postgres's leader's logs do not contain 'i am the leader with the lock'.
cray-sls-postgres's leader's logs do not contain 'i am the leader with the lock'.
cray-smd-postgres's leader's logs do not contain 'i am the leader with the lock'.
gitea-vcs-postgres's leader's logs do not contain 'i am the leader with the lock'.
keycloak-postgres's leader's logs do not contain 'i am the leader with the lock'.
spire-postgres's leader's logs do not contain 'i am the leader with the lock'.
FAIL
```

After the fix
```
 # ./postgres_clusters_leader.sh -p
PASS
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

