### PR TITLE
CASMINST-6130: Fix HOSTNAME var in start-goss-servers.sh

### DIFF
--- a/start-goss-servers.sh
+++ b/start-goss-servers.sh
@@ -35,7 +35,8 @@ fi
 export KUBECONFIG=/etc/kubernetes/admin.conf
 
 # necessary for test that need to know the current hostname
-export HOSTNAME=$(hostname -s | grep -Eo '(ncn-[msw][0-9]{3}|.*-pit)$')
+HOSTNAME=$(hostname -s | grep -Eo '(ncn-[msw][0-9]{3}|.*pit)$')
+export HOSTNAME
 
 # During the NCN image build, this service is started, even though the csm-testing RPM is not installed. In that
 # situation, the run-ncn-tests.sh file will not be present on the system, but we do not want the service to exit in

--- a/start-goss-servers.sh
+++ b/start-goss-servers.sh
@@ -35,7 +35,7 @@ fi
 export KUBECONFIG=/etc/kubernetes/admin.conf
 
 # necessary for test that need to know the current hostname
-HOSTNAME=$(hostname -s | grep -Eo '(ncn-[msw][0-9]{3}|.*pit)$')
+HOSTNAME=$(hostname -s)
 export HOSTNAME
 
 # During the NCN image build, this service is started, even though the csm-testing RPM is not installed. In that


### PR DESCRIPTION
## Summary and Scope

The HOSTNAME var being set in start-goss-servers.sh doesn't handle the hostname of the pit in vshasta because it is just "pit".   I removed the dash before the pit because it is not needed.   It was only there because I borrowed the regex from run-ncn-tests.sh. 

I also split the export from the var definition to match the same thing done in the main branch to satisfy shell-check.

## Issues and Related PRs

* Resolves [CASMINST-6130](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6130)

## Testing

### Tested on:

  * `fanta`
  * Virtual Shasta - `cilium`

### Test description:

On both fanta's m002 and cilium's pit node, I started the goss-servers service and made sure that there were no errors.  I also ran `curl http://ncn-m002.hmn:8997/ncn-healthcheck-master` on fanta to make sure the endpoint still works.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

