### PR TITLE
CASMINST-6097 Add HMS CT tests and CMS service tests

### DIFF
--- a/goss-testing/automated/run-ncn-tests.sh
+++ b/goss-testing/automated/run-ncn-tests.sh
@@ -656,6 +656,22 @@ function add_local_vars {
         var_string+="  - ${node}\n"
     done
 
+    # add list of CMS tests, if cmsdev utility is present
+    if [ -f /usr/local/bin/cmsdev ]; then
+        var_string+="\ncms_tests:\n"
+        for test in $(/usr/local/bin/cmsdev test -l --exclude-aliases); do
+            var_string+="  - ${test}\n"
+        done
+    fi
+
+    # add list of HMS CT tests, if run_hms_ct_tests.sh script is present
+    if [ -f /opt/cray/csm/scripts/hms_verification/run_hms_ct_tests.sh ]; then
+        var_string+="\nhms_ct_tests:\n"
+        for test in $(/opt/cray/csm/scripts/hms_verification/run_hms_ct_tests.sh -l); do
+            var_string+="  - ${test}\n"
+        done
+    fi
+
     var_string+="\n${is_vshasta}\n"
 
     echo -e "${var_string}" >> "$1"

--- a/goss-testing/dat/goss-servers.cfg
+++ b/goss-testing/dat/goss-servers.cfg
@@ -35,3 +35,7 @@
 9003       ncn-afterpitreboot-kubernetes-tests-worker-single.yaml  worker
 
 9004       ncn-storage-tests.yaml                                  storage
+
+9005       ncn-cms-tests.yaml                                      master worker
+
+9006       ncn-hms-ct-tests.yaml                                   master

--- a/goss-testing/suites/ncn-cms-tests.yaml
+++ b/goss-testing/suites/ncn-cms-tests.yaml
@@ -1,0 +1,25 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+gossfile:
+  ../tests/goss-cms-tests.yaml: {}

--- a/goss-testing/suites/ncn-hms-ct-tests.yaml
+++ b/goss-testing/suites/ncn-hms-ct-tests.yaml
@@ -1,0 +1,25 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+gossfile:
+  ../tests/goss-hms-ct-tests.yaml: {}

--- a/goss-testing/tests/ncn/goss-cms-tests.yaml
+++ b/goss-testing/tests/ncn/goss-cms-tests.yaml
@@ -1,0 +1,33 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
+command:
+  {{ range $test := index .Vars "cms_tests"}}
+  cms-test-{{ $test }}:
+    exec: "{{$logrun}} -l cms-test-{{ $test }} /usr/local/bin/cmsdev test -v {{ $test }}"
+    exit-status: 0
+    timeout: 300000
+    skip: false
+  {{ end }}

--- a/goss-testing/tests/ncn/goss-hms-ct-tests.yaml
+++ b/goss-testing/tests/ncn/goss-hms-ct-tests.yaml
@@ -1,0 +1,33 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
+command:
+  {{ range $test := index .Vars "hms_ct_tests"}}
+  hms-ct-test-{{ $test }}:
+    exec: "{{$logrun}} -l hms-ct-test-{{ $test }} /opt/cray/csm/scripts/hms_verification/run_hms_ct_tests.sh -t {{ $test }} -p"
+    exit-status: 0
+    timeout: 300000
+    skip: false
+  {{ end }}


### PR DESCRIPTION
## Summary and Scope

Add 2 new goss test suites for HMS CT tests and CMS tests. List of tests for each suite is generated dynamically at the moment when goss server starts. Suites are bound to dedicated port numbers `9005` and `9006` on master nodes.

## Issues and Related PRs

* Resolves [CASMINST-6097](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6097)

## Testing
### Tested on:

  * Virtual Shasta

### Test description:

Executed vShasta pipeline, which supports overriding of `csm-testing` and `goss-servers` packages:
https://jenkins.algol60.net/blue/organizations/jenkins/Cray-HPE%2Fcsm-vshasta-deploy/detail/feature%2Fhms-cms-tests/34/tests/

Tests were successfully executed and results recorded. From CMS tests, 3 tests failed (`vcs`, `ims` and `bos`). The 2 latter tests failed due to 1 minute timeout expiration, so I have already increased this timeout to 5 minutes. From HMS tests, 2 tests failed (`capmc` and `pcs`). Failures were properly recorded and available for investigation.

## Risks and Mitigations

Low - new functionality for test framework only.
