### PR TITLE
CASMPET-7058 Skip dnsmasq-lease-count test on vShasta

### DIFF
--- a/goss-testing/tests/livecd/goss-dnsmasq-lease-count.yaml
+++ b/goss-testing/tests/livecd/goss-dnsmasq-lease-count.yaml
@@ -40,4 +40,9 @@ command:
     - >7
     exit-status: 0
     timeout: 20000
+    # skip this test on vshasta
+    {{ if eq true .Vars.vshasta }}
+    skip: true
+    {{ else }}
     skip: false
+    {{ end }}


### PR DESCRIPTION
## Summary and Scope

The `dnsmasq-lease-count` test is not valid for vShasta, because we don't use dnsmasq on vShasta for bootstrapping nodes via DHCP.

## Issues and Related PRs

* Resolves [CASMPET-7058](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7058)

## Risks and Mitigations

Low - exclusion of previously failing test
