### PR TITLE
CASMTRIAGE-6231 1.6 : Goss etcd cluster balance test timed out

### DIFF
--- a/goss-testing/tests/ncn/goss-k8s-etcd-cluster-balance.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-etcd-cluster-balance.yaml
@@ -40,5 +40,5 @@ command:
         exit-status: 0
         stdout:
             - "!FAILED"
-        timeout: 20000
+        timeout: 30000
         skip: false


### PR DESCRIPTION
## Summary and Scope

Increases timeout - needed now that SPC is installed on the system

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-6231](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6231)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

### Tested on:

  * spice

### Test description:

When the timeout is changed to 30s, the test passes
```
 # GOSS_BASE=/opt/cray/tests/install/ncn goss -g /opt/cray/tests/install/ncn/tests/goss-k8s-etcd-cluster-balance.yaml v
..

Total Duration: 21.353s
Count: 2, Failed: 0, Skipped: 0```

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

