### PR TITLE
CASMTRIAGE-5758: postgres testing script error

### DIFF
--- a/goss-testing/scripts/postgres_pods_running.sh
+++ b/goss-testing/scripts/postgres_pods_running.sh
@@ -56,7 +56,7 @@ do
     # If the sqlCluster.instanceCount is set in the customizations and it is not the same as that set in the postgresql cr then fails and continue to the next cluster.
     num_of_instances=$(kubectl get postgresql -n $c_ns ${c_name} -o json | jq -r '.spec.numberOfInstances')
     service_name=$(kubectl get postgresql -n $c_ns ${c_name} -o yaml | grep "meta.helm.sh/release-name:" | awk '{print $2}')
-    customization_instance_count=$(kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d | yq read customizations.yaml "spec.kubernetes.services.${service_name}.cray-service*.sqlCluster.instanceCount")
+    customization_instance_count=$(kubectl get secrets -n loftsman site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d | yq read - "spec.kubernetes.services.${service_name}.cray-service*.sqlCluster.instanceCount")
 
     if [[ ! -z $customization_instance_count ]]; then
         if [[ $num_of_instances -ne $customization_instance_count ]]; then


### PR DESCRIPTION
## Summary and Scope

This PR fixes an error in postgres_pods_running script, where stdout from the previous command should be read instead of a file.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5758](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5758)
* Change will also be needed in `release/1.5`

## Testing

### Tested on:

  * `drax`

### Test description:

Changed the postgres_pods_running.sh script, and made sure that it ran successfully.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

