### PR TITLE
Adding a condition in ncn-k8s-combined-healthcheck-post-service-upgrade script

### DIFF
--- a/goss-testing/automated/ncn-k8s-combined-healthcheck-post-service-upgrade
+++ b/goss-testing/automated/ncn-k8s-combined-healthcheck-post-service-upgrade
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -91,6 +91,12 @@ else
     # run NCN local Kubernetes cluster tests plus the NCN worker BGP test
     run_goss_tests_print_results suites/ncn-combined-k8s-bgp-tests.yaml ${test_urls}
     rc=$?
+fi
+
+# Additional check to verify script is run from iuf hook script
+# To get original return code to validate goss-tests in iuf hook script
+if [[ -n "$1" && "$1" == "iuf" ]]; then
+    exit $rc
 fi
 
 # This script does not exit with non-0 return code just for test failures


### PR DESCRIPTION
goss-test to know its called through iuf and return exit code 1 if there is a test case failure

## Summary and Scope

This condition in csm hook script is failing to verify as goss-testing is giving exit code 0 even when there is test case failure

GRAND TOTAL: 715 passed, 11 failed
ERROR: There was at least one test failure
Sample 1
1

FAILED
ncn-m001:~ # echo $?
0

Adding a condition in ncn-k8s-combined-healthcheck-post-service-upgrade script from goss-test to know its called through iuf and return exit code 1 if there is a test case failure

Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?
yes

## Issues and Related PRs

List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

CASMTRIAGE-7320

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * surtur

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
yes
- Were continuous integration tests run?
yes
- Was upgrade tested?
yes
- Was downgrade tested?
yes

## Risks and Mitigations

No

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

