### PR TITLE
Casminst 6650 release-1.4 fix storage goss tests that should not run on storage node ncn-s004+

### DIFF
--- a/goss-testing/tests/ncn/goss-ceph-storage-config-files.yaml
+++ b/goss-testing/tests/ncn/goss-ceph-storage-config-files.yaml
@@ -22,6 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
+{{ $this_node_name := .Env.HOSTNAME }}
 {{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
     {{ $testlabel := "ceph_storage_config_files" }}
@@ -33,7 +34,14 @@ command:
         exec: |-
             "{{$logrun}}" -l "{{$testlabel}}" \
                 ls -al /etc/ceph
+        # We expect the 'ceph.admin.keyring' on the first three storage nodes
+        # and any master node
+        {{if $this_node_name | regexMatch "^ncn-(m|s00[1-3])"}}
         stdout:
             - ceph.client.admin.keyring
             - ceph.conf
+        {{else}}
+        stdout:
+            - ceph.conf
+        {{end}}
         exit-status: 0

--- a/goss-testing/tests/ncn/goss-ceph-storage-health.yaml
+++ b/goss-testing/tests/ncn/goss-ceph-storage-health.yaml
@@ -21,19 +21,24 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+{{ $this_node_name := .Env.HOSTNAME }}
 {{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
 {{ $logrun := $scripts | printf "%s/log_run.sh" }}
 command:
-    {{ $testlabel := "ceph_storage_health" }}
-    {{$testlabel}}:
-        title: Ceph Service Healthy
-        meta:
-            desc: Checks that the Ceph service is in a healthy state. If this test fails, refer to 'operations/utility_storage/Ceph_Service_Check_Script_Usage.md' for more information.
-            sev: 0
-        exec: |-
-            # Now that we are logging, call script with verbose option
-            "{{$logrun}}" -l "{{$testlabel}}" \
-                "{{$scripts}}/ceph-service-status.sh" -v true
-        exit-status: 0
-        timeout: 20000
-        skip: false
+    # We expect the 'ceph.admin.keyring' on the first three storage nodes
+    # and any master node. That keyring is necessary for this test.
+    {{if $this_node_name | regexMatch "^ncn-(m|s00[1-3])"}}
+        {{ $testlabel := "ceph_storage_health" }}
+        {{$testlabel}}:
+            title: Ceph Service Healthy
+            meta:
+                desc: Checks that the Ceph service is in a healthy state. If this test fails, refer to 'operations/utility_storage/Ceph_Service_Check_Script_Usage.md' for more information.
+                sev: 0
+            exec: |-
+                # Now that we are logging, call script with verbose option
+                "{{$logrun}}" -l "{{$testlabel}}" \
+                    "{{$scripts}}/ceph-service-status.sh" -v true
+            exit-status: 0
+            timeout: 20000
+            skip: false
+    {{end}}

--- a/goss-testing/tests/ncn/goss-rgw-health.yaml
+++ b/goss-testing/tests/ncn/goss-rgw-health.yaml
@@ -22,19 +22,24 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
+{{ $this_node_name := .Env.HOSTNAME }}
 {{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
 {{ $logrun := $scripts | printf "%s/log_run.sh" }}
 {{ $rgw_health_check := $scripts | printf "%s/rgw_health_check.sh" }}
 command:
-    {{ $testlabel := "verify_rgw_health" }}
-    {{$testlabel}}:
-        title: Verify rgw is healthy
-        meta:
-            desc: Check that rgw-vip and all storage nodes are up. Check rgw endpoint health by uploading and downloading a file from a bucket. For more detailed output, run 'GOSS_BASE={{.Env.GOSS_BASE}} {{$rgw_health_check}}'
-            sev: 0
-        exec: |-
-            "{{$logrun}}" -l "{{$testlabel}}" \
-                "{{$rgw_health_check}}"
-        exit-status: 0
-        timeout: 180000
-        skip: false
+    # We expect the 'ceph.admin.keyring' on the first three storage nodes
+    # and any master node. That keyring is necessary for this test.
+    {{if $this_node_name | regexMatch "^ncn-(m|s00[1-3])"}}
+        {{ $testlabel := "verify_rgw_health" }}
+        {{$testlabel}}:
+            title: Verify rgw is healthy
+            meta:
+                desc: Check that rgw-vip and all storage nodes are up. Check rgw endpoint health by uploading and downloading a file from a bucket. For more detailed output, run 'GOSS_BASE={{.Env.GOSS_BASE}} {{$rgw_health_check}}'
+                sev: 0
+            exec: |-
+                "{{$logrun}}" -l "{{$testlabel}}" \
+                    "{{$rgw_health_check}}"
+            exit-status: 0
+            timeout: 180000
+            skip: false
+    {{end}}

--- a/goss-testing/tests/ncn/goss-rgw-health.yaml
+++ b/goss-testing/tests/ncn/goss-rgw-health.yaml
@@ -27,19 +27,23 @@
 {{ $logrun := $scripts | printf "%s/log_run.sh" }}
 {{ $rgw_health_check := $scripts | printf "%s/rgw_health_check.sh" }}
 command:
-    # We expect the 'ceph.admin.keyring' on the first three storage nodes
-    # and any master node. That keyring is necessary for this test.
-    {{if $this_node_name | regexMatch "^ncn-(m|s00[1-3])"}}
-        {{ $testlabel := "verify_rgw_health" }}
-        {{$testlabel}}:
-            title: Verify rgw is healthy
-            meta:
-                desc: Check that rgw-vip and all storage nodes are up. Check rgw endpoint health by uploading and downloading a file from a bucket. For more detailed output, run 'GOSS_BASE={{.Env.GOSS_BASE}} {{$rgw_health_check}}'
-                sev: 0
-            exec: |-
-                "{{$logrun}}" -l "{{$testlabel}}" \
-                    "{{$rgw_health_check}}"
-            exit-status: 0
-            timeout: 180000
-            skip: false
-    {{end}}
+    {{ $testlabel := "verify_rgw_health" }}
+    {{$testlabel}}:
+        title: Verify rgw is healthy
+        meta:
+            desc: Check that rgw-vip and all storage nodes are up. Check rgw endpoint health by uploading and downloading a file from a bucket. For more detailed output, run 'GOSS_BASE={{.Env.GOSS_BASE}} {{$rgw_health_check}}'
+            sev: 0
+        {{if $this_node_name | regexMatch "^ncn-(m|s00[1-3])"}}
+        # We expect the 'ceph.admin.keyring' on the first three storage nodes
+        # and any master node. That keyring is necessary for this test.
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$rgw_health_check}}"
+        {{else}}
+        exec: |-
+            "{{$logrun}}" -l "{{$testlabel}}" \
+                "{{$rgw_health_check}}" --minimal-check
+        {{end}}
+        exit-status: 0
+        timeout: 180000
+        skip: false


### PR DESCRIPTION
## Summary and Scope

Some storage node goss tests require the ceph.admin.keyring in order to run because the test contains 'ceph' commands. The admin.keyring is only present on ncn-s00[1-3] and not on ncn-s004+. Because the keyring is missing on ncn-s004+, the goss tests fail. This change avoids running goss tests that need the admin.keyring on ncn-s004+. The specific goss tests that are changed are goss-ceph-storage-config-files.yaml, goss-ceph-storage-health.yaml, and goss-rgw-health.yaml.

## Issues and Related PRs

* Resolves [CASMINST-6650](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6650)

## Testing

### Tested on:

  * Tyr
  * Dorian

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

