### PR TITLE
CASMINST-6821: goss-k8s-pods-ips-in-nmn-pool: Backport fixes to CSM 1.4.5

### DIFF
--- a/goss-testing/scripts/check_goss_k8s_pods_ips_in_nmn_pool.sh
+++ b/goss-testing/scripts/check_goss_k8s_pods_ips_in_nmn_pool.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+out=$(cray sls search networks list --name NMN --format json 2>&1)
+if [ "$?" -eq 0 ]; then
+  echo "Successfully called sls search networks..."
+  network=$(echo "$out" | jq -r '.[].ExtraProperties.Subnets[] | select(.FullName == "NMN Bootstrap DHCP Subnet") | .CIDR')
+else
+  echo "Failed to talk to sls, looking for sls_input_file.json on the filesystem..."
+  #
+  # We are unable to talk to sls, let's see if can find the sls_input_file.json
+  # on the filesystem in either of these locations:
+  #
+  # /var/www/ephemeral/prep/SYSTEM-NAME/sls_input_file.json
+  # /metal/bootstrap/prep/SYSTEM-NAME/sls_input_file.json
+  #
+  system_name=$(craysys metadata get system-name)
+  if [ "$?" -ne 0 ]; then
+    echo "FAIL: Unable to call craysys to get system name"
+    exit 1
+  fi
+
+  pit_file="/var/www/ephemeral/prep/${system_name}/sls_input_file.json"
+  post_pit_file="/metal/bootstrap/prep/${system_name}/sls_input_file.json"
+  if test -f "$pit_file"; then
+    echo "Found sls_input_file.json at $pit_file, proceeding..."
+    network=$(cat $pit_file | jq -r '.Networks.NMN.ExtraProperties.Subnets[] | select(.FullName == "NMN Bootstrap DHCP Subnet") | .CIDR')
+  elif test -f "$post_pit_file"; then
+    echo "Found sls_input_file.json at $post_pit_file, proceeding..."
+    network=$(cat $post_pit_file | jq -r '.Networks.NMN.ExtraProperties.Subnets[] | select(.FullName == "NMN Bootstrap DHCP Subnet") | .CIDR')
+  else
+    #
+    # Couldn't talk to SLS, or find the sls_input_file.json file
+    # anywhere, without valid data, we'll skip this test.
+    #
+    echo "PASS: Unable to determine NMN subnet, skipping test..."
+    exit 0
+  fi
+fi
+
+ips=$(kubectl -n kube-system get pods -o wide | grep -E '^kube-apiserver|^kube-controller-manager|^kube-multus-ds|^kube-proxy|^kube-scheduler|^weave-net' | awk '{print $(NF-3)}')
+
+valid_ips=$(nmap -sL -n $network)
+bad_ip=0
+for ip in $ips
+do
+  echo "$valid_ips" | grep -q $ip
+  if [ "$?" -ne 0 ]; then
+    bad_ip=1
+    echo "ERROR: The following IP: $ip is not in the NMN subnet ($network)"
+  fi
+done
+
+if [ "$bad_ip" -eq 1 ]; then
+    echo "FAIL: At least one IP was not in the correct NMN Bootstrap DHCP Subnet"
+    exit 1
+fi
+
+echo "PASS: All K8S pod IPs are in the NMN Bootstrap DHCP Subnet"
+exit 0

--- a/goss-testing/scripts/check_goss_k8s_pods_ips_in_nmn_pool.sh
+++ b/goss-testing/scripts/check_goss_k8s_pods_ips_in_nmn_pool.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 
 out=$(cray sls search networks list --name NMN --format json 2>&1)
 if [ "$?" -eq 0 ]; then

--- a/goss-testing/scripts/k8s_kyverno_pods_running.sh
+++ b/goss-testing/scripts/k8s_kyverno_pods_running.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -46,7 +46,7 @@ rc=$?
 if [[ ${rc} -ne 0 ]]
 then
     # Split into two echo commands for code readability
-    echo -n "ERROR: Command pipeline failed (return code $?): " 1>&2
+    echo -n "ERROR: Command pipeline failed (return code $rc): " 1>&2
     echo "kubectl get pods -n kyverno -o json | jq '[.items[] | select(.metadata.labels.app == \"kyverno\").status.containerStatuses[0].state.running] | length'" 1>&2
     echo "FAIL"
     exit 10

--- a/goss-testing/scripts/velero_backups_check.sh
+++ b/goss-testing/scripts/velero_backups_check.sh
@@ -1,4 +1,28 @@
 #!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
 
 # Due to a velero bug, a backup is created anytime the backup schedule is created or updated.
 # Backups should only occurs based upon the cron schedule and not when the schedule itself is created.. 
@@ -45,7 +69,7 @@ cleanup_velero_backups() {
                     time_from_schedule_creation_to_backup=$(( $backup_creation_date_sec - $schedule_creation_date_sec ))
                     if [[ ! -z $backup_creation_date_sec && ${time_from_schedule_creation_to_backup} -ge 0 && ${time_from_schedule_creation_to_backup} -lt $ten_minutes ]]
                     then
-                        delete_count+=1
+                        (( delete_count+=1 ))
 		        echo "velero backup delete ${backup_name}"
 	                velero backup delete ${backup_name} --confirm
                     fi

--- a/goss-testing/tests/ncn/goss-k8s-pods-ips-in-nmn-pool.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-pods-ips-in-nmn-pool.yaml
@@ -21,13 +21,19 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+{{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
+{{ $logrun := $scripts | printf "%s/log_run.sh" }}
+{{ $k8s_pods_ips_in_nmn_pool_check := $scripts | printf "%s/check_goss_k8s_pods_ips_in_nmn_pool.sh" }}
 command:
-  check_k8s_pods_ips_in_nmn_pool:
+  {{ $testlabel := "check_k8s_pods_ips_in_nmn_pool" }}
+  {{$testlabel}}:
     title: Kubernetes Pod IPs in NMN Pool
     meta:
-      desc: Correct pods in kube-system namespace exist and are on the right network.
+      desc: If this test fails, run the script "{{$k8s_pods_ips_in_nmn_pool_check}}" to see a description of the offending IPs.
       sev: 0
-    exec: "cidr=$(cray sls search networks list --name NMN --format json | jq -r '.[].ExtraProperties.Subnets[] | select(.FullName == \"NMN Bootstrap DHCP Subnet\") | .CIDR' | cut -d. -f1,2) && kubectl -n kube-system get pods -o wide | grep -E '^kube-apiserver|^kube-controller-manager|^kube-multus-ds|^kube-proxy|^kube-scheduler|^weave-net' | awk '{print $(NF-3)}' | grep -v \"$cidr\" || echo PASS"
+    exec: |-
+        "{{$logrun}}" -l "{{$testlabel}}" \
+            "{{$k8s_pods_ips_in_nmn_pool_check}}"
     stdout:
       - PASS
     exit-status: 0

--- a/goss-testing/tests/ncn/goss-k8s-pods-ips-in-nmn-pool.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-pods-ips-in-nmn-pool.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2014-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -27,7 +27,7 @@ command:
     meta:
       desc: Correct pods in kube-system namespace exist and are on the right network.
       sev: 0
-    exec: "kubectl -n kube-system get pods -o wide | grep -E '^kube-apiserver|^kube-controller-manager|^kube-multus-ds|^kube-proxy|^kube-scheduler|^weave-net' | awk '{print $6}' | grep -v '10\\.252\\.' || echo PASS"
+    exec: "cidr=$(cray sls search networks list --name NMN --format json | jq -r '.[].ExtraProperties.Subnets[] | select(.FullName == \"NMN Bootstrap DHCP Subnet\") | .CIDR' | cut -d. -f1,2) && kubectl -n kube-system get pods -o wide | grep -E '^kube-apiserver|^kube-controller-manager|^kube-multus-ds|^kube-proxy|^kube-scheduler|^weave-net' | awk '{print $(NF-3)}' | grep -v \"$cidr\" || echo PASS"
     stdout:
       - PASS
     exit-status: 0

--- a/goss-testing/tests/ncn/goss-k8s-pods-ips-in-nmn-pool.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-pods-ips-in-nmn-pool.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2014-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
This PR backports test fixes for these two tickets:
* [CASMTRIAGE-5638](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5638)
* [CASMINST-6527](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6527)

These fixes were only made to CSM 1.5+, but they also apply to CSM 1.4, and we are seeing this test fail on UKMet systems running CSM 1.4. I tested and verified that these changes correct the problem. I'm backporting them here so we can include them in CSM 1.4.5.