### PR TITLE
CASMPET-6429 1.5 : csm-vshasta-deploy test failure : k8s_postgres_pods_per_cluster

### DIFF
--- a/goss-testing/scripts/postgres_pods_running.sh
+++ b/goss-testing/scripts/postgres_pods_running.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,6 +22,14 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+# How many postgres pods should be running?
+#  Do no hard code the number of instances -- determine from postgresql, customizations and/or patronictl list.
+#    - Fail if customizations has set sqlCluster.instanceCount, and the postgresql numberOfInstances is not the same as the
+#           customizations sqlCluster.instanceCount (no clear source of truth).
+#    - Fail if the number of Running pods for the postgres cluster is not the same as the postgresql numberOfInstances.
+#    - Fail if the number of running cluster members (as reported by patronictl list) is not the same as the postgresql 
+#           numberOfInstances.
+
 print_results=0
 while getopts ph stack
 do
@@ -44,45 +52,52 @@ do
     c_ns="$(echo $c | awk -F, '{print $1;}')"
     c_name="$(echo $c | awk -F, '{print $2;}')"
 
-    num_pods_running=$(kubectl get pods -n $c_ns -l "application=spilo,cluster-name=${c_name}" | grep Running | wc -l)
-    clusterFailFlag=0
-    if [[ $c_name == "sma-postgres-cluster" ]]; then
-        if [[ $num_pods_running -ne 2 ]]; then clusterFailFlag=1; fi
-    else
-        if [[ $num_pods_running -ne 3 ]]; then clusterFailFlag=1; fi
+    # Determine the number of postgres pods based on the numberIfInstances from the postgresql cr and the site-init customizations sqlCluster.instanceCount.
+    # If the sqlCluster.instanceCount is set in the customizations and it is not the same as that set in the postgresql cr then fails and continue to the next cluster.
+    num_of_instances=$(kubectl get postgresql -n $c_ns ${c_name} -o json | jq -r '.spec.numberOfInstances')
+    service_name=$(kubectl get postgresql -n $c_ns ${c_name} -o yaml | grep "meta.helm.sh/release-name:" | awk '{print $2}')
+    customization_instance_count=$(kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d | yq read customizations.yaml "spec.kubernetes.services.${service_name}.cray-service*.sqlCluster.instanceCount")
+
+    if [[ ! -z $customization_instance_count ]]; then
+        if [[ $num_of_instances -ne $customization_instance_count ]]; then
+            failFlag=1;
+	    if [[ $print_results -eq 1 ]]
+	    then
+		echo "$c_name -- Postgresql numOfInstances:$num_of_instances and sqlCluster.instanceCount:$customization_instance_count do not match (fail)"
+            fi
+            continue
+	fi
     fi
 
-    if [[ $clusterFailFlag -eq 1 ]]
-    then
+    num_pods_running=$(kubectl get pods -n $c_ns -l "application=spilo,cluster-name=${c_name}" | grep Running | wc -l)
+    if [[ $num_pods_running -ne $num_of_instances ]]; then 
+	failFlag=1
         if [[ $print_results -eq 1 ]]
         then
-            echo "Error: $c_name does not have the expected number of pods Running."
+            echo "$c_name -- Does not have the expected number of $num_pods_running pods Running (fail)"
             kubectl get pods -n $c_ns -l "application=spilo,cluster-name=${c_name}"
             echo
-            failFlag=1;
-        else exit 1; fi
+	fi
+        continue
     fi
 
-    clusterFailFlag=0
     first_member="$(kubectl get pod -n $c_ns -l "cluster-name=$c_name,application=spilo" \
                   -o custom-columns=NAME:.metadata.name --no-headers | head -1)"
     num_patronictl_running=$(kubectl -n $c_ns exec $first_member -c postgres -- patronictl list 2>/dev/null | grep running | wc -l)
-    if [[ $c_name == "sma-postgres-cluster" ]]; then
-        if [[ $num_patronictl_running -ne 2 ]]; then clusterFailFlag=1; fi
-    else
-        if [[ $num_patronictl_running -ne 3 ]]; then clusterFailFlag=1; fi
-    fi
-
-    if [[ $clusterFailFlag -eq 1 ]]
-    then
+    if [[ $num_patronictl_running -ne $num_of_instances ]]; then 
+        failFlag=1
         if [[ $print_results -eq 1 ]]
         then
-            echo "Error: $c_name instances are not running, shown by patronictl command."
+            echo "$c_name -- $num_patronictl_running instances are not running, shown by patronictl command (fail)"
             kubectl -n $c_ns exec $first_member -c postgres -- patronictl list 2>/dev/null
             echo
-            failFlag=1;
-        else exit 1; fi
-    fi
+	fi
+        continue
+     fi
+     if [[ $print_results -eq 1 ]]
+     then
+  	 echo "$c_name -- Running instances (pass)"
+     fi
 done
 
 if [[ $failFlag -eq 0 ]]; then echo "PASS"; exit 0;


### PR DESCRIPTION
## Summary and Scope
Modify the existing postgres goss test that checks for the number of running pods. Check that this is correct as compared 
to customizations, postgresql cr and/or partonictl list.
This will allow for the test to pass in a small vshasta v2 environment where the cluster may be customized to only run one instance.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6429](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6429)
csm-vshasta-deploy test failure : k8s_postgres_pods_per_cluster
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

### Tested on:

  * Virtual Shasta V2 (dorian)

### Test description:
* Fail if override is customizations does not match that defined in the postgresql cr for any cluster - no consistent source of truth
```
# kubectl edit postgresql cfs-ara-postgres -n services
set numberOfInstances to 2
# kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d | yq read customizations.yaml "spec.kubernetes.services.cfs-ara.cray-service*.sqlCluster.instanceCount"
1

# ./postgres_pods_running.sh -p
cray-nls-postgres -- Running instances (pass)
cfs-ara-postgres -- Postgresql numOfInstances:2 and sqlCluster.instanceCount:1 do not match (fail)
cray-console-data-postgres -- Running instances (pass)
cray-dns-powerdns-postgres -- Running instances (pass)
cray-sls-postgres -- Running instances (pass)
cray-smd-postgres -- Running instances (pass)
gitea-vcs-postgres -- Running instances (pass)
keycloak-postgres -- Running instances (pass)
spire-postgres -- Running instances (pass)
FAIL
```

* Fail if 3 pods are not running for any cluster
```
 # kubectl delete pod keycloak-postgres-2 -n services; sleep 1; ./postgres_pods_running.sh -p
pod "keycloak-postgres-2" deleted
cray-nls-postgres -- Running instances (pass)
cfs-ara-postgres -- Running instances (pass)
cray-console-data-postgres -- Running instances (pass)
cray-dns-powerdns-postgres -- Running instances (pass)
cray-sls-postgres -- Running instances (pass)
cray-smd-postgres -- Running instances (pass)
gitea-vcs-postgres -- Running instances (pass)
keycloak-postgres -- Does not have the expected number of 2 pods Running (fail)
NAME                  READY   STATUS     RESTARTS   AGE
keycloak-postgres-0   3/3     Running    0          2d6h
keycloak-postgres-1   3/3     Running    0          2d5h
keycloak-postgres-2   0/3     Init:0/1   0          10s

spire-postgres -- Running instances (pass)
FAIL
```

* Pass if all postgres cluster have the correct number of pods - based on postgresql, customizations and patronictl list
```
# ./postgres_pods_running.sh -p
cray-nls-postgres -- Running instances (pass)
cfs-ara-postgres -- Running instances (pass)
cray-console-data-postgres -- Running instances (pass)
cray-dns-powerdns-postgres -- Running instances (pass)
cray-sls-postgres -- Running instances (pass)
cray-smd-postgres -- Running instances (pass)
gitea-vcs-postgres -- Running instances (pass)
keycloak-postgres -- Running instances (pass)
spire-postgres -- Running instances (pass)
PASS
```

* Run via goss
```
# GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-postgres-pods-running.yaml validate
..

Total Duration: 11.195s
Count: 2, Failed: 0, Skipped: 0
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

