### PR TITLE
CASMINST-6523: Modify upgrade stage 0 iPXE check; create scripts to run Goss tests during CSM upgrades

### DIFF
--- a/goss-testing/automated/ncn-post-csm-service-upgrade-tests
+++ b/goss-testing/automated/ncn-post-csm-service-upgrade-tests
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# A wrapper to run the ncn-post-csm-service-upgrade-tests.yaml test suite.
+# Exits non-0 on test failure.
+
+echo $'\e[1;33m'NCN Post-CSM Service Upgrade Tests$'\e[0m'
+echo $'\e[1;33m'----------------------------------$'\e[0m'
+echo
+
+# The run-ncn-tests.sh library is located in the same directory as the
+# current script. Using dirname like this could produce a relative path,
+# but that's fine, since we just want to source this library script.
+# Note that this method is not infallible -- in particular, some symbolic
+# links can mess it up. But that won't be the case if this was installed
+# with the csm-testing RPM.
+source "$(dirname -- "$0")/run-ncn-tests.sh"
+
+run_goss_tests suites/ncn-post-csm-service-upgrade-tests.yaml

--- a/goss-testing/automated/ncn-upgrade-preflight-tests
+++ b/goss-testing/automated/ncn-upgrade-preflight-tests
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# A wrapper to run the ncn-upgrade-preflight-tests.yaml test suite.
+# Exits non-0 on test failure.
+
+echo $'\e[1;33m'NCN Upgrade Preflight Checks$'\e[0m'
+echo $'\e[1;33m'----------------------------$'\e[0m'
+echo
+
+# The run-ncn-tests.sh library is located in the same directory as the
+# current script. Using dirname like this could produce a relative path,
+# but that's fine, since we just want to source this library script.
+# Note that this method is not infallible -- in particular, some symbolic
+# links can mess it up. But that won't be the case if this was installed
+# with the csm-testing RPM.
+source "$(dirname -- "$0")/run-ncn-tests.sh"
+
+run_goss_tests suites/ncn-upgrade-preflight-tests.yaml

--- a/goss-testing/automated/ncn-upgrade-tests-master
+++ b/goss-testing/automated/ncn-upgrade-tests-master
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# A wrapper to run the ncn-upgrade-tests-master.yaml test suite.
+# Exits non-0 on test failure.
+
+echo $'\e[1;33m'NCN Master Upgrade Tests$'\e[0m'
+echo $'\e[1;33m'------------------------$'\e[0m'
+echo
+
+# The run-ncn-tests.sh library is located in the same directory as the
+# current script. Using dirname like this could produce a relative path,
+# but that's fine, since we just want to source this library script.
+# Note that this method is not infallible -- in particular, some symbolic
+# links can mess it up. But that won't be the case if this was installed
+# with the csm-testing RPM.
+source "$(dirname -- "$0")/run-ncn-tests.sh"
+
+run_goss_tests suites/ncn-upgrade-tests-master.yaml

--- a/goss-testing/automated/ncn-upgrade-tests-storage
+++ b/goss-testing/automated/ncn-upgrade-tests-storage
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# A wrapper to run the ncn-upgrade-tests-storage.yaml test suite.
+# Exits non-0 on test failure.
+
+echo $'\e[1;33m'NCN Storage Upgrade Tests$'\e[0m'
+echo $'\e[1;33m'-------------------------$'\e[0m'
+echo
+
+# The run-ncn-tests.sh library is located in the same directory as the
+# current script. Using dirname like this could produce a relative path,
+# but that's fine, since we just want to source this library script.
+# Note that this method is not infallible -- in particular, some symbolic
+# links can mess it up. But that won't be the case if this was installed
+# with the csm-testing RPM.
+source "$(dirname -- "$0")/run-ncn-tests.sh"
+
+run_goss_tests suites/ncn-upgrade-tests-storage.yaml

--- a/goss-testing/automated/ncn-upgrade-tests-worker
+++ b/goss-testing/automated/ncn-upgrade-tests-worker
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #
 # MIT License
 #
@@ -20,30 +21,20 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-#
 
-# This suite is run from the prerequisites.sh script during a CSM upgrade
-# to a new patch version. It is not run from prerequisites.sh during a CSM
-# upgrade to a new major/minor version.
-#
-# When it is run, neither the services nor the NCNs have been upgraded. They
-# are still running the previous version of CSM.
+# A wrapper to run the ncn-upgrade-tests-worker.yaml test suite.
+# Exits non-0 on test failure.
 
-gossfile:
-  ../tests/goss-dns-nodes.yaml: {}
-  ../tests/goss-k8s-nodes-ready.yaml: {}
-  ../tests/goss-command-available.yaml: {}
-  ../tests/goss-bond-members-have-links.yaml: {}
-  ../tests/goss-unbound-ip.yaml: {}
-  ../tests/goss-bond-members-have-correct-mtu.yaml: {}
-  ../tests/goss-ceph-storage-health.yaml: {}
-  ../tests/goss-k8s-cray-cli-configured.yaml: {}
-  ../tests/goss-rgw-health.yaml: {}
-  ../tests/goss-k8s-nexus-pods-running.yaml: {}
-  ../tests/goss-k8s-ipxe-pod-running.yaml: {}
-  ../tests/goss-k8s-kea-pod-running.yaml: {}
-  ../tests/goss-k8s-tftp-pods-running.yaml: {}
-  ../tests/goss-postgresql-syncfailed.yaml: {}
-  ../tests/goss-ip-dns-check.yaml: {}
-  ../tests/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml: {}
-  ../tests/goss-k8s-nexus-space.yaml: {}
+echo $'\e[1;33m'NCN Worker Upgrade Tests$'\e[0m'
+echo $'\e[1;33m'------------------------$'\e[0m'
+echo
+
+# The run-ncn-tests.sh library is located in the same directory as the
+# current script. Using dirname like this could produce a relative path,
+# but that's fine, since we just want to source this library script.
+# Note that this method is not infallible -- in particular, some symbolic
+# links can mess it up. But that won't be the case if this was installed
+# with the csm-testing RPM.
+source "$(dirname -- "$0")/run-ncn-tests.sh"
+
+run_goss_tests suites/ncn-upgrade-tests-worker.yaml

--- a/goss-testing/scripts/check_ipxe_x86_64_pod_is_running.sh
+++ b/goss-testing/scripts/check_ipxe_x86_64_pod_is_running.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Checks that the iPXE pod responsible for generating x86-64 binaries is running
+# The exact nature of this check varies based on whether the system is running
+# CSM 1.4 or if it is running CSM 1.5 or later. Since this check is run during upgrades,
+# either may be the case.
+
+# Usage: check_ipxe_x86_64_pod_is_running.sh [-v]
+#
+# -v    Use set -x to produce verbose output
+
+# If it passes, this script ends by printing PASSED and exiting with a 0 exit code.
+# Otherwise, it exits non-0.
+
+# -e :          Exit immediately on error
+# -o pipefail : The exit code of a command pipeline is equal to the highest exit code of any
+#               command in the pipeline (used to prevent errors in the middle of a pipeline
+#               from being lost)
+# -u :          Treat unset variables as errors
+set -euo pipefail
+
+if [[ $# -eq 1 && $1 == -v ]]; then
+  # -x :          Echo commands being run
+  set -x
+elif [[ $# -ne 0 ]]; then
+  echo "usage: check_ipxe_x86_64_pod_is_running.sh [-v]" >&2
+  exit 2
+fi
+
+function err_exit {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+# Get a temporary file to redirect where we can redirect the kubectl output
+# That way we can display the entire output, and also check it to make sure the pod is running
+tmpfile=$(mktemp)
+
+echo "Temporary file is '${tmpfile}'"
+
+# List pre-CSM 1.5-style iPXE pods:
+kubectl get pods -n services -l 'app.kubernetes.io/name=cray-ipxe' --ignore-not-found | tee "${tmpfile}"
+
+# Append CSM 1.5+-style x86-64 iPXE pods:
+kubectl get pods -n services -l 'app.kubernetes.io/name=cray-ipxe-x86-64' --ignore-not-found | tee -a "${tmpfile}"
+
+passed=Y
+
+# grep the status column to make sure it is running.
+awk '{ print $3 }' "${tmpfile}" | grep -q Running || passed=N
+
+# Delete the temporary file, if it exists (it should, but a healthy dose of paranoia is good for the soul)
+if [[ -f ${tmpfile} ]]; then
+  rm ${tmpfile}
+fi
+
+[[ ${passed} == Y ]] || err_exit "iPXE pod status does not appear to be Running"
+
+echo "PASSED"
+exit 0

--- a/goss-testing/tests/ncn/goss-k8s-ipxe-pod-running-pre-upgrade.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-ipxe-pod-running-pre-upgrade.yaml
@@ -22,12 +22,16 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-# This test is intended to be run BEFORE the CSM services have been upgraded
-# to CSM 1.5. It checks to make sure that the iPXE service is running.
+# This test is run during stage 0 of a CSM upgrade to CSM 1.5.x.
+# The CSM services have not yet been upgraded by stage 0, HOWEVER the
+# source CSM version of the upgrade may be CSM 1.4 or it may be CSM 1.5.
+#
 # The deployment of the iPXE service changed from CSM 1.4 to CSM 1.5, so
-# the same test cannot be run for both versions.
-{{ $kubectl := .Vars.kubectl }}
-{{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
+# this test calls a script which checks to make sure one of the two styles of
+# iPXE deployment is running.
+{{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
+{{ $logrun := $scripts | printf "%s/log_run.sh" }}
+{{ $check_ipxe_x86_64_pod_is_running := $scripts | printf "%s/check_ipxe_x86_64_pod_is_running.sh" }}
 command:
     {{ $testlabel := "k8s_service_ipxe_running_pre_upgrade" }}
     {{$testlabel}}:
@@ -37,9 +41,7 @@ command:
             sev: 0
         exec: |-
             "{{$logrun}}" -l "{{$testlabel}}" \
-                "{{$kubectl}}" get pods -n services -l 'app.kubernetes.io/name=cray-ipxe' |
-                awk '{ print $3 }' |
-                grep Running
+                "{{$check_ipxe_x86_64_pod_is_running}}" -v
         exit-status: 0
         timeout: 20000
         skip: false


### PR DESCRIPTION
## Summary and Scope

This PR makes the following changes/additions:

* Creates a new iPXE check script that will pass if the CSM 1.4 style iPXE pod is running or if the CSM 1.5 style x86-64 iPXE pod is running (it will not pass if only the aarch64 pod is running, because that won't work for NCN boots).
* Modifies the iPXE test run during stage 0 of CSM upgrades to use this new script. This is the only situation where we run the iPXE test that it may be the old or new style of deployment. All other cases will expect only the new style of deployment.
* Because of this change, the `ncn-patch-upgrade-preflight-tests.yaml` suite is no longer needed. It isn't being used (it was intended to be used to handle the iPXE situation for CSM 1.5.1 upgrades) so this PR deletes it.
* I noticed that the upgrade scripts are calling Goss directly to run the test suites. This isn't a big deal except I noticed they also have code to manually fix the variables file. This is something that is already handled in the shared function library in the `csm-testing` repo, and can easily be leveraged to avoid having to make those kind of changes in the `docs-csm` repo. This is better because the way things are now, the upgrade scripts could break if internal `csm-testing` repo changes are made, and the person making those changes would likely not realize that this is happening in `docs-csm`.

## Issues and Related PRs

* Resolves [CASMINST-6523](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6523)/[CASMINST-6541](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6541)
* For CSM 1.6 we can go back to having a monolithic iPXE check, since the source version will always be using the new style of deployment. I have [CASMINST-6522](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6522) open for that, and will implement it once we branch `csm-testing`.

## Testing

I tested the new iPXE test (both shell script and Goss test) on wasp (CSM 1.4) and ashton (CSM 1.5) to verify that it works as expected.
I also tested the new automated shell scripts on wasp to make sure that they behaved as expected.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
