### PR TITLE
CASMTRIAGE-7316 add additional check to the bgp test to check for the

### DIFF
--- a/goss-testing/scripts/check_bgp_neighbors_established.sh
+++ b/goss-testing/scripts/check_bgp_neighbors_established.sh
@@ -90,6 +90,13 @@ else
     metallb_check=1
 fi
 
+# the test should fail if metallb-speaker is not running
+printf "metallb-speaker pods: "
+if ! kubectl -n metallb-system get po -l app.kubernetes.io/name=metallb -l app.kubernetes.io/component=speaker -o json | jq -e 'all(.items[].status.containerStatuses[].ready; . == true)' ; then
+    err_exit 16 "metallb-speaker pods are not ready, which can cause this test to fail"
+fi
+
+
 # check SLS Networks data for BiCAN toggle
 if curl -s -k -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks/BICAN |
     jq -r .ExtraProperties.SystemDefaultRoute |


### PR DESCRIPTION
state of metallb-speaker

After checking with SME, @spillerc-hpe, I learned it is possible for BGP to not be up when running the neighbour test from these conditions:

- Bad or no credentials from vault
- The node is not yet up: 
    - metallb-speaker isn't running on the node 
    - BGP session has gone idle: [https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-7858/Content/Chp_BGP/bgp-nei-sta27.htm](https://www.arubanetworks.com/techdocs/AOS-CX/10.07/HTML/5200-7858/Content/Chp_BGP/bgp-nei-sta27.htm)
- A misconfigured switch 
    - The switch configuration can be wrong, but customers can also use BGP to connect to their own network that can lead to false positives.

This PR aims to reduce the need to re-run this test, which can often work if the pods are running after the initial failure, which has been observed in the JIRA.

New output from this change as seen below:

```
ncn-w004:~ # /opt/cray/tests/install/ncn/scripts/check_bgp_neighbors_established.sh
Running in interactive mode
NAME      DATA   AGE
metallb   1      30d
Able to get metallb configmap from Kubernetes
metallb-speaker pods: false <------------------------
ERROR: metallb-speaker pods are not ready, which can cause this test to fail
FAIL
ncn-w004:~ # echo $?
16
```

It also reports if the pods are ok:

```
ncn-w004:~ # /opt/cray/tests/install/ncn/scripts/check_bgp_neighbors_established.sh
Running in interactive mode
NAME      DATA   AGE
metallb   1      30d
Able to get metallb configmap from Kubernetes
metallb-speaker pods: true <----------------------
```
