### PR TITLE
CASMTRIAGE-7314

### DIFF
--- a/goss-testing/scripts/check_bootloader.sh
+++ b/goss-testing/scripts/check_bootloader.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -57,7 +57,7 @@ function verify_initrd {
     local needed_initrd_name
     local needed_initrd
     
-    needed_initrd_name="$(grep -oP '(?<=initrdefi \$prefix/\.\./)(initrd[a-zA-Z.\-_]*)' ${BOOTRAID}/boot/grub2/grub.cfg)"
+    needed_initrd_name="$(grep -oE '(initrd|initrdefi)\s+\$prefix\/\.\.\/initrd[a-zA-Z.\-_]*' ${BOOTRAID}/boot/grub2/grub.cfg | awk -F'/' '{print $NF}')"
     needed_initrd="${BOOTRAID}/boot/${needed_initrd_name}"
     if [ ! -f $needed_initrd ]; then
 


### PR DESCRIPTION
## Summary and Scope

Update check_bootloader.sh to allow "initrd" and "initrdefi"
- https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7314

### Tested on:

- surtur

### Test description:

Modified check_bootloader.sh on ncn-m001 and ran it.
It now returns the following:
```
The disk's kernel exists and is validated.
The disk's initrd was validated. The initrd name in GRUB's configuration exists on the filesystem and is a proper CPIO archive.
```

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable