### PR TITLE
Add grace period for etcd statefulsets not old enough for backup

### DIFF
--- a/goss-testing/scripts/etcd_backups_check.sh
+++ b/goss-testing/scripts/etcd_backups_check.sh
@@ -32,17 +32,46 @@ do
     esac
 done
 
+#
+# Since clusters subscribed to disaster recovery will have a
+# snapshot taken when the cluster first starts, and the cronjob
+# that pushes snapshots to S3 happens just after the top of the
+# hour, two hours should be enough to have a backup if things are
+# working.  Even though below we check has_recent_backup (below)
+# within a day, that should succeed.
+#
+check_ss_old_enough() {
+    cluster=$1
+    old_enough=0
+    now=$(date +"%s")
+    two_hours_sec=7200
+    create_date=$(kubectl get statefulsets.apps -n services ${cluster}-bitnami-etcd -o jsonpath='{.metadata.creationTimestamp}')
+    create_sec=$(date -d "${create_date}" "+%s" 2>/dev/null)
+    if [[ ! -z $create_sec && $(( $now - $create_sec )) -ge $two_hours_sec ]]; then
+        old_enough=1
+    fi
+    echo $old_enough
+}
+
 error_flag=0
 
 clusters=$(kubectl get statefulsets.apps -A | grep bitnami-etcd | awk '{print $2}')
 for c in $clusters; do
   short_name=$(echo $c | sed s/-bitnami-etcd//g)
   ns=$(kubectl get statefulset -A -o json | jq --arg name ${c} '.items[].metadata | select (.name==$name) | .namespace' | sed 's/\"//g')
+
   dr_setting=$(kubectl get statefulsets.apps -n ${ns} ${c} -o json | jq -r '.spec.template.spec.containers[].env[] | select(."name" == "ETCD_DISASTER_RECOVERY") | .value')
   if [ "$dr_setting" != "yes" ]; then
     echo "$short_name -- not configured for disaster recovery, skipping..."
     continue
   fi
+
+  old_enough=$(check_ss_old_enough $short_name)
+  if [ ! $old_enough ]; then
+    echo "$short_name -- not old enough to expect backups, skipping..."
+    continue
+  fi
+
   #
   # Need to chop off the goofy carriage return in the result from the pod
   #

--- a/goss-testing/tests/ncn/goss-k8s-etcd-backups.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-etcd-backups.yaml
@@ -30,7 +30,7 @@ command:
     {{$testlabel}}:
         title: All Kubernetes Etcd Clusters have a Backup Created within the Last 24 Hours.
         meta:
-            desc: If this test fails, run the script "{{$etcd_backups_check}} -p" to see a printed description of the errors. Check that cron jobs are running and creating backups periodically with the command "kubectl -n operators get cronjob kube-etcd-periodic-backup-cron". To see the last scheduled time, run the command "kubectl -n operators get cronjob kube-etcd-periodic-backup-cron -o jsonpath='{.status}'". To restart the cronjob, execute "kubectl -n operators get cronjob kube-etcd-periodic-backup-cron -o json | jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels."controller-uid")' | jq 'del(.status)' | kubectl replace --force -f -".
+            desc: If this test fails, run the script "{{$etcd_backups_check}}" to see a description of the errors. Check that cron jobs that publish snapshots to S3 are running with the command "kubectl -n services get cronjob etcd-backup-pvc-snapshots-to-s3". To see the last scheduled time, run the command "kubectl -n services get cronjob etcd-backup-pvc-snapshots-to-s3 -o jsonpath='{.status}'". To restart the cronjob, execute "kubectl -n services get cronjob etcd-backup-pvc-snapshots-to-s3 -o json | jq 'del(.spec.selector)' | jq 'del(.spec.template.metadata.labels."controller-uid")' | jq 'del(.status)' | kubectl replace --force -f -".
             sev: 0
         exec: |-
             "{{$logrun}}" -l "{{$testlabel}}" \


### PR DESCRIPTION
### Summary and Scope

Add grace period in etcd test that checks for backups

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6446

### Testing

* ashton

```
ncn-m002:~ # bash -x /tmp/foo.sh 2>&1 | grep -e old_enough -e Pass
++ check_ss_old_enough cray-bos
++ old_enough=0
++ old_enough=1
+ old_enough=1
+ result=Pass
+ '[' Pass == Pass ']'
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
