### PR TITLE
CASMPET-7242: use newer pause image

### DIFF
--- a/goss-testing/tests/ncn/goss-k8s-nexus-can-pull.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-nexus-can-pull.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2014-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -32,7 +32,7 @@ command:
             sev: 0
         exec: |-
             "{{$logrun}}" -l "{{$testlabel}}" \
-                crictl pull artifactory.algol60.net/csm-docker/stable/k8s.gcr.io/pause:3.4.1
+                crictl pull artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.7
         exit-status: 0
         timeout: 20000
         skip: false


### PR DESCRIPTION
## Summary and Scope

CSM 1.6 uses a newer pause image for kubernetes 1.24. This PR fixes the test case to pull the updated pause image.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7242](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7242)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

