### PR TITLE
CASMINST-6663: Check for hostname using Goss variable first, then environment variable

### DIFF
--- a/goss-testing/suites/ncn-storage-tests.yaml
+++ b/goss-testing/suites/ncn-storage-tests.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,7 +26,12 @@
 # This suite is run during CSM installs before CSM services have been deployed
 #
 
-{{ $this_node_name := .Vars.this_node_name }}
+# Use hostname from variable file, if set.
+# Otherwise use hostname from environment variable (or blank, if that is also not set)
+{{ $env_hostname := getEnv "HOSTNAME" }}
+{{ $vars_hostname := get .Vars "this_node_name" }}
+{{ $this_node_name := default $env_hostname $vars_hostname }}
+
 gossfile:
     {{if eq $this_node_name "ncn-s001"}}
     # This test checks for the presence of files which indicate that

--- a/goss-testing/tests/ncn/goss-ceph-csi-storage-node-requirements.yaml
+++ b/goss-testing/tests/ncn/goss-ceph-csi-storage-node-requirements.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,9 +22,14 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
+# Use hostname from variable file, if set.
+# Otherwise use hostname from environment variable (or blank, if that is also not set)
+{{ $env_hostname := getEnv "HOSTNAME" }}
+{{ $vars_hostname := get .Vars "this_node_name" }}
+{{ $this_node_name := default $env_hostname $vars_hostname }}
+
 # set a var for vshasta
 {{ $vs := .Vars.vshasta}}
-{{ $this_node_name := .Vars.this_node_name }}
 {{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 file:
     # These files only are checked on ncn-s001

--- a/goss-testing/tests/ncn/goss-ceph-status.yaml
+++ b/goss-testing/tests/ncn/goss-ceph-status.yaml
@@ -21,7 +21,12 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{ $this_node_name := .Vars.this_node_name }}
+# Use hostname from variable file, if set.
+# Otherwise use hostname from environment variable (or blank, if that is also not set)
+{{ $env_hostname := getEnv "HOSTNAME" }}
+{{ $vars_hostname := get .Vars "this_node_name" }}
+{{ $this_node_name := default $env_hostname $vars_hostname }}
+
 {{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 package:
     # This package is installed on all NCNs

--- a/goss-testing/tests/ncn/goss-ceph-storage-config-files.yaml
+++ b/goss-testing/tests/ncn/goss-ceph-storage-config-files.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2014-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,7 +22,12 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-{{ $this_node_name := .Env.HOSTNAME }}
+# Use hostname from variable file, if set.
+# Otherwise use hostname from environment variable (or blank, if that is also not set)
+{{ $env_hostname := getEnv "HOSTNAME" }}
+{{ $vars_hostname := get .Vars "this_node_name" }}
+{{ $this_node_name := default $env_hostname $vars_hostname }}
+
 {{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:
     {{ $testlabel := "ceph_storage_config_files" }}

--- a/goss-testing/tests/ncn/goss-ceph-storage-health.yaml
+++ b/goss-testing/tests/ncn/goss-ceph-storage-health.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2014-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,7 +21,12 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-{{ $this_node_name := .Env.HOSTNAME }}
+# Use hostname from variable file, if set.
+# Otherwise use hostname from environment variable (or blank, if that is also not set)
+{{ $env_hostname := getEnv "HOSTNAME" }}
+{{ $vars_hostname := get .Vars "this_node_name" }}
+{{ $this_node_name := default $env_hostname $vars_hostname }}
+
 {{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
 {{ $logrun := $scripts | printf "%s/log_run.sh" }}
 command:

--- a/goss-testing/tests/ncn/goss-check-taints.yaml
+++ b/goss-testing/tests/ncn/goss-check-taints.yaml
@@ -22,7 +22,11 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
  
-{{ $this_node_name := .Env.HOSTNAME }}
+# Use hostname from variable file, if set.
+# Otherwise use hostname from environment variable (or blank, if that is also not set)
+{{ $env_hostname := getEnv "HOSTNAME" }}
+{{ $vars_hostname := get .Vars "this_node_name" }}
+{{ $this_node_name := default $env_hostname $vars_hostname }}
 {{ $kubectl := .Vars.kubectl }}
 {{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
 command:

--- a/goss-testing/tests/ncn/goss-rgw-health.yaml
+++ b/goss-testing/tests/ncn/goss-rgw-health.yaml
@@ -22,7 +22,12 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-{{ $this_node_name := .Env.HOSTNAME }}
+# Use hostname from variable file, if set.
+# Otherwise use hostname from environment variable (or blank, if that is also not set)
+{{ $env_hostname := getEnv "HOSTNAME" }}
+{{ $vars_hostname := get .Vars "this_node_name" }}
+{{ $this_node_name := default $env_hostname $vars_hostname }}
+
 {{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
 {{ $logrun := $scripts | printf "%s/log_run.sh" }}
 {{ $rgw_health_check := $scripts | printf "%s/rgw_health_check.sh" }}

--- a/goss-testing/tests/ncn/goss-spire-healthcheck.yaml
+++ b/goss-testing/tests/ncn/goss-spire-healthcheck.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2014-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,13 @@
 #
 
 {{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
-{{ $this_node_name := .Vars.this_node_name }}
+
+# Use hostname from variable file, if set.
+# Otherwise use hostname from environment variable (or blank, if that is also not set)
+{{ $env_hostname := getEnv "HOSTNAME" }}
+{{ $vars_hostname := get .Vars "this_node_name" }}
+{{ $this_node_name := default $env_hostname $vars_hostname }}
+
 # The test description text varies depending on where the test is run. However, it always begins the same way. The shared
 # prefix text is in the following variable
 {{ $common_description_prefix := "Validates that the spire healthcheck runs successfully. If this fails, then fix the issue by running" }}


### PR DESCRIPTION
## Summary and Scope

During the latest CSM 1.4.3 vshasta test run, a test did not execute because the HOSTNAME environment variable was not set. In fact, this caused the entire suite to not execute, because attempting to access the nonexistent variable essentially prevented the test templates from being resolved.

This problem could happen for other cases where our tests use variables (either .Vars or .Env), but this PR specifically addresses the use of .Env.HOSTNAME and .Vars.this_node_name. This PR changes every test and suite which uses either of these, and modifies them all as follows:
1. Use methods to get their values which do not cause fatal errors if they are not set
2. If this_node_name is set in the variables file (which it should always be), then this value will be used. If that value is empty, then it will use the HOSTNAME environment variable (or an empty string, if that is not set).

This will prevent the problem seen in the vshasta run, and should make our tests more robust in general.

## Testing

I tested the updated Goss file logic on wasp with different combinations of environment variables and variable files, and verified that it behaved as expected in all cases.
