### PR TITLE
Also publish to sp4 and sp3

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -109,12 +109,50 @@ pipeline {
                                     os: "noos",
                                     pattern: "dist/rpmbuild/SRPMS/*.rpm",
                             )
-
                             publishCsmRpms(
                                     arch: "noarch",
                                     component: 'goss-servers',
                                     isStable: isStable,
                                     os: "noos",
+                                    pattern: "dist/rpmbuild/RPMS/noarch/goss-servers*.rpm",
+                            )
+                            // Publish to sp4 and sp3 until docs-csm is cut-over to use noos in its various directions that install csm-testing and goss-servers.
+                            publishCsmRpms(arch: "noarch",
+                                    component: env.NAME,
+                                    isStable: isStable,
+                                    os: "sle-15sp4",
+                                    pattern: "dist/rpmbuild/RPMS/noarch/*.rpm",
+                            )
+                            publishCsmRpms(arch: "src",
+                                    component: env.NAME,
+                                    isStable: isStable,
+                                    os: "sle-15sp4",
+                                    pattern: "dist/rpmbuild/SRPMS/*.rpm",
+                            )
+                            publishCsmRpms(
+                                    arch: "noarch",
+                                    component: 'goss-servers',
+                                    isStable: isStable,
+                                    os: "sle-15sp4",
+                                    pattern: "dist/rpmbuild/RPMS/noarch/goss-servers*.rpm",
+                            )
+                            publishCsmRpms(arch: "noarch",
+                                    component: env.NAME,
+                                    isStable: isStable,
+                                    os: "sle-15sp3",
+                                    pattern: "dist/rpmbuild/RPMS/noarch/*.rpm",
+                            )
+                            publishCsmRpms(arch: "src",
+                                    component: env.NAME,
+                                    isStable: isStable,
+                                    os: "sle-15sp3",
+                                    pattern: "dist/rpmbuild/SRPMS/*.rpm",
+                            )
+                            publishCsmRpms(
+                                    arch: "noarch",
+                                    component: 'goss-servers',
+                                    isStable: isStable,
+                                    os: "sle-15sp3",
                                     pattern: "dist/rpmbuild/RPMS/noarch/goss-servers*.rpm",
                             )
                         }


### PR DESCRIPTION
To cover cases where noos is not fully used, especially for CSM 1.4 and older, also publish the packages to SP4 and SP3.

This prevents having to do things like the following workaround, where repo index files cross-pollinate with one another.
![image](https://github.com/Cray-HPE/csm-testing/assets/7772179/fe780684-6e0b-48a9-8c91-f96def47a964)

