### PR TITLE
CASMINST-6103:  Make sure the HOSTNAME env is set in start-goss-servers.sh

### DIFF
--- a/start-goss-servers.sh
+++ b/start-goss-servers.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -33,6 +33,9 @@ fi
 
 # necessary for kubectl commands to run
 export KUBECONFIG=/etc/kubernetes/admin.conf
+
+# necessary for test that need to know the current hostname
+export HOSTNAME=$(hostname -s | grep -Eo '(ncn-[msw][0-9]{3}|.*-pit)$')
 
 # During the NCN image build, this service is started, even though the csm-testing RPM is not installed. In that
 # situation, the run-ncn-tests.sh file will not be present on the system, but we do not want the service to exit in


### PR DESCRIPTION
## Summary and Scope

Found that goss-servers doesn't have access to the HOSTNAME env at startup.   This makes sure it is set to run any tests that need to know the current hostname.

## Issues and Related PRs

* Resolves [CASMINST-6103](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6103)

## Testing

### Tested on:

  * `drax`

### Test description:

Tested without the change and verified that goss-servers service fails.   Tested with this change and verified that the goss-servers services is running and I was able to run the ncn-healthcheck-master endpoint.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

