### PR TITLE
CASMINST-6097 Add CMS service tests

### DIFF
--- a/goss-testing/automated/run-ncn-tests.sh
+++ b/goss-testing/automated/run-ncn-tests.sh
@@ -650,6 +650,14 @@ function add_local_vars {
         var_string+="  - ${node}\n"
     done
 
+    # add list of CMS tests, if cmsdev utility is present
+    if [ -f /usr/local/bin/cmsdev ]; then
+        var_string+="\ncms_tests:\n"
+        for test in $(/usr/local/bin/cmsdev test -l --exclude-aliases); do
+            var_string+="  - ${test}\n"
+        done
+    fi
+
     var_string+="\n${is_vshasta}\n"
 
     echo -e "${var_string}" >> "$1"

--- a/goss-testing/dat/goss-servers.cfg
+++ b/goss-testing/dat/goss-servers.cfg
@@ -35,3 +35,6 @@
 9003       ncn-afterpitreboot-kubernetes-tests-worker-single.yaml  worker
 
 9004       ncn-storage-tests.yaml                                  storage
+
+9005       ncn-cms-tests.yaml                                      master worker
+

--- a/goss-testing/suites/ncn-cms-tests.yaml
+++ b/goss-testing/suites/ncn-cms-tests.yaml
@@ -1,0 +1,25 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+gossfile:
+  ../tests/goss-cms-tests.yaml: {}

--- a/goss-testing/tests/ncn/goss-cms-tests.yaml
+++ b/goss-testing/tests/ncn/goss-cms-tests.yaml
@@ -1,0 +1,33 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
+command:
+  {{ range $test := index .Vars "cms_tests"}}
+  cms-test-{{ $test }}:
+    exec: "{{$logrun}} -l cms-test-{{ $test }} /usr/local/bin/cmsdev test -v {{ $test }}"
+    exit-status: 0
+    timeout: 300000
+    skip: false
+  {{ end }}


### PR DESCRIPTION
## Summary and Scope

Backport CMS part of https://github.com/Cray-HPE/csm-testing/pull/478 to `release/1.4`.

## Issues and Related PRs

* Resolves [CASMINST-6097](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6097)

## Testing
### Tested on:

  * Virtual Shasta

### Test description:

Running a build with `csm-testing` and `goss-servers` packages overridden:
https://jenkins.algol60.net/blue/organizations/jenkins/Cray-HPE%2Fcsm-vshasta-deploy/detail/release%2F1.4/23/pipeline

## Risks and Mitigations

Low - new functionality for test framework only.
