### PR TITLE
Fix Jenkins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # Look for `.github/workflows` in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+    labels:
+      - "github_actions"
+      - "dependencies"

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -25,8 +25,23 @@
  */
 @Library('csm-shared-library') _
 
-def isStable = env.TAG_NAME != null ? true : false
 def sleImage = 'artifactory.algol60.net/csm-docker/stable/csm-docker-sle'
+// Disable pr-merge builds; not used.
+if (env.BRANCH_NAME ==~ ~"^PR-\\d+") {
+    currentBuild.result = 'SUCCESS'
+    echo "Pull-Request builds are skipped."
+    return
+} else if (env.BRANCH_NAME ==~ ~"^dependabot/github_actions") {
+    currentBuild.result = 'SUCCESS'
+    echo "Dependabot GitHub action builds are skipped."
+    return
+}
+
+// Only consider X.Y.Z as stable
+// Never consider X.Y.Z{[a|b|rc} or X.Y.Z.* tags as stable.
+// The ==~ operator performs an exact match.
+def stableToken = ~/v?\d+\.\d+\.\d+/
+def isStable = (env.TAG_NAME != null & env.TAG_NAME ==~ stableToken) ? true : false
 pipeline {
 
     agent {
@@ -41,86 +56,93 @@ pipeline {
     }
 
     environment {
+        ARCH = 'noarch'
         NAME = getRepoName()
-        VERSION = sh(returnStdout: true, script: "git describe --tags | tr -s '-' '~' | tr -d '^v'").trim()
+        VERSION = sh(returnStdout: true, script: "git describe --tags | tr -s '-' '~' | sed 's/^v//'").trim()
     }
 
     stages {
+
+        stage('Prepare') {
+            steps {
+                script {
+                    // lock .git for writing - otherwise getting "content has changed" error while preparing tar.bz2 for RPM
+                    sh "chmod -R a-w .git"
+                }
+            }
+        }
 
         stage('Build & Publish') {
 
             matrix {
 
                 agent {
-                    node {
-                        label "metal-gcp-builder"
-                        customWorkspace "${env.WORKSPACE}/${sleVersion}"
+                    docker {
+                        args '-v /home/jenkins/.ssh:/home/jenkins/.ssh'
+                        reuseNode true
+                        image "${sleImage}:${SLE_VERSION}"
                     }
                 }
 
                 axes {
                     axis {
-                        name 'sleVersion'
-                        values 15.3, 15.4
+                        name 'SLE_VERSION'
+                        values '15.4', '15.3'
                     }
+                }
+
+                environment {
+                    BUILD_DIR = "${env.WORKSPACE}/dist/rpmbuild/${ARCH}/${SLE_VERSION}"
                 }
 
                 stages {
 
                     stage('Prepare: RPMs') {
-                        agent {
-                            docker {
-                                label 'docker'
-                                reuseNode true
-                                image "${sleImage}:${sleVersion}"
-                            }
-                        }
                         steps {
-                            runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
                             sh "make prepare"
-                            sh "git update-index --assume-unchanged ${env.NAME}.spec"
+
+                            // Inject distro-specific metadata (e.g. which distro and service pack).
+                            // Change into the env.BUILD_DIR to prevent runLibraryScript from removing another axis' script.
+                            dir("${env.BUILD_DIR}/SPECS/") {
+                                runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
+                            }
                         }
                     }
 
                     stage('Build: RPMs') {
-                        agent {
-                            docker {
-                                label 'docker'
-                                reuseNode true
-                                image "${sleImage}:${sleVersion}"
-                            }
-                        }
                         steps {
                             sh "make rpm"
                         }
                     }
 
                     stage('Publish: RPMs') {
+
                         steps {
                             script {
+                                def sleVersion = sh(returnStdout: true, script: 'awk -F= \'/VERSION_ID/{gsub(/["]/,""); print \$NF}\' /etc/os-release').trim()
                                 def sles_version_parts = "${sleVersion}".tokenize('.')
                                 def sles_major = "${sles_version_parts[0]}"
                                 def sles_minor = "${sles_version_parts[1]}"
                                 publishCsmRpms(
-                                        arch: "noarch",
+                                        arch: "${ARCH}",
                                         component: env.NAME,
                                         isStable: isStable,
                                         os: "sle-${sles_major}sp${sles_minor}",
-                                        pattern: "dist/rpmbuild/RPMS/noarch/${env.NAME}-*.rpm",
-                                )
-                                publishCsmRpms(
-                                        arch: "noarch",
-                                        component: 'goss-servers',
-                                        isStable: isStable,
-                                        os: "sle-${sles_major}sp${sles_minor}",
-                                        pattern: "dist/rpmbuild/RPMS/noarch/goss-servers-*.rpm",
+                                        pattern: "dist/rpmbuild/${ARCH}/${SLE_VERSION}/RPMS/${ARCH}/${env.NAME}-*.rpm",
                                 )
                                 publishCsmRpms(
                                         arch: "src",
                                         component: env.NAME,
                                         isStable: isStable,
                                         os: "sle-${sles_major}sp${sles_minor}",
-                                        pattern: "dist/rpmbuild/SRPMS/*.rpm",
+                                        pattern: "dist/rpmbuild/${ARCH}/${SLE_VERSION}/SRPMS/*.rpm",
+                                )
+                                publishCsmRpms(
+                                        arch: "noarch",
+                                        component: 'goss-servers',
+                                        isStable: isStable,
+                                        os: "sle-${sles_major}sp${sles_minor}",
+                                        pattern: "dist/rpmbuild/${ARCH}/${SLE_VERSION}/RPMS/${ARCH}/goss-servers*.rpm",
                                 )
                             }
                         }

--- a/csm-testing.spec
+++ b/csm-testing.spec
@@ -36,7 +36,7 @@ Version: %(echo $VERSION)
 Release: 1
 Source: %{name}-%{version}.tar.bz2
 Vendor: HPE
-BuildArchitectures: noarch
+BuildArchitectures: %(echo $ARCH)
 
 %description
 Tests to test the set-up during installation.


### PR DESCRIPTION
This change does a few things.

1. It fixes a race condition in the `matrix` where one axis overrides the other axis' delivery point. We've observed the SP3 build publishing RPMs into the SP4 build on more than one occasion (see https://jenkins.algol60.net/blue/organizations/jenkins/Cray-HPE%2Fcsm-testing/detail/v1.15.43/2/pipeline/105#step-205-log-2). This is often "fixed" by a re-run, but that has no guarantees of working.
1. This lightens the load on Jenkins by restricting the build to a single GCP agent and spawning a container atop that agent for each axis. Right now multiple hosts are requested, this adds needless demand to Jenkins and is slower.
1. This updates the `Makefile` and `csm-testing.spec` to accommodate the above changes
1. Adds `dependabot.yaml` for auto-updating GitHub workflows
