### PR TITLE
CASMPET-6823:   Adding healthcheck test for cilium live migration

### DIFF
--- a/goss-testing/suites/ncn-cilium-migrate-tests.yaml
+++ b/goss-testing/suites/ncn-cilium-migrate-tests.yaml
@@ -1,0 +1,40 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# This suite is run after an NCN worker node is rebuilt, possibly but NOT
+# necessarily during a CSM upgrade. The CSM services will have already
+# been upgraded to the current CSM version, however.
+
+gossfile:
+  ../tests/goss-cray-service-etcd-health-check.yaml: {}
+  ../tests/goss-k8s-console-services.yaml: {}
+  ../tests/goss-k8s-ipxe-pod-running.yaml: {}
+  ../tests/goss-k8s-istio-pod-containers-running.yaml: {}
+  ../tests/goss-k8s-istio-pods-running.yaml: {}
+  ../tests/goss-k8s-kea-pod-running.yaml: {}
+  ../tests/goss-k8s-keycloak-healthy.yaml: {}
+  ../tests/goss-k8s-nexus-can-pull.yaml: {}
+  ../tests/goss-k8s-nexus-pods-running.yaml: {}
+  ../tests/goss-k8s-nodes-have-running-pods.yaml: {}
+  ../tests/goss-k8s-nodes-ready.yaml: {}
+  ../tests/goss-k8s-tftp-pods-running.yaml: {}


### PR DESCRIPTION
## Summary and Scope

We need a health check during the cilium live migration workflow to make sure that critical services are healthy before moving on to migrate the next node.   I first looked at the ncn-upgrade-tests-* suites for worker and master but they include several tests (e.g. goss-check-static-routes, goss-check-mounts-worker) that are not necessary because we are not rebooting the nodes at this point.   This new test has a subset of the union of both the ncn-upgrade-tests-worker and ncn-upgrade-tests-master tests.

## Issues and Related PRs


* Resolves [CASMPET-6823](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6823)

## Testing


### Tested on:

  * Virtual Shasta - cilium cluster

### Test description:

Used this test as a step in the live migration workflow.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

