### PR TITLE
CASMINST-6665: spire-agent executable moved

### DIFF
--- a/goss-testing/tests/ncn/goss-spire-healthcheck.yaml
+++ b/goss-testing/tests/ncn/goss-spire-healthcheck.yaml
@@ -47,7 +47,7 @@ command:
             sev: 0
         exec: |-
             "{{$logrun}}" -l "{{$testlabel}}" \
-                spire-agent healthcheck -socketPath /var/lib/spire/agent.sock
+                /opt/cray/cray-spire/spire-agent healthcheck -socketPath /var/lib/spire/agent.sock
         exit-status: 0
         timeout: 20000
         skip: false


### PR DESCRIPTION
## Summary and Scope

spire-agent is no longer in /usr/bin