### PR TITLE
CASMCMS-8812: Skip CMS conman test when running on vshasta

### DIFF
--- a/goss-testing/tests/ncn/goss-cms-tests.yaml
+++ b/goss-testing/tests/ncn/goss-cms-tests.yaml
@@ -25,6 +25,7 @@
 {{ $cmsdev := "/usr/local/bin/cmsdev" }}
 {{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
+  {{ $vshasta := .Vars.vshasta }}
   {{ range $test := index .Vars "cms_tests"}}
   cms-test-{{ $test }}:
     title: Check {{ $test }} service
@@ -33,5 +34,14 @@ command:
     exec: "{{$logrun}} -l cms-test-{{ $test }} {{ $cmsdev }} test -v {{ $test }}"
     exit-status: 0
     timeout: 300000
+    # If not on vshasta, do not skip any tests
+    {{ if ne true $vshasta }}
     skip: false
+    # Even on vshasta, if this is not the conman test, do not skip it
+    {{ else if ne "conman" $test }}
+    skip: false
+    # Skip the conman test when running on vshasta
+    {{ else }}
+    skip: true
+    {{ end }}
   {{ end }}


### PR DESCRIPTION
## Summary and Scope

The CMS conman test doesn't work on vshasta because one of the console services pods is blacklisted under vshasta (due to other problems that it causes). This PR updates the CMS test so that when running on vshasta, the conman test is skipped.

## Testing

I tested this on wasp (but modified it so that it skipped when not on vshasta), to confirm that it worked as desired.

