### PR TITLE
CASMTRIAGE-7218 -- 1.6

### DIFF
--- a/goss-testing/tests/common/goss-ceph-csi-k8s-requirements.yaml
+++ b/goss-testing/tests/common/goss-ceph-csi-k8s-requirements.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,7 +31,7 @@ file:
             desc: "Check that kubectl command exists"
             sev: 0
         exists: true
-        filetype: file
+        filetype: symlink
 command:
     {{range $configmap := index .Vars "k8s_ceph_csi_configmaps"}}
         {{ $testlabel := $configmap | printf "k8s_cm_%s" }}


### PR DESCRIPTION
## Summary and Scope

in k8s 1.24 /usr/bin/kubectl is a symlink to /etc/alternatives/kubectl
updated goss test to look for symlink instead of file.

## Issues and Related PRs

https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7218

## Testing

Updated the tests locally on fanta and confirmed they passed.
Also manually confirmed on all NCNs that /usr/bin/kubectl is indeed a symlink.

### Tested on:

- fanta

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable