### PR TITLE
CASMTRIAGE-5685 PostgeSQL backup test failure in vShasta

### DIFF
--- a/goss-testing/scripts/postgresql_backups_check.sh
+++ b/goss-testing/scripts/postgresql_backups_check.sh
@@ -44,6 +44,14 @@ do
     esac
 done
 
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "${tmp_dir}"; unset CRAY_CREDENTIALS' EXIT
+admin_secret=$(kubectl get secrets admin-client-auth -ojsonpath='{.data.client-secret}' | base64 -d)
+curl -k -s -d grant_type=client_credentials \
+        -d client_id=admin-client \
+        -d client_secret="$admin_secret" https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token > "${tmp_dir}/cray-token.json"
+export CRAY_CREDENTIALS="${tmp_dir}/cray-token.json"
+
 current_date_sec=$(date +"%s")
 
 # Given a timestamp, determine how many minutes have elapsed.


### PR DESCRIPTION
## Summary and Scope

PostgeSQL backup test requires `CRAY_CREDENTIALS` environment variable to be set, to run `cray artifact list` command.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5685](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5685)

## Testing
### Tested on:

  * Virtual Shasta

### Test description:

Ran modified script `/opt/cray/tests/install/ncn/scripts/postgresql_backups_check.sh` on vShasta system.

## Risks and Mitigations

Low - test only
