### PR TITLE
CASMTRIAGE-5616: Update iPXE check to look for the x86-64 iPXE pod specifically

### DIFF
--- a/goss-testing/tests/ncn/goss-k8s-ipxe-pod-running.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-ipxe-pod-running.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2014-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,18 +22,22 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
+# This test specifically validates the iPXE pod that builds x86-64 binaries.
+# There is also an iPXE pod for aarch64 binaries, but we do not include it in our Goss
+# tests, since it is not needed for basic CSM functionality. Testing of that is
+# covered by the cmsdev tool in the cmstools RPM.
 {{ $kubectl := .Vars.kubectl }}
 {{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
     {{ $testlabel := "k8s_service_ipxe_running" }}
     {{$testlabel}}:
-        title: Kubernetes Service 'cray-ipxe' Is Running
+        title: Kubernetes Service 'cray-ipxe-x86-64' Is Running
         meta:
-            desc: If this test fails, look at the state of the ipxe pod (kubectl get po -n services | grep cray-ipxe) to investigate.
+            desc: If this test fails, look at the state of the cray-ipxe-x86-64 pod (kubectl get po -n services | grep cray-ipxe-x86-64) to investigate.
             sev: 0
         exec: |-
             "{{$logrun}}" -l "{{$testlabel}}" \
-                "{{$kubectl}}" get pods -n services -l 'app.kubernetes.io/name=cray-ipxe' |
+                "{{$kubectl}}" get pods -n services -l 'app.kubernetes.io/name=cray-ipxe-x86-64' |
                 awk '{ print $3 }' |
                 grep Running
         exit-status: 0


### PR DESCRIPTION
## Summary and Scope

In CSM 1.5, cray-ipxe now has two pods -- one which builds x86-64 binaries, and one which builds aarch64. The labels of these pods are both different from the previous iPXE pod label, which is causing a Goss test to fail. This test is run to ensure that NCN boots will work, so in that context we are only concerned with the x86-64 iPXE pod. The cmsdev test tool already includes more complete test coverage of iPXE, including the new aarch64 binaries, so it doesn't make sense to duplicate that here.

This modifies the test to use the correct label for the x86-64 pod.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5616](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5616)
* Related to the changes made to cmsdev with [CASMCMS-8504](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8504)

## Testing

I tested the updated `kubectl` command on ashton (installed with csm-1.5.0-alpha.66) and verified that it works.

## Risks and Mitigations

Without this change, this test will always fail.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
