### PR TITLE
CASMTRIAGE-6991 `goss-servers.service` systemd-preset

### DIFF
--- a/csm-testing.spec
+++ b/csm-testing.spec
@@ -121,8 +121,9 @@ cp -a goss-testing/suites/ncn-*         %{buildroot}%{ncn}/suites
 install -m 644 goss-testing/dat/*       %{buildroot}%{dat}
 
 # goss-servers files
-install -D -m 0755 -t %{buildroot}%{_sbindir} systemd/start-goss-servers.sh
-install -D -m 0644 -t %{buildroot}%{_unitdir} systemd/goss-servers.service
+install -D -m 0755 -t %{buildroot}%{_sbindir}           systemd/start-goss-servers.sh
+install -D -m 0644 -t %{buildroot}%{_unitdir}           systemd/goss-servers.service
+install -D -m 0644 -t %{buildroot}%{_unitdir}-preset/   systemd/90-goss-servers.preset
 
 %clean
 rm -rf %{buildroot}%{dat}
@@ -167,3 +168,4 @@ Sets up a systemd service for running Goss health check servers
 %files -n goss-servers
 %{_sbindir}/start-goss-servers.sh
 %{_unitdir}/goss-servers.service
+%{_unitdir}-preset/90-goss-servers.preset

--- a/csm-testing.spec
+++ b/csm-testing.spec
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -37,6 +37,7 @@ Release: 1
 Source: %{name}-%{version}.tar.bz2
 Vendor: HPE
 BuildArchitectures: %(echo $ARCH)
+BuildRequires: systemd-rpm-macros
 
 %description
 Tests to test the set-up during installation.

--- a/csm-testing.spec
+++ b/csm-testing.spec
@@ -121,10 +121,8 @@ cp -a goss-testing/suites/ncn-*         %{buildroot}%{ncn}/suites
 install -m 644 goss-testing/dat/*       %{buildroot}%{dat}
 
 # goss-servers files
-mkdir -p %{buildroot}/usr/sbin
-mkdir -p %{buildroot}/etc/systemd/system/
-install -m 755 start-goss-servers.sh %{buildroot}/usr/sbin/
-install -m 644 goss-servers.service %{buildroot}/etc/systemd/system/
+install -D -m 0755 -t %{buildroot}%{_sbindir} systemd/start-goss-servers.sh
+install -D -m 0644 -t %{buildroot}%{_unitdir} systemd/goss-servers.service
 
 %clean
 rm -rf %{buildroot}%{dat}
@@ -167,5 +165,5 @@ Summary: Goss Health Check Endpoint Service
 Sets up a systemd service for running Goss health check servers
 
 %files -n goss-servers
-/usr/sbin/start-goss-servers.sh
-/etc/systemd/system/goss-servers.service
+%{_sbindir}/start-goss-servers.sh
+%{_unitdir}/goss-servers.service

--- a/systemd/90-goss-servers.preset
+++ b/systemd/90-goss-servers.preset
@@ -1,0 +1,24 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+enable goss-servers.service

--- a/systemd/goss-servers.service
+++ b/systemd/goss-servers.service
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022,2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/systemd/start-goss-servers.sh
+++ b/systemd/start-goss-servers.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
Fixes CASMTRIAGE-6991.

Prevents disabling `goss-servers.service` when upgrading the goss-servers RPM package by installing a systemd-presets file. This new systemd-presets file (`/usr/lib/systemd/system-preset/90-goss-servers.preset`) will prevent the removal of the systemd symlink for `goss-servers.service`.

Note below that the service remained `enabled` following the package update, and that `vendor preset: enabled` is shown.
```bash
ncn-w001:~ # rpm -Uvh rusty/goss-servers-1.17.26~3~geb15ca3-1.noarch.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:goss-servers-1.17.26~3~geb15ca3-1################################# [ 50%]
Cleaning up / removing...
   2:goss-servers-1.16.71-1           ################################# [100%]
ncn-w001:~ # systemctl status goss-servers | grep vendor
     Loaded: loaded (/usr/lib/systemd/system/goss-servers.service; enabled; vendor preset: enabled)
```