### PR TITLE
CASMINST-6342: Skip goss-rgw-health.yaml on vshasta

### DIFF
--- a/goss-testing/tests/ncn/goss-rgw-health.yaml
+++ b/goss-testing/tests/ncn/goss-rgw-health.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -37,4 +37,9 @@ command:
                 "{{$rgw_health_check}}"
         exit-status: 0
         timeout: 180000
+        # skip this test on vshasta
+        {{ if eq true .Vars.vshasta }}
+        skip: true
+        {{ else }}
         skip: false
+        {{ end }}


### PR DESCRIPTION
## Summary and Scope

The goss-rgw-health test fails on vshasta because it doesn't have an HMN network.   Adding the vshasta skip to this test.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-6342](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6342)

## Testing

### Tested on:

  * Virtual Shasta - grog

### Test description:

Ran the preflight checks in prerequisites on grog and verified that this test was skipped.

## Risks and Mitigations

Low


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

