### PR TITLE
CASMPET-6426: Add goss-check-taints test

### DIFF
--- a/goss-testing/suites/ncn-healthcheck-master.yaml
+++ b/goss-testing/suites/ncn-healthcheck-master.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2014-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -44,3 +44,4 @@ gossfile:
   ../tests/goss-spire-healthcheck.yaml: {}
   ../tests/goss-unbound-ip.yaml: {}
   ../tests/goss-validate-certifi-version.yaml: {}
+  ../tests/goss-check-taints.yaml: {}

--- a/goss-testing/tests/ncn/goss-check-taints.yaml
+++ b/goss-testing/tests/ncn/goss-check-taints.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,21 +21,22 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-gossfile:
-  ../tests/goss-k8s-nodes-ready.yaml: {}
-  ../tests/goss-k8s-etcd-service.yaml: {}
-  ../tests/goss-k8s-etcd-members.yaml: {}
-  ../tests/goss-k8s-nexus-can-pull.yaml: {}
-  ../tests/goss-k8s-keycloak-healthy.yaml: {}
-  ../tests/goss-check-mounts-etcdlvm.yaml: {}
-  ../tests/goss-etcdlvm-drive-master.yaml: {}
-  ../tests/goss-k8s-nodes-have-running-pods.yaml: {}
-  ../tests/goss-check-clock-skew.yaml: {}
-  ../tests/goss-k8s-nexus-pods-running.yaml: {}
-  ../tests/goss-k8s-console-services.yaml: {}
-  ../tests/goss-k8s-ipxe-pod-running.yaml: {}
-  ../tests/goss-k8s-kea-pod-running.yaml: {}
-  ../tests/goss-k8s-tftp-pods-running.yaml: {}
-  ../tests/goss-k8s-istio-pods-running.yaml: {}
-  ../tests/goss-k8s-istio-pod-containers-running.yaml: {}
-  ../tests/goss-check-taints.yaml: {}
+ 
+{{ $this_node_name := .Env.HOSTNAME }}
+{{ $kubectl := .Vars.kubectl }}
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
+command:
+    # We are only checking for this taint on master nodes 
+    {{if $this_node_name | regexMatch "^ncn-m.*" }}
+        {{ $testlabel := "master_taint" }}
+        {{$testlabel}}:
+            title: master-taint 
+            meta:
+                desc: Checks that the node-role.kubernetes.io/master:NoSchedule taint exists on this master node. If this tests fails, make the node-role.kubernetes.io/master:NoSchedule gets added to this node. 
+                sev: 0
+            exec: |-
+                "{{$logrun}}" -l "{{$testlabel}}" \
+                    {{$kubectl}} get node {{$this_node_name}}  -o jsonpath='{range .spec.taints[*]}{.key}:{.effect}{"\n"}{end}' | grep "node-role.kubernetes.io/master:NoSchedule" 
+            exit-status: 0
+            timeout: 20000
+    {{end}}


### PR DESCRIPTION
## Summary and Scope

This adds the goss-check-taints test.   This test runs on master nodes only and checks that the node-role.kubernetes.io/master:NoSchedule taint exists for the node on which the test is running.  This test has been added to the ncn-healthcheck-master.yaml suite to be run anytime NCN healthcheck tests are run on master nodes and it has been added to the  ncn-upgrade-tests-master.yaml suite to be run after each master node is upgraded.

## Issues and Related PRs

* Resolves [CASMPET-6426](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6426)
* Related to [CASMTRIAGE-5049](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5049)

## Testing

### Tested on:

  * `fanta`
  * Virtual Shasta - `beau`

### Test description:

Fanta is a system where we recently found that the master taint is missing on m002.   I ran this test on both m002 where it failed and on m003 where it passed.   I ran it with both the ncn-healthcheck-master.yaml and ncn-upgrade-tests-master.yaml suites.

I also ran this on beau to make sure it works in vshasta.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

