### PR TITLE
CASMAUTO-53 add a new script to run tests and make dst results.json

### DIFF
--- a/.shellspec
+++ b/.shellspec
@@ -1,0 +1,12 @@
+--require spec_helper
+
+## Default kcov (coverage) options
+# --kcov-options "--include-path=. --path-strip-level=1"
+# --kcov-options "--include-pattern=.sh"
+# --kcov-options "--exclude-pattern=/.shellspec,/spec/,/coverage/,/report/"
+
+## Example: Include script "myprog" with no extension
+# --kcov-options "--include-pattern=.sh,myprog"
+
+## Example: Only specified files/directories
+# --kcov-options "--include-pattern=myprog,/lib/"

--- a/goss-testing/automated/dst-ct-results.sh
+++ b/goss-testing/automated/dst-ct-results.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Run CSM goss tests and produce a DST-compatible results.json file.
+# 
+# 1. Query the cgroups file for the pids of the goss suites/vars that are linked to an http endpoint
+# 2. Get the command each PID is running 
+# 3. Reformat the command into a goss command that can be run directly instead of with 'goss serve'
+# 4. Loop through and run each newly-formatted goss command and save the results to a file
+# 5. Aggregate each iteration into an api-results.json file, used by DST (additional formatting is required)
+# 6. Save the file, which can then be slurped up by the dst pipeline and sent to the results dashboard
+set -euo pipefail
+
+#######################################
+# Check for required RPMs, commands, and other prerequisites.
+# Globals:
+#   None
+# Arguments:
+#   ostype: the operating system type (default is $OSTYPE)
+# Outputs:
+#   None
+# Returns:
+#   0 if reqs are met, non-zero if not.
+#######################################
+prereqs() {
+  local rc=0
+  local reqs_rpms reqs_cmds
+  local ostype="${1:-${OSTYPE}}"
+
+  if [[ "${ostype}" != "linux"* ]]; then
+    echo "This script is only supported on Linux, detected: $ostype" >&2
+    return 1
+  fi
+
+  reqs_rpms=(
+    csm-testing 
+    goss-servers
+  )
+  for req in "${reqs_rpms[@]}"; do
+    if ! rpm -q "$req" &>/dev/null; then
+      echo "Required RPM is not installed: $req" >&2
+      rc=1
+    fi
+  done
+
+  reqs_cmds=(
+    jq
+    kubectl
+    yq
+  )
+  for req in "${reqs_cmds[@]}"; do
+    if ! command -v "$req" &>/dev/null; then
+      echo "Required command is not available: $req" >&2
+      rc=1
+    fi
+  done
+
+  if [[ "${rc:-0}" -ne 0 ]]; then
+    echo "Please address the missing prerequisites and try again." >&2
+    return $rc
+  fi
+
+  return 0
+}
+
+usage() {
+  # echo the usage in order to use the variable for the script name
+  # everything else is in the comments
+  echo "Usage: $(basename -- "${0}") [-h] OUTPUT_FILE"
+  # Any line startng with with a #/ will show up in the usage line
+
+  #/
+  #/    Run CSM goss tests and produce a DST-compatible results.json file.
+  #/
+  #/    -h      Display this help message
+  #/
+  grep '^  #/' "$0" | cut -c6-
+  return 0
+}
+
+#######################################
+# Set global variables for the script
+# Globals:
+#   GOSS_BASE
+#   GOSS_CGROUPS
+#   CSM_VER
+#   DST_RESULTS_FILE
+#   GOSS_COMMANDS
+#   AGGREGATED_GOSS_RESULTS_FILE
+# Arguments:
+#   None
+# Outputs:
+#   None
+# Returns:
+#   0 when all vars are set or non-zero via set -e.
+#######################################
+set_vars() {
+  if [ -f "/etc/pit-release" ]; then
+    export GOSS_BASE="/opt/cray/tests/install/livecd"
+  else
+    export GOSS_BASE="/opt/cray/tests/install/ncn"
+  fi
+  # The cgroups file that contains the pids of the goss suites/vars that are linked to an http endpoint
+  GOSS_CGROUPS="/sys/fs/cgroup/systemd/system.slice/goss-servers.service/cgroup.procs"
+  # The CSM version is needed for the DST pipeline for showing the version of the product the test ran on in the dashboard
+  CSM_VER="$(kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}' | yq r -j - | jq -r 'keys[]' | sed '/-/!{s/$/_/}' | sort -V | sed 's/_$//' | head -n1)"
+  # The DST-compatible results file (see https://github.hpe.com/hpe/hpc-dst-ct-results-api/blob/master/docs/usage/getting-started.md#quick-start)
+  DST_RESULTS_FILE="${TEST_BASE_DIR:-/tmp}/api-results.json"
+  # Each goss command to run will be added to this array
+  GOSS_COMMANDS=()
+  # this new file will be used after the loop to aggregate the results into a single "tests" key with an array of results for DST
+  AGGREGATED_GOSS_RESULTS_FILE=$(mktemp)
+  # Initialize an empty goss JSON object in a new temporary file
+  # By defining the default values, we can append to the results object in the loop
+  echo '
+  {
+    "results": [],
+    "summary": {
+      "failed-count": 0,
+      "summary-line": "Count: 0, Failed: 0, Duration: 0.0s",
+      "test-count": 0,
+      "total-duration": 0
+    }
+  }' > "$AGGREGATED_GOSS_RESULTS_FILE"
+
+  return 0
+}
+
+
+#######################################
+# Loops through each pid in the cgroups file, inspect its command, and format the goss command to run directly
+# Globals:
+#   GOSS_COMMANDS (populated with goss command strings)
+# Arguments:
+#   cgroups_path: the path to the cgroups file for the goss-servers.service
+#   format: the format to use for the goss command (default is json)
+# Outputs:
+#   None
+# Returns:
+#   0 on success, else non-zero.
+#######################################
+gather_goss_commands() {
+  local cgroups_path="${1:-}"
+  local format="${2:-json}"
+    # if the goss cgroups file exists, read the pids from it
+  if [[ -f "${cgroups_path}" ]]; then
+    local goss_pids cmd cmdline regex goss_command goss_file goss_vars_file
+    # read the pids from the cgroups file
+    goss_pids=$(<"${cgroups_path}")
+    # loop through each pid
+    for pid in ${goss_pids}; do
+      # skip any commands that are not goss
+      cmd=$(ps -p "$pid" -o comm=)
+      if [[ "${cmd}" != "goss" ]]; then
+        continue
+      fi
+      # get the command line of the pid (this is the full command that is running in the goss-server)
+      cmdline=$(ps --no-headers -o args fp "${pid}")
+      # regex the command line to gather the pieces needed to run the goss command directly
+      regex="^(/usr/bin/goss) -g ([^ ]+) --vars ([^ ]+) "
+      if [[ "$cmdline" =~ $regex ]]; then
+        # this shouldn't change, but it is also hardcoded in the regex as /usr/bin/goss
+        goss_command="${BASH_REMATCH[1]}"
+        # the goss file, which is the suite that contains links to all the tests
+        goss_file="${BASH_REMATCH[2]}"
+        # the vars file, which contains the variables that the tests use
+        goss_vars_file="${BASH_REMATCH[3]}"
+        # format the goss command to run directly
+        # add the goss command to the array of commands to run
+        GOSS_COMMANDS+=("${goss_command} -g ${goss_file} --vars ${goss_vars_file} validate -f ${format}")
+      fi
+    done
+  else
+    return 1
+  fi
+
+  return 0
+}
+
+#######################################
+# Loop through each goss command and processes it.
+# Globals:
+#   GOSS_COMMANDS (default)
+#   AGGREGATED_GOSS_RESULTS_FILE (default)
+# Arguments:
+#   aggregated_goss_results_file: the file to save the aggregated results to
+#   goss_commands: an array of goss commands to run
+# Outputs:
+#   Prints total suites found to run
+# Returns:
+#   0 on success, else non-zero via set -e.
+#######################################
+run_goss_aggregate_results() {
+  # first arg is a file
+  local aggregated_goss_results_file="${1:-$AGGREGATED_GOSS_RESULTS_FILE}"
+  shift ; local -a goss_commands=("${@:-${GOSS_COMMANDS[@]}}") # anything that follows should be a goss command string into an array
+  echo "Found ${#goss_commands[@]} suites to run"
+  for goss_command in "${goss_commands[@]}"; do
+    process_goss_command "$goss_command" "$aggregated_goss_results_file"
+  done
+  return 0
+}
+
+#######################################
+# Loops through each goss command, executes it, and aggregates the results into a single file
+# Globals:
+#   GOSS_COMMANDS (default)
+#   AGGREGATED_GOSS_RESULTS_FILE (default)
+# Arguments:
+#   aggregated_goss_results_file: the file to save the aggregated results to
+#   goss_commands: an array of goss commands to run
+# Outputs:
+#   Prints total suites found to run
+# Returns:
+#   0 on success, else non-zero via set -e.
+#######################################
+process_goss_command() {
+  local goss_command="${1:-}"
+  local aggregated_goss_results_file="${2:-}"
+  
+  # get the goss file name for the current suite
+  local goss_file
+  goss_file=$(echo "$goss_command" | awk '{print $3}')
+  goss_file=$(basename -- "${goss_file}")
+  printf "%s" "Running ${goss_file}..."
+  
+  # execute goss validate and save the result
+  local result
+  result=$($goss_command || echo {}) # || it should not fail since we just aggregate the results at the end
+  printf "%s\n" "DONE"
+  # aggregate each results to the aggregated_goss_results_file
+  # 1. extract the results key from the goss output
+  # 2. add the results to the existing array in the aggregated results file
+  # 3. save the new results to a temp file
+  echo "$result" | jq '.results' | jq -s 'add' | jq --argfile agg "$aggregated_goss_results_file" '. as $new | $agg | .results += $new' > "$aggregated_goss_results_file.tmp"
+  # move the temp file to become the new original file
+  mv "$aggregated_goss_results_file.tmp" "$aggregated_goss_results_file"
+  return 0
+}
+
+#######################################
+# Munges the aggregated results file into a format that is compatible with the DST pipeline
+# Globals:
+#   CSM_VER 
+#   AGGREGATED_GOSS_RESULTS_FILE
+#   TOTAL_TEST_COUNT
+#   TOTAL_FAILED_COUNT
+#   TOTAL_DURATION
+#   AGGREGATED_EXIT_CODE
+#   VERBOSE
+# Arguments:
+#   None
+# Outputs:
+#   Prints a summary of the aggregated results
+#   Prints the JSON if VERBOSE=1
+# Returns:
+#   0 on success, else +1 for each failed test suite.
+#######################################
+format_goss_results_for_dst() {
+  local aggregated_goss_results_file="${1:-$AGGREGATED_GOSS_RESULTS_FILE}"
+  local dst_results_file="${2:-$DST_RESULTS_FILE}"
+  # See https://github.hpe.com/hpe/hpc-dst-ct-results-api/blob/master/docs/usage/getting-started.md#creating-a-payload-for-the-json-endpoint
+  # 
+  # 1. extract the results key and assigns it to the variable $results
+  # 2. map the $results array to a new array of objects called "tests", required by DST
+  # 3. for each object in the $results array, create a new object, compatible with DST
+  # 4. assign the value of the "product_name" key to "CSM"
+  # 5. assign the value of the "product_version" key to the value of the $CSM_VER variable gathered earlier
+  # 6. assign the value of the "release_name" key to an empty string
+  # 7. assign the value of the "release_version" key to an empty string
+  # 8. assign the value of the "status" key to "pass" if the value of the successful key is true, otherwise assign "fail"
+  # 9. assign the value of the "label" key to the value of the "resource-id" key
+  # 10. assign the value of the "test_name" key to the value of the "meta.desc" key
+  # 11. (currently disabled since it only accepts a string) assign the value of the "output" key to the current object (this is the normal goss output)
+  #     "output": .,
+  # 12. create a new "triage" object, required by DST, with the following keys: slack, jira, spira (default to false)
+  # 13. (disabled since DST does not accept extra keys) create a new summary object, which is the aggregated total for this node
+  #     "summary": {
+  #       "failed-count": $TOTAL_FAILED_COUNT,
+  #       "summary-line": $summary_line,
+  #       "test-count": $TOTAL_TEST_COUNT,
+  #       "total-duration": $TOTAL_DURATION
+  #      }
+  # 14. save the output to a new file
+  jq --arg csm_version "${CSM_VER:-}" \
+    '.results as $results |
+    {
+      run_id: "",
+      tests: $results | map({
+        "product_name": "CSM",
+        "product_version": $csm_version,
+        "release_name": "",
+        "release_version": "",
+        "output": (if .successful then "omitted" else .stderr end),
+        "status": (if .successful then "pass" else "fail" end),
+        "label": ."resource-id",
+        "test_name": .title, 
+      }),
+      triage: {}
+  }' < "${aggregated_goss_results_file}" > "$dst_results_file"
+
+  # Print the summary
+  echo "Aggregated goss results have been saved to: $aggregated_goss_results_file"
+  echo "DST-and-ct-results-compatible file been saved to: $dst_results_file"
+  # Return the aggregated exit code (+1 per failed test suite)
+  return 0
+}
+
+#######################################
+# Loops through each goss command, executes it, and aggregates the results into a single file
+# Globals:
+#   GOSS_CGROUPS
+# Arguments:
+#   None
+# Outputs:
+#   Prints total suites found
+#   Prints current suite being executed and if OK or ERR
+#   Prints total count and failed count at the end
+#   Prints total count and failed count for each suite if VERBOSE=1
+# Returns:
+#   0 on success, else non-zero via set -e.
+#######################################
+main() {
+  # always run the prereqs function first to fail early
+  prereqs "${OSTYPE:=}"
+  # if prereqs passes, set the global variables
+  set_vars
+  
+  # parse the options into named variables
+  local dst_results_file="${1:-$DST_RESULTS_FILE}"
+  # parse the options
+  while getopts "h" opt; do
+  case ${opt} in
+    h)
+      shift
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Invalid option"
+      exit 1
+      ;;
+  esac
+  done
+
+  # get the goss commands from the cgroups file and format them
+  gather_goss_commands "${GOSS_CGROUPS}"
+  # loop through each goss command and run it directly
+  run_goss_aggregate_results "${AGGREGATED_GOSS_RESULTS_FILE}"
+  # format the aggregated results into a DST-compatible format
+  format_goss_results_for_dst "${AGGREGATED_GOSS_RESULTS_FILE}" "${dst_results_file}"
+}
+
+
+if [[ "${BASH_SOURCE[0]}" -ef "${0}" ]]; then
+  # if the script is run directly, run the main function
+  main "$@"
+fi
+

--- a/spec/functional/dst-ct-results_spec.sh
+++ b/spec/functional/dst-ct-results_spec.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# MIT License
+#
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+#
+# Permissioff is hereby granted, free of charge, to any persoff obtaining a
+# copy of this software and associated documentatioff files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permissioff notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTIoff OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTIoff WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+Describe "dst-ct-results.sh"
+Include "goss-testing/automated/dst-ct-results.sh"
+
+# usage should return 0 and display the usage line
+Describe "usage()"
+  It "should display the usage"
+    When call "usage"
+    The status should equal 0
+    The stdout should include "Usage: "
+  End
+End
+
+# prereqs should fail if not running on linux
+Describe "validate this only runs on linux variants:"
+  Parameters
+    linux         succeed    0    ""    ""
+    darwin21.1    fail       1    ""    "This script is only supported on Linux"
+  End
+
+  # loop through the parameters to check different OSTYPEs
+  Describe "prereqs()"
+    rpm() { return 0; } # mock rpm to succeed
+    command() { return 0; } # mock command to succeed
+    It "should $2 if \$OSTYPE is $1"
+      When run prereqs "$1"
+      The status should equal "$3"
+      The stdout should include "$4"
+      The stderr should include "$5"
+    End
+  End
+End
+
+# prereqs should fail if required rpms are not installed
+Describe "validate required rpms are installed:"
+  Describe "prereqs():"
+    rpm() { return 1; } # redefine and mock rpm command
+    It "should fail if required rpms are not installed"
+      When run prereqs linux
+      The status should equal 1
+      The stdout should include ""
+      The stderr should include "Required RPM is not installed"
+      The stderr should include "Please address the missing prerequisites and try again"
+    End
+  End
+End
+
+# prereqs should fail if required commands are not installed
+Describe "validate required commands are installed:"
+  Describe "prereqs():"
+    rpm() { return 0; } # redefine and mock rpm command
+    command() { return 1; } # redefine and mock rpm command
+    It "should fail if required commands are not available"
+      When run prereqs linux
+      The status should equal 1
+      The stdout should include ""
+      The stderr should include "Required command is not available"
+      The stderr should include "Please address the missing prerequisites and try again"
+    End
+  End
+End
+
+# set_vars should succeed and set global variables if all prerequisites are met
+Describe "validate global variables are set:"
+  Describe "set_vars():"
+    Parameters
+      GOSS_BASE               "/opt/cray/tests/install/ncn"
+      GOSS_CGROUPS            "/sys/fs/cgroup/systemd/system.slice/goss-servers.service/cgroup.procs"
+      CSM_VER                 "1.6.0"
+      DST_RESULTS_FILE            "/tmp/api-results.json"
+      # AGGREGATED_RESULTS_FILE "/tmp/aggregated-results.json" # mktmp varies
+    End
+    kubectl() { return 0; } # mock kubectl to set a csm version
+    # mock yq, jq, sed, and sort to return 0 since they vary in output between systems and are not relevant to this test
+    # the CSM_VER is normally gathered from a painful kubectl command, but works consistently irl
+    # but we mock all the portions here to just have it populate the variable with a version string
+    yq() { return 0; } # mock yq
+    jq() { return 0; } # mock jq
+    sed() { return 0; } # mock sed 
+    sort() { return 0; } # mock sort
+    head() { echo "1.6.0"; } # mock head to return a version string since it is last in the pipes
+    It "\$$1 should be set to $2"
+      When call set_vars # call, not run must be used here to inspect vars
+      The status should equal 0
+      The variable "$1" should be defined
+      The variable "$1" should equal "$2"
+    End
+  End
+End
+
+Describe "validate results file is created:"
+  temp_dir="$(mktemp -d)"
+  mock_goss_results() { # mock goss to return a pass and a fail
+    echo '
+    {
+    "results": [
+      {
+        "duration": 24890,
+        "err": null,
+        "expected": [
+          "0"
+        ],
+        "found": [
+          "1"
+        ],
+        "human": "Mock a successful test.",
+        "meta": {
+          "desc": "Mock a successful test.",
+          "sev": 0
+        },
+        "property": "exit-status",
+        "resource-id": "mock_success",
+        "resource-type": "Command",
+        "result": 1,
+        "skipped": false,
+        "stderr": "error",
+        "stdout": "",
+        "successful": true,
+        "summary-line": "Command: success",
+        "test-type": 0,
+        "title": "Mock success"
+      },
+      {
+        "duration": 24890,
+        "err": null,
+        "expected": [
+          "0"
+        ],
+        "found": [
+          "1"
+        ],
+        "human": "Mock a faled test.",
+        "meta": {
+          "desc": "Mock a faled test.",
+          "sev": 0
+        },
+        "property": "exit-status",
+        "resource-id": "mock_fail",
+        "resource-type": "Command",
+        "result": 1,
+        "skipped": false,
+        "stderr": "error",
+        "stdout": "",
+        "successful": false,
+        "summary-line": "Command: failure",
+        "test-type": 0,
+        "title": "Mock failure"
+      }
+    ],
+    "summary": {
+      "failed-count": 2,
+      "summary-line": "Count: 2, Failed: 1, Duration: 0.841s",
+      "test-count": 33,
+      "total-duration": 840698333
+      }
+    }' > "${temp_dir}"/aggregated-goss-results.json
+  } 
+  
+  Describe "format_goss_results_for_dst():"
+    BeforeCall mock_goss_results
+    File aggregated_goss_results="${temp_dir}"/aggregated-goss-results.json
+    File dst_results="${temp_dir}"/dst-results.json 
+    It "should create a results file"
+      When call format_goss_results_for_dst "${temp_dir}"/aggregated-goss-results.json "${temp_dir}"/dst-results.json 
+      The status should equal 0
+      The stdout should include "Aggregated goss results have been saved to: ${temp_dir}/aggregated-goss-results.json"
+      The stdout should include "DST-and-ct-results-compatible file been saved to: ${temp_dir}/dst-results.json"
+      The file aggregated_goss_results should be exist
+      # The file aggregated_goss_results should be_json         # FIXME: need a better custom matcher
+      The file dst_results should be exist
+      # The file dst_results should be_json                     # FIXME: need a better custom matcher
+    End
+  End
+End
+
+# TODO: implement this last test. jq's --argfile is not supported on mac, so this will need to be reworked
+# Describe "validate 'goss serve' commands can be reformatted to be compatible with 'goss validate':"
+#   Describe "gather_goss_commands():
+#   End
+# End
+
+End
+

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -1,0 +1,60 @@
+#
+# MIT License
+#
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# shellcheck shell=sh
+
+# Defining variables and functions here will affect all specfiles.
+# Change shell options inside a function may cause different behavior,
+# so it is better to set them here.
+# set -eu
+
+# This callback function will be invoked only once before loading specfiles.
+spec_helper_precheck() {
+  # Available functions: info, warn, error, abort, setenv, unsetenv
+  # Available variables: VERSION, SHELL_TYPE, SHELL_VERSION
+  : minimum_version "0.28.1"
+
+  # Fixtures location ./spec/testdata/fixtures
+  setenv FIXTURES="$SHELLSPEC_HELPERDIR/testdata/fixtures"
+  # use /tmp for consistent test dir that doesn't conflict with local dev
+  # also helpful for cani config fixtures if this is a static, abs path
+}
+
+# This callback function will be invoked after a specfile has been loaded.
+spec_helper_loaded() {
+  :
+}
+
+# This callback function will be invoked after core modules has been loaded.
+spec_helper_configure() {
+  # Available functions: import, before_each, after_each, before_all, after_all
+  import 'support/custom_matcher'
+}
+
+# compare value to file content
+# https://github.com/shellspec/shellspec/issues/295#issuecomment-1531834218
+fixture(){
+  #shellcheck disable=SC2317
+  [ "${fixture:?}" = "$( cat "$FIXTURES/$1" )" ]
+}
+

--- a/spec/support/custom_matcher.sh
+++ b/spec/support/custom_matcher.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+shellspec_syntax 'shellspec_matcher_regexp'
+
+shellspec_matcher_regexp() {
+  shellspec_matcher__match() {
+    SHELLSPEC_EXPECT="$1"
+    [ "${SHELLSPEC_SUBJECT+x}" ] || return 1
+    expr "$SHELLSPEC_SUBJECT" : "$SHELLSPEC_EXPECT" > /dev/null || return 1
+    return 0
+  }
+
+  # Message when the matcher fails with "should"
+  shellspec_matcher__failure_message() {
+    shellspec_putsn "expected: $1 match $2"
+  }
+
+  # Message when the matcher fails with "should not"
+  shellspec_matcher__failure_message_when_negated() {
+    shellspec_putsn "expected: $1 not match $2"
+  }
+
+  # checking for parameter count
+  shellspec_syntax_param count [ $# -eq 1 ] || return 0
+  shellspec_matcher_do_match "$@"
+}
+
+
+shellspec_syntax 'shellspec_matcher_be_json'
+shellspec_matcher_be_json() {
+  shellspec_matcher__match() {
+    # no args because we match the subject
+    [ ${SHELLSPEC_SUBJECT+x} ]
+    # check if jq can read the subject
+    if ! echo "$SHELLSPEC_SUBJECT" | jq -r > /dev/null;then return 1;fi
+    return 0
+  }
+
+  shellspec_syntax_failure_message + \
+    'expected: valid json' \
+    '     got: $1'
+
+  shellspec_syntax_failure_message - \
+    'expected: invalid json' \
+    '     got: $1'
+
+  shellspec_syntax_param count [ $# -eq 0 ] || return 0
+  shellspec_matcher_do_match "$@"
+}
+
+shellspec_syntax 'shellspec_matcher_be_yaml'
+shellspec_matcher_be_yaml() {
+  shellspec_matcher__match() {
+    # no args because we match the subject
+    [ ${SHELLSPEC_SUBJECT+x} ]
+    # check if yq can read the subject
+    if ! echo "$SHELLSPEC_SUBJECT" | yq > /dev/null;then return 1;fi
+    return 0
+  }
+
+  shellspec_syntax_failure_message + \
+    'expected: valid yaml' \
+    '     got: $1'
+
+  shellspec_syntax_failure_message - \
+    'expected: invalid yaml' \
+    '     got: $1'
+
+  shellspec_syntax_param count [ $# -eq 0 ] || return 0
+  shellspec_matcher_do_match "$@"
+}


### PR DESCRIPTION
CASMAUTO-53 add a new script that runs all available goss tests on any node type and creates a DST-compatible json

It works by looking for the commands that are running in goss-servers
and reformats them so they can be executed directly by the script, or
potentially a human trying to debug them.  This was needed to get the
JSON output without needing to go through several layers of wrapper
scripts that currently exist.

While it may be possible to have the DST pipeline properly execute the
goss tests with the existing framework and wrapper scripts, it proved to
be challenging and easy to get lost on what calls what.  There is a
strong need for three important things:

1. it should be trivial for a contributor of any skill level to add a
   new test
1. any new tests should be automatically run the next time the rpm is
   installed as part of a build
1. the test output needs to be machine-readable, which is currently
   limited with the existing wrapper scripts and http endpoints (or it
   is non-trivial to modify it to do so)

Here is an example of this complexity I am trying to overcome with this
script:

1. a systemd service is started with `start-goss-servers.sh`, which reads `dat/goss-servers.cfg` and runs `goss serve` for each suite file
1. each suite file has one or more individual test files it will run,
   many of which are in multiple suites

those two steps are logical and a reasonable setup.  when you start
adding in these wrapper scripts, it gets confusing:

1. a comprehensive helper script, `run-ncn-tests.sh` has many functions, one of which sets up temporary variable files, which is used by the `start-goss-servers.sh`
1. with the http endpoints up and running, additional wrapper scripts
   are used to facilitate __calling__ the endpoints and vary in their
   methods to do so
1. in most cases, `run-ncn-tests.sh` is `source`d by the
   `automated/<wrapper>` script, and there is some bash functions, which
   call a python script that will determine the http endpoint urls and
   get appropriate node types
1. in addition to the endpoints from the python wrapper script, the bash
   function also accepts individual test files, so each wrapper script
   can add their own extra tests if needed.  this functionality is
   helpful, but makes it difficult to track down what is being run
1. these endpoints may vary depending on different factors: if it is a
   vshasta node, if it is the pit or not, if kube credentials are
   available or not, so logic exists in all these wrapper scripts to
   calculate that
1. some of that logic can also add a suite instead of a test, so there
   is the potential for individual tests to be run multiple times
1. some of these wrapper scripts run different functions to the same end
   result.  some call `run_goss_tests_print_results`, some call
   `print_goss_json_results`, some do one or the other based on previous
   logic, and some simply call `run_goss_tests` with little other logic,
   one even skips those helper functions and just calls goss directly
   (`ncn-postgres-tests`)
1. in
   https://cray-hpe.github.io/docs-csm/en-15/operations/validate_csm_health/,
   the document mainly calls out
   `/opt/cray/tests/install/ncn/automated/ncn-k8s-combined-healthcheck`,
   which is one of the wrapper scripts, so it isn't immediately clear
   where the others come into play
1. in addition to this automated wrapper script, the document also calls
   out:
    1. some PET wrappers: `/opt/cray/platform-utils/ncnHealthChecks.sh`
    1. some HMS wrappers:
       `/opt/cray/csm/scripts/hms_verification/hsm_discovery_status_test.sh`
       and `/opt/cray/csm/scripts/hms_verification/verify_hsm_discovery.py`
    1. some CMS wrappers: `/usr/local/bin/cmsdev`
    1. a barebones test:
       `/opt/cray/tests/integration/csm/barebonesImageTest`

1. HMS and CSM both have goss test files in this repo, but also use
   their own wrappers, which may do other things I have not investigated
1. in addition to the wrapper scripts, the vars files contain some
   things, but not as many as would be most useful.  for example, the
   `pod_services` has only four services which are checked, but there
   are much more.
1. some of these vars could be dynamically gathered at run time. this is
   out of scope right now for this ticket, but worth mentioning in the
   complexity of things since we have a lot of complexity, but are then
   prone to not testing everything at that expense (such as testing four
   services instead of all of them)
1. some tests only need to run from one node (for example, if they are
   only querying the apis or running a kubectl command that would be the
   same on every node), while others need to run on each node and run
   local commands, so there is likely some overlap and unnecessary
   running of some tests in some places, but again, it is hard to flush
   out where and what exactly is happening

This new script I made adds to the complexity of having yet another
wrapper, but the end goal is to allow the three important bullets I
mentioned previously and to allow the tests to run in the pipeline and
report properly to the DST dashboard.  Since these tests are a gate to a
release, we need to ensure they are actually run properly and reported
properly; right now, they are not.

So this new script jumps in front of the complexity and queries the goss
endpoints, borrows their created variable files and creates a goss
command that can be run by a human or a machine.

This script can run on any node type and will only run the tests it
finds (those that are setup with a goss endpoint).  this allows the
majority of this repo to remain the same and will allow any new changes
people are used to making to automatically be executed when this script
runs.

this script's current puprose is to create the results.json file DST can
use, but it could be grown to replace some wrappers or improve upon
them.

We also need the ability to run and individually trigger smoke, funcitonal, and destructive level tests, both ad-hoc and automated.

So while this script is not perfect right now, it can run on all nodes
and run the existing tests.  this is step one to get the gate in a
better position and allow newly-added tests to run without a change to
this script.

I ran this new script on three node types:

**Master**

```
ncn-m002:~ # ./dst-ct-results.sh
Found 14 suites to run
Running ncn-preflight-tests.yaml...DONE
Running ncn-smoke-tests.yaml...DONE
Running ncn-spire-healthchecks.yaml...DONE
Running ncn-healthcheck-master.yaml...DONE
Running ncn-healthcheck-master-single.yaml...DONE
Running ncn-afterpitreboot-healthcheck-master.yaml...DONE
Running ncn-kubernetes-tests-master.yaml...DONE
Running ncn-kubernetes-tests-master-single.yaml...DONE
Running ncn-afterpitreboot-kubernetes-tests-master-single.yaml...DONE
Running ncn-kubernetes-tests-cluster.yaml...DONE
Running ncn-cms-tests.yaml...DONE
Running ncn-hms-ct-tests.yaml...DONE
Running ncn-post-csm-service-upgrade-tests.yaml...DONE
Running ncn-healthcheck-master-single-post-service-upgrade.yaml...DONE
Aggregated goss results have been saved to: /tmp/tmp.ppyE5WIK3y
DST-and-ct-results-compatible file been saved to: /tmp/api-results.json
ncn-m002:~ # jq '.tests | length' < /tmp/api-results.json
297
```

**Worker**

```
ncn-w002:~ # ./dst-ct-results.sh
Found 10 suites to run
Running ncn-preflight-tests.yaml...DONE
Running ncn-smoke-tests.yaml...DONE
Running ncn-spire-healthchecks.yaml...DONE
Running ncn-healthcheck-worker.yaml...DONE
Running ncn-healthcheck-worker-single.yaml...DONE
Running ncn-afterpitreboot-healthcheck-worker.yaml...DONE
Running ncn-afterpitreboot-healthcheck-worker-single.yaml...DONE
Running ncn-kubernetes-tests-worker.yaml...DONE
Running ncn-afterpitreboot-kubernetes-tests-worker-single.yaml...DONE
Running ncn-cms-tests.yaml...DONE
Aggregated goss results have been saved to: /tmp/tmp.pLpgqaGT8V
DST-and-ct-results-compatible file been saved to: /tmp/api-results.json
ncn-w002:~/ # jq '.tests | length' < /tmp/api-results.json
119
```

**Storage**

```
ncn-s001:~ # ./dst-ct-results.sh
Found 6 suites to run
Running ncn-preflight-tests.yaml...DONE
Running ncn-smoke-tests.yaml...DONE
Running ncn-spire-healthchecks.yaml...DONE
Running ncn-healthcheck-storage.yaml...DONE
Running ncn-afterpitreboot-healthcheck-storage.yaml...DONE
Running ncn-storage-tests.yaml...DONE
Aggregated goss results have been saved to: /tmp/tmp.8UfELQmAS1
DST-and-ct-results-compatible file been saved to: /tmp/api-results.json
ncn-s001:~ # jq '.tests | length' < /tmp/api-results.json
96
```

I also submitted the resulting files to the dashboard and saw they
reported appropriately.

```
HTTP/2 200
server: nginx/1.24.0
date: Wed, 16 Oct 2024 19:29:54 GMT
content-type: application/json
content-length: 341
access-control-allow-origin: *

{
  "artifacts": {
    "github_url": "",
    "run_id": "2234567890",
    "run_url": "
  },
  "success": true,
  "trace_id": "",
  "warnings":[]
}
```

Signed-off-by: Jacob Salmela <jacob.salmela@hpe.com>