### PR TITLE
Fix logic for etcd backup test (CASMPET-6461)

### DIFF
--- a/goss-testing/scripts/etcd_backups_check.sh
+++ b/goss-testing/scripts/etcd_backups_check.sh
@@ -67,7 +67,7 @@ for c in $clusters; do
   fi
 
   old_enough=$(check_ss_old_enough $short_name)
-  if [ ! $old_enough ]; then
+  if [[ $old_enough -eq 0 ]]; then
     echo "$short_name -- not old enough to expect backups, skipping..."
     continue
   fi


### PR DESCRIPTION
### Summary and Scope

Fix logic for detecting statefulset age.

### Issues and Related PRs

* https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6461

### Testing

* yasha

```
ncn-m002:/opt/cray/tests/install/ncn/scripts # export GOSS_BASE=/opt/cray/tests/install/ncn; goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-etcd-backups.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
..

Total Duration: 0.582s
Count: 2, Failed: 0, Skipped: 0
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
