### PR TITLE
CASMINST-6538: Add troubleshooting info to CMS test files

### DIFF
--- a/goss-testing/tests/ncn/goss-cms-tests.yaml
+++ b/goss-testing/tests/ncn/goss-cms-tests.yaml
@@ -22,11 +22,15 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
+{{ $cmsdev := "/usr/local/bin/cmsdev" }}
 {{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
   {{ range $test := index .Vars "cms_tests"}}
   cms-test-{{ $test }}:
-    exec: "{{$logrun}} -l cms-test-{{ $test }} /usr/local/bin/cmsdev test -v {{ $test }}"
+    title: Check {{ $test }} service
+    meta:
+      desc: Performs a basic health check on the {{ $test }} service. If this test fails, then manually run '{{ $cmsdev }} test {{ $test }}' on the same node where the test failed. For more information, see 'troubleshooting/known_issues/sms_health_check.md' in the CSM documentation.
+    exec: "{{$logrun}} -l cms-test-{{ $test }} {{ $cmsdev }} test -v {{ $test }}"
     exit-status: 0
     timeout: 300000
     skip: false

--- a/goss-testing/tests/ncn/goss-cray-tftp-check.yaml
+++ b/goss-testing/tests/ncn/goss-cray-tftp-check.yaml
@@ -30,7 +30,7 @@ command:
     {{$testlabel}}:
         title: cray-tftp service is healthy
         meta:
-            desc: If this test fails, run `{{$cmsdev}} test tftp` on the target node for more information
+            desc: If this test fails, then run `{{$cmsdev}} test tftp` on the target node. For more information, see 'troubleshooting/known_issues/sms_health_check.md' in the CSM documentation.
             sev: 0
         # Run test in verbose mode, since we're capturing the output
         exec: |-            


### PR DESCRIPTION
(cherry picked from commit 0374b80a233aed9d3f913316283a98d9d4ec86d2)

## Summary and Scope

Limited 1.4.2 backport of this PR:
https://github.com/Cray-HPE/csm-testing/pull/509

Specifically, this just adds some troubleshooting information to the CMS Goss test files.