### PR TITLE
Fix nmn pool test to attempt to find input file if sls not up yet (CASMINST-6527)

### DIFF
--- a/goss-testing/scripts/check_goss_k8s_pods_ips_in_nmn_pool.sh
+++ b/goss-testing/scripts/check_goss_k8s_pods_ips_in_nmn_pool.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+out=$(cray sls search networks list --name NMN --format json 2>&1)
+if [ "$?" -eq 0 ]; then
+  echo "Successfully called sls search networks..."
+  network=$(echo "$out" | jq -r '.[].ExtraProperties.Subnets[] | select(.FullName == "NMN Bootstrap DHCP Subnet") | .CIDR')
+else
+  echo "Failed to talk to sls, looking for sls_input_file.json on the filesystem..."
+  #
+  # We are unable to talk to sls, let's see if can find the sls_input_file.json
+  # on the filesystem in either of these locations:
+  #
+  # /var/www/ephemeral/prep/SYSTEM-NAME/sls_input_file.json
+  # /metal/bootstrap/prep/SYSTEM-NAME/sls_input_file.json
+  #
+  system_name=$(craysys metadata get system-name)
+  if [ "$?" -ne 0 ]; then
+    echo "FAIL: Unable to call craysys to get system name"
+    exit 1
+  fi
+
+  pit_file="/var/www/ephemeral/prep/${system_name}/sls_input_file.json"
+  post_pit_file="/metal/bootstrap/prep/${system_name}/sls_input_file.json"
+  if test -f "$pit_file"; then
+    echo "Found sls_input_file.json at $pit_file, proceeding..."
+    network=$(cat $pit_file | jq -r '.Networks.NMN.ExtraProperties.Subnets[] | select(.FullName == "NMN Bootstrap DHCP Subnet") | .CIDR')
+  elif test -f "$post_pit_file"; then
+    echo "Found sls_input_file.json at $post_pit_file, proceeding..."
+    network=$(cat $post_pit_file | jq -r '.Networks.NMN.ExtraProperties.Subnets[] | select(.FullName == "NMN Bootstrap DHCP Subnet") | .CIDR')
+  else
+    #
+    # Couldn't talk to SLS, or find the sls_input_file.json file
+    # anywhere, without valid data, we'll skip this test.
+    #
+    echo "PASS: Unable to determine NMN subnet, skipping test..."
+    exit 0
+  fi
+fi
+
+ips=$(kubectl -n kube-system get pods -o wide | grep -E '^kube-apiserver|^kube-controller-manager|^kube-multus-ds|^kube-proxy|^kube-scheduler|^weave-net' | awk '{print $(NF-3)}')
+
+valid_ips=$(nmap -sL -n $network)
+bad_ip=0
+for ip in $ips
+do
+  echo "$valid_ips" | grep -q $ip
+  if [ "$?" -ne 0 ]; then
+    bad_ip=1
+    echo "ERROR: The following IP: $ip is not in the NMN subnet ($network)"
+  fi
+done
+
+if [ "$bad_ip" -eq 1 ]; then
+    echo "FAIL: At least one IP was not in the correct NMN Bootstrap DHCP Subnet"
+    exit 1
+fi
+
+echo "PASS: All K8S pod IPs are in the NMN Bootstrap DHCP Subnet"
+exit 0

--- a/goss-testing/tests/ncn/goss-k8s-pods-ips-in-nmn-pool.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-pods-ips-in-nmn-pool.yaml
@@ -21,13 +21,19 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+{{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
+{{ $logrun := $scripts | printf "%s/log_run.sh" }}
+{{ $k8s_pods_ips_in_nmn_pool_check := $scripts | printf "%s/check_goss_k8s_pods_ips_in_nmn_pool.sh" }}
 command:
-  check_k8s_pods_ips_in_nmn_pool:
+  {{ $testlabel := "check_k8s_pods_ips_in_nmn_pool" }}
+  {{$testlabel}}:
     title: Kubernetes Pod IPs in NMN Pool
     meta:
-      desc: Correct pods in kube-system namespace exist and are on the right network.
+      desc: If this test fails, run the script "{{$k8s_pods_ips_in_nmn_pool_check}}" to see a description of the offending IPs.
       sev: 0
-    exec: "cidr=$(cray sls search networks list --name NMN --format json | jq -r '.[].ExtraProperties.Subnets[] | select(.FullName == \"NMN Bootstrap DHCP Subnet\") | .CIDR' | cut -d. -f1,2) && kubectl -n kube-system get pods -o wide | grep -E '^kube-apiserver|^kube-controller-manager|^kube-multus-ds|^kube-proxy|^kube-scheduler|^weave-net' | awk '{print $(NF-3)}' | grep -v \"$cidr\" || echo PASS"
+    exec: |-
+        "{{$logrun}}" -l "{{$testlabel}}" \
+            "{{$k8s_pods_ips_in_nmn_pool_check}}"
     stdout:
       - PASS
     exit-status: 0


### PR DESCRIPTION
### Summary and Scope

Enhance goss-k8s-pods-ips-in-nmn-pool.yaml test to attempt to find sls file on filesystem if sls not available, as well as use nmap to determine if IP is in subnet range.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMINST-6527

### Testing

Drax:

```
ncn-m001:~/brad # export GOSS_BASE=/opt/cray/tests/install/ncn; goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-pods-ips-in-nmn-pool-brad.yaml --vars=/opt/cray/tests/install/ncn/vars/variables-ncn.yaml validate
..

Total Duration: 1.660s
Count: 2, Failed: 0, Skipped: 0
```

```
ncn-m001:~/brad # ./check_goss_k8s_pods_ips_in_nmn_pool.sh
Successfully called sls search networks...
PASS: All K8S pod IPs are in the NMN Bootstrap DNCP Subnet
```

```
ncn-m001:~/brad # ./check_goss_k8s_pods_ips_in_nmn_pool.sh
Failed to talk to sls, looking for sls_input_file.json on the filesystem...
Found sls_input_file.json at /metal/bootstrap/prep/drax/sls_input_file.json, proceeding...
PASS: All K8S pod IPs are in the NMN Bootstrap DNCP Subnet
```

```
ncn-m001:~/brad # ./check_goss_k8s_pods_ips_in_nmn_pool.sh
Failed to talk to sls, looking for sls_input_file.json on the filesystem...
Unable to find sls_input_file.json on the filesystem, defaulting subnet to 10.252.1.0/17...
PASS: All K8S pod IPs are in the NMN Bootstrap DNCP Subnet
```


Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
