### PR TITLE
CASMINST-6870: Fix syntax error in goss-cray-tftp-check

### DIFF
--- a/goss-testing/tests/ncn/goss-cray-tftp-check.yaml
+++ b/goss-testing/tests/ncn/goss-cray-tftp-check.yaml
@@ -47,4 +47,4 @@ command:
         skip: true
         {{ else }}
         skip: false
-        {{ fi }}
+        {{ end }}


### PR DESCRIPTION
This fixes a Goss syntax error in a test. The test uses `fi` where it should use `end`. This causes the goss-servers service to not start the endpoint which includes this test.

I found this problem on TDSY at UKMet, and tested the fix there to verify that it works.