### PR TITLE
CASMPET-6447 Update spire socket path.

### DIFF
--- a/goss-testing/tests/ncn/goss-cray-spire-check-key-id-in-jwks.yaml
+++ b/goss-testing/tests/ncn/goss-cray-spire-check-key-id-in-jwks.yaml
@@ -27,7 +27,7 @@ command:
     meta:
       desc: Validate token key ID exists in spire jwks. If this fails, try running kubectl rollout restart -n spire daemonset cray-spire-agent and kubectl rollout restart -n spire deployment cray-spire-jwks
       sev: 0
-    exec: kubectl exec -itn spire spire-postgres-0 -c postgres -- curl http://cray-spire-jwks/keys | jq -r '.[][].kid' | grep $(/usr/bin/heartbeat-spire-agent api fetch jwt -socketPath /root/spire/agent.sock -audience goss-test | head -n2 | awk -F. 'FNR==2{sub(/^[ \t]+/, ""); print $1}' | base64 -d 2>/dev/null| jq -r .kid)
+    exec: kubectl exec -itn spire spire-postgres-0 -c postgres -- curl http://cray-spire-jwks/keys | jq -r '.[][].kid' | grep $(/usr/bin/heartbeat-spire-agent api fetch jwt -socketPath /var/lib/spire/agent.sock -audience goss-test | head -n2 | awk -F. 'FNR==2{sub(/^[ \t]+/, ""); print $1}' | base64 -d 2>/dev/null| jq -r .kid)
     exit-status: 0
     timeout: 20000
     skip: false

--- a/goss-testing/tests/ncn/goss-spire-healthcheck.yaml
+++ b/goss-testing/tests/ncn/goss-spire-healthcheck.yaml
@@ -41,7 +41,7 @@ command:
             sev: 0
         exec: |-
             "{{$logrun}}" -l "{{$testlabel}}" \
-                spire-agent healthcheck -socketPath /root/spire/agent.sock
+                spire-agent healthcheck -socketPath /var/lib/spire/agent.sock
         exit-status: 0
         timeout: 20000
         skip: false

--- a/goss-testing/tests/ncn/goss-spire-verify-api-fetch-jwt.yaml
+++ b/goss-testing/tests/ncn/goss-spire-verify-api-fetch-jwt.yaml
@@ -33,7 +33,7 @@ command:
         # We do not want to log stdout from this command, so we call log_run with --no-stdout
         exec: |-
             "{{$logrun}}" -l "{{$testlabel}}" --no-stdout \
-                /usr/bin/heartbeat-spire-agent api fetch jwt -socketPath /root/spire/agent.sock -audience goss-test >/dev/null
+                /usr/bin/heartbeat-spire-agent api fetch jwt -socketPath /var/lib/spire/agent.sock -audience goss-test >/dev/null
         exit-status: 0
         timeout: 20000
         skip: false


### PR DESCRIPTION
## Summary and Scope

The /root/spire path is obsolete and should be changed to it's new path, /var/lib/spire.

## Issues and Related PRs

* Resolves [CASMPET-6447](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6447)

## Testing

No environments available to test.

### Test description:

This is another attempt to fix a test being run in the CSM 1.5 test pipeline.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This may not be the issue, but it should still be updated.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

