### PR TITLE
CASMTRIAGE-5630: Split iPXE check into two tests

### DIFF
--- a/goss-testing/suites/ncn-patch-upgrade-preflight-tests.yaml
+++ b/goss-testing/suites/ncn-patch-upgrade-preflight-tests.yaml
@@ -1,0 +1,49 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# This suite is run from the prerequisites.sh script during a CSM upgrade
+# to a new patch version. It is not run from prerequisites.sh during a CSM
+# upgrade to a new major/minor version.
+#
+# When it is run, neither the services nor the NCNs have been upgraded. They
+# are still running the previous version of CSM.
+
+gossfile:
+  ../tests/goss-dns-nodes.yaml: {}
+  ../tests/goss-k8s-nodes-ready.yaml: {}
+  ../tests/goss-command-available.yaml: {}
+  ../tests/goss-bond-members-have-links.yaml: {}
+  ../tests/goss-unbound-ip.yaml: {}
+  ../tests/goss-bond-members-have-correct-mtu.yaml: {}
+  ../tests/goss-ceph-storage-health.yaml: {}
+  ../tests/goss-k8s-cray-cli-configured.yaml: {}
+  ../tests/goss-rgw-health.yaml: {}
+  ../tests/goss-k8s-nexus-pods-running.yaml: {}
+  ../tests/goss-k8s-ipxe-pod-running.yaml: {}
+  ../tests/goss-k8s-kea-pod-running.yaml: {}
+  ../tests/goss-k8s-tftp-pods-running.yaml: {}
+  ../tests/goss-postgresql-syncfailed.yaml: {}
+  ../tests/goss-ip-dns-check.yaml: {}
+  ../tests/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml: {}
+  ../tests/goss-k8s-nexus-space.yaml: {}

--- a/goss-testing/suites/ncn-post-csm-service-upgrade-tests.yaml
+++ b/goss-testing/suites/ncn-post-csm-service-upgrade-tests.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,6 +21,11 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+# These tests are run after CSM services have been upgraded to the current
+# CSM version. Note that the NCNs have not necessarily been upgraded yet,
+# only the services.
+
 gossfile:
   ../tests/goss-dns-nodes.yaml: {}
   ../tests/goss-k8s-nodes-ready.yaml: {}

--- a/goss-testing/suites/ncn-upgrade-preflight-tests.yaml
+++ b/goss-testing/suites/ncn-upgrade-preflight-tests.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2014-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,6 +21,11 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+# This suite is run from the prerequisites.sh script during a CSM upgrade.
+# When it is run, neither the services nor the NCNs have been upgraded. They
+# are still running the previous version of CSM.
+
 gossfile:
   ../tests/goss-dns-nodes.yaml: {}
   ../tests/goss-k8s-nodes-ready.yaml: {}
@@ -32,7 +37,7 @@ gossfile:
   ../tests/goss-k8s-cray-cli-configured.yaml: {}
   ../tests/goss-rgw-health.yaml: {}
   ../tests/goss-k8s-nexus-pods-running.yaml: {}
-  ../tests/goss-k8s-ipxe-pod-running.yaml: {}
+  ../tests/goss-k8s-ipxe-pod-running-pre-upgrade.yaml: {}
   ../tests/goss-k8s-kea-pod-running.yaml: {}
   ../tests/goss-k8s-tftp-pods-running.yaml: {}
   ../tests/goss-postgresql-syncfailed.yaml: {}

--- a/goss-testing/suites/ncn-upgrade-tests-master.yaml
+++ b/goss-testing/suites/ncn-upgrade-tests-master.yaml
@@ -21,6 +21,11 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+# This suite is run after an NCN worker node is rebuilt, possibly but NOT
+# necessarily during a CSM upgrade. The CSM services will have already
+# been upgraded to the current CSM version, however.
+
 gossfile:
   ../tests/goss-k8s-nodes-ready.yaml: {}
   ../tests/goss-k8s-etcd-service.yaml: {}

--- a/goss-testing/tests/ncn/goss-k8s-ipxe-pod-running-pre-upgrade.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-ipxe-pod-running-pre-upgrade.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2014-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -20,23 +20,26 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
+#
 
-# This suite is run after an NCN worker node is rebuilt, possibly but NOT
-# necessarily during a CSM upgrade. The CSM services will have already
-# been upgraded to the current CSM version, however.
-
-gossfile:
-  ../tests/goss-check-static-routes.yaml: {}
-  ../tests/goss-k8s-nodes-ready.yaml: {}
-  ../tests/goss-check-mounts-worker.yaml: {}
-  ../tests/goss-dedicated-drive-worker.yaml: {}
-  ../tests/goss-k8s-nodes-have-running-pods.yaml: {}
-  ../tests/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml: {}
-  ../tests/goss-check-clock-skew.yaml: {}
-  ../tests/goss-cray-service-etcd-health-check.yaml: {}
-  ../tests/goss-k8s-nexus-pods-running.yaml: {}
-  ../tests/goss-k8s-ipxe-pod-running.yaml: {}
-  ../tests/goss-k8s-kea-pod-running.yaml: {}
-  ../tests/goss-k8s-tftp-pods-running.yaml: {}
-  ../tests/goss-k8s-istio-pods-running.yaml: {}
-  ../tests/goss-k8s-istio-pod-containers-running.yaml: {}
+# This test is intended to be run BEFORE the CSM services have been upgraded
+# to CSM 1.5. It checks to make sure that the iPXE service is running.
+# The deployment of the iPXE service changed from CSM 1.4 to CSM 1.5, so
+# the same test cannot be run for both versions.
+{{ $kubectl := .Vars.kubectl }}
+{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
+command:
+    {{ $testlabel := "k8s_service_ipxe_running_pre_upgrade" }}
+    {{$testlabel}}:
+        title: Kubernetes Service 'cray-ipxe' Is Running Pre-Upgrade
+        meta:
+            desc: If this test fails, look at the state of the iPXE pod (kubectl get po -n services | grep cray-ipxe) to investigate.
+            sev: 0
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$kubectl}}" get pods -n services -l 'app.kubernetes.io/name=cray-ipxe' |
+                awk '{ print $3 }' |
+                grep Running
+        exit-status: 0
+        timeout: 20000
+        skip: false


### PR DESCRIPTION
## Summary and Scope

It turns out that we can no longer use the same iPXE test for all places where it was previously being run. It worked before because the iPXE deployment didn't have fundamental changes from one CSM version to another. However, that is not true from CSM 1.4 to CSM 1.5. Therefore we need to run the old-style check when doing pre-service-upgrade checks, and the new-style check when doing checks after the CSM services have been upgraded.

This PR splits off a pre-upgrade iPXE test, and modifies the appropriate test suite to call it. This PR also adds comments to several suites explaining when they are run (specifically in relation to CSM upgrades), to hopefully make this easier to navigate in the future.

Note that this will have to be modified again to handle upgrades where both the starting and ending CSM versions use the new style of iPXE deployments. I am opening additional tickets to cover this and will link them to this ticket (I cannot implement them now because we haven't branched the relevant repos yet). The one thing that this ticket does do to anticipate this need is create a new pre-upgrade test suite (`ncn-patch-upgrade-preflight-tests`) that can be used when doing upgrades from CSM 1.5.0 to CSM 1.5.x. For such upgrades, the iPXE check should be for the new deployment. This suite is not currently used by anything, but if/when we have CSM 1.5.x upgrades, it is what we will need to call from prerequisites.sh

## Issues and Related PRs

* Resolves [CASMTRIAGE-5630](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5630)
* Relates to [CASMTRIAGE-5616](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5616)

## Testing

This PR just restores the original iPXE test, which has been tested extensively, just under a new name, and adds it to the suite called by prerequites.sh. It has been run in this context before and worked fine.

## Risks and Mitigations

Without this change, the test suite called by prerequisites.sh will always fail during CSM upgrades from pre-1.5 to 1.5+.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
