### PR TITLE
Include post services install suite in ncn-k8s-combined-healthcheck

### DIFF
--- a/goss-testing/automated/ncn-k8s-combined-healthcheck-post-service-upgrade
+++ b/goss-testing/automated/ncn-k8s-combined-healthcheck-post-service-upgrade
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# This is intended to be a flavor of ncn-k8s-combined-healthcheck to run
+# just after CSM services have been upgraded (but other products have not
+# been updated yet by iuf).
+#
+# At least one test from ncn-k8s-combined-healthcheck isn't appropriate
+# at this stage (goss-cray-spire-check-key-id-in-jwks).
+#
+
+echo $'\e[1;33m'NCN and Kubernetes Checks \(post CSM services upgrade\)$'\e[0m'
+echo $'\e[1;33m'------------------------------$'\e[0m'
+echo
+
+# The run-ncn-tests.sh library is located in the same directory as the
+# current script. Using dirname like this could produce a relative path,
+# but that's fine, since we just want to source this library script.
+# Note that this method is not infallible -- in particular, some symbolic
+# links can mess it up. But that won't be the case if this was installed
+# with the csm-testing RPM.
+source "$(dirname -- "$0")/run-ncn-tests.sh"
+
+# BGP test requires switch password to be set
+sw_admin_pw_set || exit 1
+
+# Get master and worker node lists (storage node list is created inside the ncn_healthcheck_storage_urls function)
+master_nodes=$(get_ncns --masters --exclude-pit) || exit 1
+worker_nodes=$(get_ncns --workers) || exit 1
+
+# Add k8s master test URLs
+test_urls=$(k8s_check_urls_for_master_nodelist_post_services_upgrade ${master_nodes}) || exit 1
+
+# Add k8s worker test URLs
+more_test_urls=$(k8s_check_urls_for_worker_nodelist ${worker_nodes}) || exit 1
+test_urls+=" ${more_test_urls}"
+
+# Add master NCN healthcheck URLs
+more_test_urls=$(healthcheck_urls_for_master_nodelist_post_services_upgrade ${master_nodes}) || exit 1
+test_urls+=" ${more_test_urls}"
+
+# Add storage NCN healthcheck URLs
+more_test_urls=$(ncn_healthcheck_storage_urls) || exit 1
+test_urls+=" ${more_test_urls}"
+
+# Add worker NCN healthcheck URLs
+more_test_urls=$(healthcheck_urls_for_worker_nodelist ${worker_nodes}) || exit 1
+test_urls+=" ${more_test_urls}"
+
+if is_pit_node ; then
+    # running on a pit node
+
+    # file needed to run from livecd
+    kube_creds=/root/.kube/config
+
+    if is_nonempty_file "${kube_creds}"; then
+        # run livecd local Kubernetes cluster tests plus the NCN worker BGP test
+        run_goss_tests_print_results suites/common-combined-k8s-bgp-tests.yaml ${test_urls}
+        rc=$?
+    else
+        echo
+        echo $'\e[1;31m'WARNING: Unable to run local Kubernetes checks because ${kube_creds} does not exist or is invalid$'\e[0m'
+        # But we are still able to run the BGP test that the NCN worker healthcheck runs
+        run_goss_tests_print_results tests/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml ${test_urls}
+        rc=$?
+    fi
+else
+    # running on an NCN
+
+    # run NCN local Kubernetes cluster tests plus the NCN worker BGP test
+    run_goss_tests_print_results suites/ncn-combined-k8s-bgp-tests.yaml ${test_urls}
+    rc=$?
+fi
+
+# This script does not exit with non-0 return code just for test failures
+[[ $rc -le 1 ]] && exit 0
+exit 1

--- a/goss-testing/dat/goss-servers.cfg
+++ b/goss-testing/dat/goss-servers.cfg
@@ -4,38 +4,42 @@
 
 # In this file, lines beginning with # and lines with only whitespace are ignored.
 
-#port      Suite file                                              NCN type(s) where it will be run
-8994 	   ncn-preflight-tests.yaml                                master storage worker
+#port      Suite file                                                NCN type(s) where it will be run
+8994       ncn-preflight-tests.yaml                                  master storage worker
 
-8995       ncn-smoke-tests.yaml                                    master storage worker
+8995       ncn-smoke-tests.yaml                                      master storage worker
 
-8996       ncn-spire-healthchecks.yaml                             master storage worker
+8996       ncn-spire-healthchecks.yaml                               master storage worker
 
-8997       ncn-healthcheck-master.yaml                             master
-8997       ncn-healthcheck-storage.yaml                            storage
-8997       ncn-healthcheck-worker.yaml                             worker
-8997       livecd-healthcheck.yaml                                 livecd
+8997       ncn-healthcheck-master.yaml                               master
+8997       ncn-healthcheck-storage.yaml                              storage
+8997       ncn-healthcheck-worker.yaml                               worker
+8997       livecd-healthcheck.yaml                                   livecd
 
-8998       ncn-healthcheck-master-single.yaml                      master
-8998       ncn-healthcheck-worker-single.yaml                      worker
+8998       ncn-healthcheck-master-single.yaml                        master
+8998       ncn-healthcheck-worker-single.yaml                        worker
 
-8999       ncn-afterpitreboot-healthcheck-master.yaml              master
-8999       ncn-afterpitreboot-healthcheck-storage.yaml             storage
-8999       ncn-afterpitreboot-healthcheck-worker.yaml              worker
+8999       ncn-afterpitreboot-healthcheck-master.yaml                master
+8999       ncn-afterpitreboot-healthcheck-storage.yaml               storage
+8999       ncn-afterpitreboot-healthcheck-worker.yaml                worker
 
-9000       ncn-afterpitreboot-healthcheck-worker-single.yaml       worker
+9000       ncn-afterpitreboot-healthcheck-worker-single.yaml         worker
 
-9001       ncn-kubernetes-tests-master.yaml                        master
-9001       ncn-kubernetes-tests-worker.yaml                        worker
-9001       livecd-preflight-tests.yaml                             livecd
+9001       ncn-kubernetes-tests-master.yaml                          master
+9001       ncn-kubernetes-tests-worker.yaml                          worker
+9001       livecd-preflight-tests.yaml                               livecd
 
-9002       ncn-kubernetes-tests-master-single.yaml                 master
+9002       ncn-kubernetes-tests-master-single.yaml                   master
 
-9003       ncn-afterpitreboot-kubernetes-tests-master-single.yaml  master
-9003       ncn-afterpitreboot-kubernetes-tests-worker-single.yaml  worker
+9003       ncn-afterpitreboot-kubernetes-tests-master-single.yaml    master
+9003       ncn-afterpitreboot-kubernetes-tests-worker-single.yaml    worker
 
-9004       ncn-storage-tests.yaml                                  storage
+9004       ncn-storage-tests.yaml                                    storage
 
-9005       ncn-cms-tests.yaml                                      master worker
+9005       ncn-cms-tests.yaml                                        master worker
 
-9006       ncn-hms-ct-tests.yaml                                   master
+9006       ncn-hms-ct-tests.yaml                                     master
+
+9007       ncn-post-csm-service-upgrade-tests.yaml                   master
+
+9008       ncn-healthcheck-master-single-post-service-upgrade.yaml  master

--- a/goss-testing/suites/ncn-healthcheck-master-single-post-service-upgrade.yaml
+++ b/goss-testing/suites/ncn-healthcheck-master-single-post-service-upgrade.yaml
@@ -1,0 +1,54 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# During health validation, these tests are executed on a single master node
+# in the cluster. Tests that are executed on every master node are in the
+# corresponding suite file without the -single suffix.
+gossfile:
+  ../tests/goss-bss-basecamp-valid.yaml: {}
+  ../tests/goss-hms-ct-tests.yaml: {}
+  ../tests/goss-k8s-etcd-backups.yaml: {}
+  ../tests/goss-k8s-etcd-cluster-balance.yaml: {}
+  ../tests/goss-k8s-etcd-database-health.yaml: {}
+  ../tests/goss-k8s-etcd-endpoint-health.yaml: {}
+  ../tests/goss-k8s-etcd-members.yaml: {}
+  ../tests/goss-k8s-kea-has-active-dhcp-leases.yaml: {}
+  ../tests/goss-k8s-kea-pod-running.yaml: {}
+  ../tests/goss-k8s-psp-enabled.yaml: {}
+  ../tests/goss-k8s-resolve-external-dns.yaml: {}
+  ../tests/goss-k8s-monitoring-url.yaml: {}
+  ../tests/goss-k8s-sealed-secret-key.yaml: {}
+  ../tests/goss-k8s-storageclass.yaml: {}
+  ../tests/goss-k8s-velero-backup-storage-locations-available.yaml: {}
+  ../tests/goss-k8s-velero-backup-vault-schedule-exists.yaml: {}
+  ../tests/goss-k8s-velero-no-failed-backups.yaml: {}
+  ../tests/goss-cray-spire-verify-pods.yaml: {}
+  ../tests/goss-spire-bss-metadata-exist.yaml: {}
+  ../tests/goss-spire-verify-api-fetch-jwt.yaml: {}
+  ../tests/goss-spire-verify-pods.yaml: {}
+  ../tests/goss-k8s-postgres-backups.yaml: {}
+  ../tests/goss-k8s-postgres-clusters-running.yaml: {}
+  ../tests/goss-k8s-postgres-leader.yaml: {}
+  ../tests/goss-k8s-postgres-pods-running.yaml: {}
+  ../tests/goss-k8s-postgres-replication-lag.yaml: {}


### PR DESCRIPTION
### Summary and Scope

Add combined health check for use after CSM services are upgraded, but NCNs have not yet rolled by IUF management node rollout.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6670

### Testing

Drax (one expected failure):

```
ncn-m003:~ # /opt/cray/tests/install/ncn/automated/ncn-k8s-combined-healthcheck-post-service-upgrade

NCN and Kubernetes Checks (post CSM services upgrade)
------------------------------

Writing full output to /opt/cray/tests/install/logs/print_goss_json_results/20230718_212313.352790-566853-ygO1buGe/out

Running tests

Checking test results
Only errors will be printed to the screen

Result: FAIL
Source: http://ncn-m001.hmn:9008/ncn-healthcheck-master-single-post-service-upgrade
Test Name: Check hmnfd service
Description: Performs a basic health check on the hmnfd service. If this test fails, then manually run '/opt/cray/csm/scripts/hms_verification/run_hms_ct_tests.sh -t hmnfd' on the same node where the test failed. For more information, see 'troubleshooting/interpreting_hms_health_check_results.md' in the CSM documentation.
Test Summary: Command: hms-ct-test-hmnfd: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0
Execution Time: 0.000020071 seconds
Node: ncn-m001



GRAND TOTAL: 679 passed, 1 failed
ERROR: There was at least one test failure

FAILED
```


Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
