### PR TITLE
MTL-2393 goss-servers is missing goss requirement

### DIFF
--- a/csm-testing.spec
+++ b/csm-testing.spec
@@ -143,6 +143,7 @@ rmdir %{buildroot}%{logs} || true
 
 %package -n goss-servers
 Summary: Goss Health Check Endpoint Service
+Requires: goss
 
 # helps when installing a program whose unit files makes use of a feature only available in a newer systemd version
 # If the program is installed on its own, it will have to make do with the available features


### PR DESCRIPTION
The goss-servers package needs goss to function, but this requirement is not specified in the spec.

This has caused a build failure where we removed the goss package, and we (I) expected goss-servers to find either hpe-csm-goss-package or goss depending on which one was available for the respective architecture (aarch64 or x86_64).

Failure: https://github.com/Cray-HPE/node-images/actions/runs/9195551941/job/25291695566#step:9:12814
Change that caused the failure: https://github.com/Cray-HPE/metal-provision/pull/675/files#diff-4b8036c5c83ba58cb56e769dfdde82765b1a451a424c8f93e114fa21775cc7f8