### PR TITLE
Fixes for goss-k8s-pods-ips-in-nmn-pool.yaml in CSM 1.5 (CASMTRIAGE-5638)

### DIFF
--- a/goss-testing/tests/ncn/goss-k8s-pods-ips-in-nmn-pool.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-pods-ips-in-nmn-pool.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2014-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -27,7 +27,7 @@ command:
     meta:
       desc: Correct pods in kube-system namespace exist and are on the right network.
       sev: 0
-    exec: "kubectl -n kube-system get pods -o wide | grep -E '^kube-apiserver|^kube-controller-manager|^kube-multus-ds|^kube-proxy|^kube-scheduler|^weave-net' | awk '{print $6}' | grep -v '10\\.252\\.' || echo PASS"
+    exec: "cidr=$(cray sls search networks list --name NMN --format json | jq -r '.[].ExtraProperties.Subnets[] | select(.FullName == \"NMN Bootstrap DHCP Subnet\") | .CIDR' | cut -d. -f1,2) && kubectl -n kube-system get pods -o wide | grep -E '^kube-apiserver|^kube-controller-manager|^kube-multus-ds|^kube-proxy|^kube-scheduler|^weave-net' | awk '{print $(NF-3)}' | grep -v \"$cidr\" || echo PASS"
     stdout:
       - PASS
     exit-status: 0


### PR DESCRIPTION
### Summary and Scope

Cleanup goss-k8s-pods-ips-in-nmn-pool.yaml test, parse K8S 1.22 output correct and discover NMN subnet from SLS.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5638
* https://jira-pro.it.hpe.com:8443/browse/CASMINST-3769

### Testing

drax:

```
ncn-m001:/opt/cray/tests/install/ncn # export GOSS_BASE=/opt/cray/tests/install/ncn; goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-pods-ips-in-nmn-pool-brad.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
..

Total Duration: 0.747s
Count: 2, Failed: 0, Skipped: 0
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
