### PR TITLE
CASMINST-6658: Add Goss endpoint for Kubernetes cluster tests

### DIFF
--- a/goss-testing/dat/goss-servers.cfg
+++ b/goss-testing/dat/goss-servers.cfg
@@ -34,6 +34,7 @@
 9003       ncn-afterpitreboot-kubernetes-tests-master-single.yaml    master
 9003       ncn-afterpitreboot-kubernetes-tests-worker-single.yaml    worker
 
+9004       ncn-kubernetes-tests-cluster.yaml                         master
 9004       ncn-storage-tests.yaml                                    storage
 
 9005       ncn-cms-tests.yaml                                        master worker
@@ -42,4 +43,4 @@
 
 9007       ncn-post-csm-service-upgrade-tests.yaml                   master
 
-9008       ncn-healthcheck-master-single-post-service-upgrade.yaml  master
+9008       ncn-healthcheck-master-single-post-service-upgrade.yaml   master


### PR DESCRIPTION
## Summary and Scope

This just adds an endpoint for an existing test suite to Kubernetes masters. This will allow us to easily add it to the tests being run during vshasta runs.