### PR TITLE
CASMINST-6306 Fix perms and update systemd

### DIFF
--- a/csm-testing.spec
+++ b/csm-testing.spec
@@ -123,7 +123,7 @@ install -m 644 goss-testing/dat/*       %{buildroot}%{dat}
 mkdir -p %{buildroot}/usr/sbin
 mkdir -p %{buildroot}/etc/systemd/system/
 install -m 755 start-goss-servers.sh %{buildroot}/usr/sbin/
-install -m 755 goss-servers.service %{buildroot}/etc/systemd/system/
+install -m 644 goss-servers.service %{buildroot}/etc/systemd/system/
 
 %clean
 rm -rf %{buildroot}%{dat}

--- a/csm-testing.spec
+++ b/csm-testing.spec
@@ -144,6 +144,24 @@ rmdir %{buildroot}%{logs} || true
 %package -n goss-servers
 Summary: Goss Health Check Endpoint Service
 
+# helps when installing a program whose unit files makes use of a feature only available in a newer systemd version
+# If the program is installed on its own, it will have to make do with the available features
+# If a newer systemd package is planned to be installed in the same transaction as the program,
+# it can be beneficial to have systemd installed first, so that the features have become available by the time program is installed and restarted
+%{?systemd_ordering}
+
+%pre -n goss-servers
+%service_add_pre goss-servers.service
+
+%post -n goss-servers
+%service_add_post goss-servers.service
+
+%preun -n goss-servers
+%service_del_preun goss-servers.service
+
+%postun -n goss-servers
+%service_del_postun goss-servers.service
+
 %description -n goss-servers
 Sets up a systemd service for running Goss health check servers
 

--- a/goss-servers.service
+++ b/goss-servers.service
@@ -24,7 +24,7 @@
 [Unit]
 Description=goss-servers
 After=network.target
-StartLimitInterval=0
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple


### PR DESCRIPTION
The `goss-servers.service` file is installed with executable permissions which cause extraneous errors to print to console:

![image](https://user-images.githubusercontent.com/7772179/236695545-c9ba53b3-8559-4983-967e-16853291e858.png)

This also patches up some systemd handling:
- `StartLimitInterval` is deprecated in favor of `StartLimitIntervalSec`
- Includes `systemd` macros in the RPM spec for goss-servers to enable/replace/remove the service properly when the RPM is installed and/or updated
