### PR TITLE
CASMTRIAGE-5580: check for completed pods

### DIFF
--- a/goss-testing/tests/ncn/goss-k8s-istio-pods-running.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-istio-pods-running.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,13 +29,13 @@ command:
     {{$testlabel}}:
         title: Validate istio-ingressgateway pods are Running
         meta:
-            desc: Validates that istio-ingressgateway pods are running. If this test fails, run "kubectl get pods -n istio-system -o wide | awk '$1 ~ "istio-ingressgateway" && $3 != "Running"'" to see a list of failing pods to investigate.
+            desc: Validates that istio-ingressgateway pods are running or completed. If this test fails, run "kubectl get pods -n istio-system -o wide | awk '$1 ~ "istio-ingressgateway" && $3 != "Running" && $3 != "Completed"'" to see a list of failing pods to investigate.
             sev: 0
         exec: |-
             set -eo pipefail
             "{{$logrun}}" -l "{{$testlabel}}" \
                 "{{$kubectl}}" get pods -n istio-system |
-                awk '$1 ~ "istio-ingressgateway" { if ($3 != "Running") print "FAIL"; else print "PASS" }'
+                awk '$1 ~ "istio-ingressgateway" { if ($3 != "Running" && $3 != "Completed") print "FAIL"; else print "PASS" }'
         exit-status: 0
         stdout:
             - "!FAIL"


### PR DESCRIPTION
## Summary and Scope

During istio upgrade, there will be short-lived completed wait-for pods that will cause an istio goss test to fail as it only expects pods with running state. This PR amends the test with either Running or Completed pods.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-5580](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5580)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `drax`
  * Local development environment

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

