### PR TITLE
CASMINST-6692 Skip bgp_neighbors_established test on vShasta

### DIFF
--- a/goss-testing/tests/common/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml
+++ b/goss-testing/tests/common/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml
@@ -40,4 +40,9 @@ command:
             - "!FAIL"
             - "!Connection Error"
         timeout: 20000
+        # skip this test on vshasta
+        {{ if eq true .Vars.vshasta }}
+        skip: true
+        {{ else }}
         skip: false
+        {{ end }}


### PR DESCRIPTION
This test is only executed during upgrade, so previosly it was never invoked in vShasta. With CASMINST-6692, we work on CSM upgrade with vShasta and need to skip this test.

## Summary and Scope
## Issues and Related PRs

* Required by [CASMINST-6692](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6692)

## Testing
### Tested on:
  * Virtual Shasta

### Test description:

Ran tests with locall modified test suite.

## Risks and Mitigations
Low - tests only.


