### PR TITLE
CASMPET-6447 Update spire tests to handle cray-spire

### DIFF
--- a/goss-testing/suites/ncn-healthcheck-master-single.yaml
+++ b/goss-testing/suites/ncn-healthcheck-master-single.yaml
@@ -42,7 +42,8 @@ gossfile:
   ../tests/goss-k8s-velero-backup-storage-locations-available.yaml: {}
   ../tests/goss-k8s-velero-backup-vault-schedule-exists.yaml: {}
   ../tests/goss-k8s-velero-no-failed-backups.yaml: {}
+  ../tests/goss-cray-spire-check-key-id-in-jwks.yaml: {}
+  ../tests/goss-cray-spire-verify-pods.yaml: {}
   ../tests/goss-spire-bss-metadata-exist.yaml: {}
-  ../tests/goss-spire-check-key-id-in-jwks.yaml: {}
   ../tests/goss-spire-verify-api-fetch-jwt.yaml: {}
   ../tests/goss-spire-verify-pods.yaml: {}

--- a/goss-testing/suites/ncn-spire-healthchecks.yaml
+++ b/goss-testing/suites/ncn-spire-healthchecks.yaml
@@ -22,9 +22,10 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 gossfile:
+  ../tests/goss-cray-spire-check-key-id-in-jwks.yaml: {}
+  ../tests/goss-cray-spire-verify-pods.yaml: {}
   ../tests/goss-spire-healthcheck.yaml: {}
   ../tests/goss-spire-bss-metadata-exist.yaml: {}
   ../tests/goss-spire-verify-pods.yaml: {}
   ../tests/goss-spire-verify-api-fetch-jwt.yaml: {}
-  ../tests/goss-spire-check-key-id-in-jwks.yaml: {}
   ../tests/goss-spire-agent-service-running.yaml: {}

--- a/goss-testing/tests/ncn/goss-cray-spire-check-key-id-in-jwks.yaml
+++ b/goss-testing/tests/ncn/goss-cray-spire-check-key-id-in-jwks.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,22 +21,13 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-
-{{ $kubectl := .Vars.kubectl }}
-{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-    {{ $testlabel := "k8s_verify_spire_pods" }}
-    {{$testlabel}}:
-        title: Spire Pods
-        meta:
-            desc: Kubernetes spire namespace pods are running.
-            sev: 0
-        exec: |-
-            "{{$logrun}}" -l "{{$testlabel}}" \
-                "{{$kubectl}}" get po -n spire -o custom-columns=:.metadata.name,:status.phase --no-headers
-        stdout:
-            - /^spire-agent-.*Running/
-            - /^spire-jwks-.*Running/
-            - /^spire-postgres-.*Running/
-            - /^spire-server-.*Running/
-        exit-status: 0
+  spire_check_key_id_in_jwks:
+    title: Validate token key ID exists in cray-spire jwks
+    meta:
+      desc: Validate token key ID exists in spire jwks. If this fails, try running kubectl rollout restart -n spire daemonset cray-spire-agent and kubectl rollout restart -n spire deployment cray-spire-jwks
+      sev: 0
+    exec: kubectl exec -itn spire spire-postgres-0 -c postgres -- curl http://cray-spire-jwks/keys | jq -r '.[][].kid' | grep $(/usr/bin/heartbeat-spire-agent api fetch jwt -socketPath /root/spire/agent.sock -audience goss-test | head -n2 | awk -F. 'FNR==2{sub(/^[ \t]+/, ""); print $1}' | base64 -d 2>/dev/null| jq -r .kid)
+    exit-status: 0
+    timeout: 20000
+    skip: false

--- a/goss-testing/tests/ncn/goss-cray-spire-verify-pods.yaml
+++ b/goss-testing/tests/ncn/goss-cray-spire-verify-pods.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,13 +21,23 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+{{ $kubectl := .Vars.kubectl }}
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
-  spire_check_key_id_in_jwks:
-    title: Validate token key ID exists in spire jwks
-    meta:
-      desc: Validate token key ID exists in spire jwks. If this fails, try running kubectl rollout restart -n spire daemonset spire-agent and kubectl rollout restart -n spire deployment spire-jwks
-      sev: 0
-    exec: kubectl exec -itn spire spire-postgres-0 -c postgres -- curl http://spire-jwks/keys | jq -r '.[][].kid' | grep $(/usr/bin/heartbeat-spire-agent api fetch jwt -socketPath /root/spire/agent.sock -audience goss-test | head -n2 | awk -F. 'FNR==2{sub(/^[ \t]+/, ""); print $1}' | base64 -d 2>/dev/null| jq -r .kid)
-    exit-status: 0
-    timeout: 20000
-    skip: false
+    {{ $testlabel := "k8s_verify_spire_pods" }}
+    {{$testlabel}}:
+        title: Cray-Spire Pods
+        meta:
+            desc: Kubernetes cray-spire namespace pods are running.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$kubectl}}" get po -n spire -o custom-columns=:.metadata.name,:status.phase --no-headers
+        stdout:
+            - /^request-ncn-join-token-.*Running/
+            - /^cray-spire-agent-.*Running/
+            - /^cray-spire-jwks-.*Running/
+            - /^cray-spire-postgres-.*Running/
+            - /^cray-spire-server-.*Running/
+        exit-status: 0


### PR DESCRIPTION
## Summary and Scope

This adds and updates tests to account for running multiple spire deployments in CSM 1.5.

## Issues and Related PRs

* Partially Resolves [CASMPET-6447](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6447)

## Testing

No test environment available.

### Test description:

No testing done.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N, no test environment available
- Was downgrade tested? If not, why? N, no test environment available
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

No way to test this outside of the CSM 1.5 pipeline. Won't cause issues, but may continue to fail the build.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [☹️] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

