### PR TITLE
CASMINST-6625: Improve handling of switch admin password

### DIFF
--- a/goss-testing/automated/run-ncn-tests.sh
+++ b/goss-testing/automated/run-ncn-tests.sh
@@ -84,9 +84,13 @@ GOSS_SERVERS_CONFIG=${GOSS_SERVERS_CONFIG:-"${GOSS_INSTALL_BASE_DIR}/dat/goss-se
 # Pattern to match 001-009: 00[1-9]
 ncn_num_pattern="([1-9][0-9][0-9]|0[1-9][0-9]|00[1-9])"
 
+# Import helper functions
+. "${GOSS_BASE}/scripts/sw_admin_password.sh"
+
 function sw_admin_pw_set {
-    if [[ -z ${SW_ADMIN_PASSWORD} ]]; then
-        print_error "Management switch 'admin' user password must be provided via the SW_ADMIN_PASSWORD environment variable"
+    # This function is defined in sw_admin_password.sh
+    if ! set_sw_admin_password_if_needed >/dev/null; then
+        print_error "Management switch 'admin' user password must be set in Vault or provided via the SW_ADMIN_PASSWORD environment variable"
         echo "Example: export SW_ADMIN_PASSWORD='changeme'"
         return 1
     fi

--- a/goss-testing/scripts/check_bgp_neighbors_established.sh
+++ b/goss-testing/scripts/check_bgp_neighbors_established.sh
@@ -141,5 +141,4 @@ else
         err_exit 40 "canu validate network bgp --network all failed (rc=$?)"
     fi
 fi
-echo "PASS"
 exit 0

--- a/goss-testing/scripts/check_bgp_neighbors_established.sh
+++ b/goss-testing/scripts/check_bgp_neighbors_established.sh
@@ -29,6 +29,11 @@
 # fail (i.e. exit non-0) if any of the commands in the chain fail
 set -o pipefail
 
+locOfScript=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+
+# Import helper functions
+. "${locOfScript}/sw_admin_password.sh"
+
 function err_exit
 {
     local rc
@@ -68,21 +73,12 @@ else
     usage "Too many arguments ($#): $*"
 fi
 
-
 SECRET=$(kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d) ||
     err_exit 10 "Command pipeline failed with return code $?: kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d"
 # We omit the client secret from the error message, so it is not recorded in the log.
 # Ideally we would not be passing it to curl on the command line either.
 TOKEN=$(curl -s -k -S -d grant_type=client_credentials -d client_id=admin-client -d client_secret="$SECRET" https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token') ||
     err_exit 15 "Command pipeline failed with return code $?: curl -s -k -S -d grant_type=client_credentials -d client_id=admin-client -d client_secret=XXXXXX https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token'"
-
-# Set vault_check to 0 if healthy and unsealed.  Set to 1 otherwise.
-VAULTPOD=$(kubectl get pods -n vault | grep -E 'cray-vault-[[:digit:]].*Running' | awk 'NR==1{print $1}')
-if [ "$(kubectl -n vault exec -i ${VAULTPOD:-cray-vault-0} -c vault -- env VAULT_ADDR=http://cray-vault.vault:8200 VAULT_FORMAT=json vault status  | jq '.sealed')" = false ]; then
-    vault_check=0
-else
-    vault_check=1
-fi
 
 # check if metalLB configmap exists
 # Set metallb_check to 1 if we cannot get the metallb configmap from Kubernetes. Set to 0 otherwise.
@@ -96,21 +92,13 @@ fi
 curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks/BICAN |
     jq -r .ExtraProperties.SystemDefaultRoute |
     grep -e CHN -e CAN
+
 # Set sls_network_check to 0 if the BICAN endpoint responds and
 # has the CAN or CHN strings in its ExtraProperties.SystemDefaultRoute field. Otherwise set to 1
 [[ $? -eq 0 ]] && sls_network_check=0 || sls_network_check=1
 
-# vault is running and checking for switch admin password in vault
-if [ -z "$SW_ADMIN_PASSWORD" ] && [ "$vault_check" -lt "1" ]; then
-    VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '.data["vault-root"]' |  base64 -d)
-    SW_ADMIN_PASSWORD=$(kubectl -n vault exec -i cray-vault-0 -c vault -- env VAULT_TOKEN="$VAULT_PASSWD" VAULT_ADDR=http://127.0.0.1:8200 VAULT_FORMAT=json vault kv get secret/net-creds/switch_admin | jq -r  .data.admin) ||
-        err_exit 20 'Detected Vault is running.  Missing switch admin password from vault.  Please run the following commands:
-        VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '"'"'.data["vault-root"]'"'"' |  base64 -d)
-        alias vault="kubectl -n vault exec -i cray-vault-0 -c vault -- env VAULT_TOKEN=\"$VAULT_PASSWD\" VAULT_ADDR=http://127.0.0.1:8200 VAULT_FORMAT=json vault"
-        vault kv put secret/net-creds/switch_admin admin=SWITCH_ADMIN_PASSWORD'
-fi
-# this is the case if vault is not running and env variable has not been set
-if [ -z "$SW_ADMIN_PASSWORD" ] && [ "$vault_check" -gt "0" ]; then
+# This function is defined in sw_admin_password.sh
+if ! set_sw_admin_password_if_needed; then
     # Do not prompt for the password if not running in interactive mode
     if [[ ${interactive} != 0 ]]; then
         err_exit 25 "Switch admin password not in SW_ADMIN_PASSWORD environment variable and not obtainable from Vault"

--- a/goss-testing/scripts/sw_admin_password.sh
+++ b/goss-testing/scripts/sw_admin_password.sh
@@ -1,0 +1,74 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# This file is sourced by automated testing scripts.
+
+# No shebang line at the top of the file, because this is not intended to be executed, only included as a source in other Bash scripts.
+# The following line lets the linter know how to appropriately check this file.
+# shellcheck shell=bash
+
+set -o pipefail
+
+function vault_check {
+    # Return 0 if healthy and unsealed. Return 1 otherwise.
+    local VAULTPOD
+    if ! VAULTPOD=$(kubectl get pods -n vault | grep -E 'cray-vault-[[:digit:]].*Running' | awk 'NR==1{print $1}'); then
+        echo "Vault appears to be unhealthy" >&2
+        return 1
+    fi
+    if [ "$(kubectl -n vault exec -i ${VAULTPOD:-cray-vault-0} -c vault -- env VAULT_ADDR=http://cray-vault.vault:8200 VAULT_FORMAT=json vault status  | jq '.sealed')" = false ]; then
+        echo "Vault appears to be healthy and unsealed"
+        return 0
+    fi
+    echo "Vault appears to be sealed" >&2
+    return 1
+}
+
+function set_sw_admin_password_if_needed {
+    # If the SW_ADMIN_PASSWORD variable is already set and non-empty, just return 0.
+    # Otherwise, get it from Vault if possible. Return 0 if successful, 1 otherwise.
+    local VAULT_PASSWD
+    if [[ -n ${SW_ADMIN_PASSWORD} ]]; then
+        echo "Using switch admin password from SW_ADMIN_PASSWORD environment variable"
+        return 0
+    fi
+    vault_check || return 1
+    if ! VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json \
+      | jq -r '.data["vault-root"]' |  base64 -d); then
+        echo "Unable to get Vault password from cray-vault-unseal-keys Kubernetes secret" >&2
+        return 1
+    fi
+    if ! SW_ADMIN_PASSWORD=$(kubectl -n vault exec -i cray-vault-0 -c vault -- \
+      env VAULT_TOKEN="$VAULT_PASSWD" VAULT_ADDR=http://127.0.0.1:8200 \
+      VAULT_FORMAT=json vault kv get secret/net-creds/switch_admin \
+      | jq -r  .data.admin); then
+        echo 'Detected Vault is running.  Missing switch admin password from vault.  Please run the following commands:
+        VAULT_PASSWD=$(kubectl -n vault get secrets cray-vault-unseal-keys -o json | jq -r '"'"'.data["vault-root"]'"'"' |  base64 -d)
+        alias vault="kubectl -n vault exec -i cray-vault-0 -c vault -- env VAULT_TOKEN=\"$VAULT_PASSWD\" VAULT_ADDR=http://127.0.0.1:8200 VAULT_FORMAT=json vault"
+        vault kv put secret/net-creds/switch_admin admin=SWITCH_ADMIN_PASSWORD' >&2
+        return 1
+    fi
+    echo "Switch admin password retrieved from Vault"
+    return 0
+}

--- a/goss-testing/tests/common/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml
+++ b/goss-testing/tests/common/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml
@@ -38,5 +38,6 @@ command:
         exit-status: 0
         stdout:
             - "!FAIL"
+            - "!Connection Error"
         timeout: 20000
         skip: false

--- a/goss-testing/tests/common/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml
+++ b/goss-testing/tests/common/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -34,7 +34,7 @@ command:
             sev: 0
         exec: |-
             "{{$logrun}}" -l "{{$testlabel}}" \
-                "{{$check_bgp_neighbors_established}}"
+                "{{$check_bgp_neighbors_established}}" --non-interactive
         exit-status: 0
         stdout:
             - "!FAIL"


### PR DESCRIPTION
## Summary and Scope

This PR contains three primary improvements to the BGP check test, script, and automated scripts which call it:
1. Modify the BGP test so that it does not try to prompt the user for a password when it is called from Goss
2. Modify the automated scripts which call the test so that they will not force the user to set the environment variable if the password is available in Vault.
3. Modify the BGP test to fail if it sees "Connection Error" in the output, as a workaround for [CASMNET-2017](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2017), since that does not seem to be getting fixed with any kind of urgency. Relatedly, remove the misleading "PASS" from the end of the test script, as that is based on the CANU return code, which has little meaning until the aforementioned ticket is resolved.

## Issues and Related PRs

* Resolves the test change side of [CASMINST-6625](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6625) for CSM 1.6
* Adds workaround for one symptom of [CASMNET-2017](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2017)
* [CSM 1.5 backport](https://github.com/Cray-HPE/csm-testing/pull/529)
* [CSM 1.4 backport](https://github.com/Cray-HPE/csm-testing/pull/530)

## Testing

I tested this on mug and verified that the changes to the test, the test script, and the automated test suite launchers all work as expected.

## Risks and Mitigations

Low risk. Most of this was just moving code to different locations, not changing the fundamental logic being used.

