### PR TITLE
CASMPET-6424-1.5 : csm-vshasta-deploy test failure : goss-k8s-velero-no-failed-backups

### DIFF
--- a/goss-testing/scripts/velero_backups_check.sh
+++ b/goss-testing/scripts/velero_backups_check.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 
 # Due to a velero bug, a backup is created anytime the backup schedule is created or updated.
 # Backups should only occurs based upon the cron schedule and not when the schedule itself is created.. 
@@ -48,6 +71,8 @@ cleanup_velero_backups() {
                         delete_count+=1
 		        echo "velero backup delete ${backup_name}"
 	                velero backup delete ${backup_name} --confirm
+                        ns=$(kubectl get backups -A -o json | jq -re ".items[] | select (.metadata.name == \"${backup_name}\") | .metadata.namespace")
+                        while kubectl get backups ${backup_name} -n ${ns}  > /dev/null 2>&1; do echo "waiting for delete of backup to complete"; sleep 1; done
                     fi
                done
 	   fi


### PR DESCRIPTION
## Summary and Scope

Based on the logs, the backup was PartiallyFailed backup was deleted as expected, but the final check still found that it existed - so this is a timing issue.  Added a loop to wait for the backup to be gone from the kubectl perspective. This only look 1-2 seconds when tested on dorian.

## Issues and Related PRs

* Resolves [CASMPET-6424](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6424)
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after TBD

## Testing

### Tested on:

  * Virtual Shasta v2 (dorian)

### Test description:

Tested that the while loop will indeed wait until the backup resource is gone from the the kubectl perspective

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations
Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

