### PR TITLE
CASMINST-6803: Skip tftp test on vshasta on CSM 1.4

### DIFF
--- a/goss-testing/tests/ncn/goss-cms-tests.yaml
+++ b/goss-testing/tests/ncn/goss-cms-tests.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -37,11 +37,14 @@ command:
     # If not on vshasta, do not skip any tests
     {{ if ne true $vshasta }}
     skip: false
-    # Even on vshasta, if this is not the conman test, do not skip it
-    {{ else if ne "conman" $test }}
-    skip: false
-    # Skip the conman test when running on vshasta
-    {{ else }}
+    # On vshasta, if this is the conman test, skip it
+    {{ else if eq "conman" $test }}
     skip: true
+    # On vshasta, if this is the tftp test, skip it
+    {{ else if eq "tftp" $test }}
+    skip: true
+    # Otherwise, run it
+    {{ else }}
+    skip: false
     {{ end }}
   {{ end }}

--- a/goss-testing/tests/ncn/goss-cray-tftp-check.yaml
+++ b/goss-testing/tests/ncn/goss-cray-tftp-check.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,6 +26,7 @@
 {{ $logrun := $scripts | printf "%s/log_run.sh" }}
 {{ $cmsdev := "/usr/local/bin/cmsdev" }}
 command:
+    {{ $vshasta := .Vars.vshasta }}
     {{ $testlabel := "cray_tftp_check" }}
     {{$testlabel}}:
         title: cray-tftp service is healthy
@@ -41,4 +42,9 @@ command:
             - SUCCESS
         # 3 minute test timeout
         timeout: 180000
+        # This test has to be skipped on vshasta for CSM 1.4
+        {{ if eq true $vshasta }}
+        skip: true
+        {{ else }}
         skip: false
+        {{ fi }}


### PR DESCRIPTION
The CMS tftp test fails on vshasta on CSM 1.4 because the vshasta deploy code uses the CSM 1.5 ipxe chart (to prevent other problems). So when running CSM 1.4 on vshasta, this test should be skipped.