### PR TITLE
CASMTRIAGE-7405 make goss tests for CSM 1.6 backwards compatible

### DIFF
--- a/goss-testing/scripts/check_master_taints.sh
+++ b/goss-testing/scripts/check_master_taints.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# This test checks that master nodes have the correct taint
+
+this_node_name=$1
+if [[ -z $this_node_name ]]; then
+  echo "ERROR node name was not supplied as an argument. Exiting."
+  exit 1
+fi
+
+# the following taint is expected in CSM 1.6+ which has K8s 1.24+
+taint="node-role.kubernetes.io/control-plane:NoSchedule"
+
+k8s_version=$(kubectl version --short -o json | jq -r '.serverVersion')
+major=$(echo $k8s_version | jq -r '.major')
+minor=$(echo $k8s_version | jq -r '.minor')
+if [[ $major -ne 1 ]]; then
+  echo "FAIL: K8s major version: $major is unexpected"
+  exit 1
+fi
+if [[ $minor -lt 24 ]]; then
+  # master node taint should be node-role.kubernetes.io/master:NoSchedule if on K8s version before 1.24
+  taint="node-role.kubernetes.io/master:NoSchedule"
+fi
+
+kubectl get node $this_node_name  -o jsonpath='{range .spec.taints[*]}{.key}:{.effect}{"\n"}{end}' | grep "$taint"
+exit $?

--- a/goss-testing/scripts/check_master_taints.sh
+++ b/goss-testing/scripts/check_master_taints.sh
@@ -33,7 +33,7 @@ fi
 # the following taint is expected in CSM 1.6+ which has K8s 1.24+
 taint="node-role.kubernetes.io/control-plane:NoSchedule"
 
-k8s_version=$(kubectl version --short -o json | jq -r '.serverVersion')
+k8s_version=$(kubectl version -o json | jq -r '.serverVersion')
 major=$(echo $k8s_version | jq -r '.major')
 minor=$(echo $k8s_version | jq -r '.minor')
 if [[ $major -ne 1 ]]; then

--- a/goss-testing/tests/common/goss-ceph-csi-k8s-requirements.yaml
+++ b/goss-testing/tests/common/goss-ceph-csi-k8s-requirements.yaml
@@ -31,7 +31,6 @@ file:
             desc: "Check that kubectl command exists"
             sev: 0
         exists: true
-        filetype: symlink
 command:
     {{range $configmap := index .Vars "k8s_ceph_csi_configmaps"}}
         {{ $testlabel := $configmap | printf "k8s_cm_%s" }}

--- a/goss-testing/tests/ncn/goss-check-taints.yaml
+++ b/goss-testing/tests/ncn/goss-check-taints.yaml
@@ -27,8 +27,9 @@
 {{ $env_hostname := getEnv "HOSTNAME" }}
 {{ $vars_hostname := get .Vars "this_node_name" }}
 {{ $this_node_name := default $env_hostname $vars_hostname }}
-{{ $kubectl := .Vars.kubectl }}
+{{ $scripts := .Env.GOSS_BASE | printf "%s/scripts" }}
 {{ $logrun := .Env.GOSS_BASE | printf "%s/scripts/log_run.sh" }}
+{{ $master_taints_check := $scripts | printf "%s/check_master_taints.sh" }}
 command:
     # We are only checking for this taint on master nodes 
     {{if $this_node_name | regexMatch "^ncn-m.*" }}
@@ -36,11 +37,11 @@ command:
         {{$testlabel}}:
             title: master-taint 
             meta:
-                desc: Checks that the node-role.kubernetes.io/control-plane:NoSchedule taint exists on this master node. If this tests fails, make the node-role.kubernetes.io/control-plane:NoSchedule gets added to this node. 
+                desc: Checks that the node-role.kubernetes.io/control-plane:NoSchedule taint exists on this master node if node is using Kubernetes 1.24+, otherwise checks that this master node has node-role.kubernetes.io/master:NoSchedule taint. If this tests fails, add the taint to this node. 
                 sev: 0
             exec: |-
                 "{{$logrun}}" -l "{{$testlabel}}" \
-                    {{$kubectl}} get node {{$this_node_name}}  -o jsonpath='{range .spec.taints[*]}{.key}:{.effect}{"\n"}{end}' | grep "node-role.kubernetes.io/control-plane:NoSchedule" 
+                    "{{$master_taints_check}}" "{{$this_node_name}}"
             exit-status: 0
             timeout: 20000
     {{end}}


### PR DESCRIPTION
## Summary and Scope

Two goss tests that were adjusted for CSM 1.6 are now failing in CSm 1.5 which causes a problem when these tests are run before all the nodes are upgraded to CSM 1.6. The specific tests that are failed are below.

```bash
Result: FAIL
Source: http://ncn-m001.hmn:9001/ncn-kubernetes-tests-master
Test Name: master-taint
Description: Checks that the node-role.kubernetes.io/control-plane:NoSchedule taint exists on this master node. If this tests fails, make the node-role.kubernetes.io/control-plane:NoSchedule gets added to this node.
Test Summary: Command: master_taint: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0
Execution Time: 0.000033342 seconds
Node: ncn-m001

Result: FAIL
Source: /opt/cray/tests/install/ncn/suites/ncn-combined-k8s-bgp-tests.yaml
Test Name: /usr/bin/kubectl command
Description: Check that kubectl command exists
Test Summary: File: /usr/bin/kubectl: filetype:
Expected
    <string>: file
to equal
    <string>: symlink
Execution Time: 0.000071423 seconds
Node: ncn-m001
```

This PR addresses these issues.

The '/usr/bin/kubectl command' test is fixed by removing the check for the filetype. The check still verifies that the '/usr/bin/kubectl' file exists but it no longer checks if it is a file or a symlink.

The 'master-taint' test is fixed by creating a script that checks the kubernetes server version. If the k8s server version is less than 1.24, then the check looks for the 'node-role.kubernetes.io/master:NoSchedule' taint. If the k8s version is 1.24+, then the check looks for the 'node-role.kubernetes.io/control-plane:NoSchedule' taint.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-7405](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7405)

## Testing

### Tested on:

  * Drax for CSM 1.5 testing
  * Wasp for CSM 1.6 testing

### Test description:

I ran the new and old versions of these tests on both CSM 1.5 and CSM 1.6. It is expected that the old version of these tests fail on CSM 1.5 and the new versions work on CSM 1.5. It is expected that both the old and new versions work on CSM 1.6. The results can be seen below.

Note: the change to the '/usr/bin/kubectl command' test removed the test for checking the filetype. This means the number of tests decreased by 1. The 'OLD' version runs 10 tests and the 'NEW' version runs 9 tests.

Ran the tests below on drax which is a CSM 1.5 system

```bash
ncn-m001:~/leliasen # bash -x ./run_goss.sh ncn/goss-check-taints-OLD.yaml
+ GOSS_BASE=/root/leliasen
+ goss -g /root/leliasen/tests/ncn/goss-check-tatins-OLD.yaml --vars=/root/leliasen/vars/variables-ncn.yaml validate
F

Failures/Skipped:

Title: master-taint
Meta:
    desc: Checks that the node-role.kubernetes.io/control-plane:NoSchedule taint exists on this master node. If this tests fails, make the node-role.kubernetes.io/control-plane:NoSchedule gets added to this node.
    sev: 0
Command: master_taint: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0

Total Duration: 0.117s
Count: 1, Failed: 1, Skipped: 0
ncn-m001:~/leliasen # bash -x ./run_goss.sh ncn/goss-check-taints-NEW.yaml
+ GOSS_BASE=/root/leliasen
+ goss -g /root/leliasen/tests/ncn/goss-check-tatins-NEW.yaml --vars=/root/leliasen/vars/variables-ncn.yaml validate
.

Total Duration: 0.243s
Count: 1, Failed: 0, Skipped: 0


ncn-m001:~/leliasen # ./run_goss.sh common/goss-ceph-csi-k8s-OLD.yaml
.F........

Failures/Skipped:

Title: /usr/bin/kubectl command
Meta:
    desc: Check that kubectl command exists
    sev: 0
File: /usr/bin/kubectl: filetype:
Expected
    <string>: file
to equal
    <string>: symlink

Total Duration: 0.102s
Count: 10, Failed: 1, Skipped: 0
ncn-m001:~/leliasen # ./run_goss.sh common/goss-ceph-csi-k8s-NEW.yaml
.........

Total Duration: 0.103s
Count: 9, Failed: 0, Skipped: 0
ncn-m001:~/leliasen #
```


Ran the tests below on wasp which is a CSM 1.6 system

```bash
ncn-m001:~/leliasen/leliasen # ./run_goss.sh common/goss-ceph-csi-k8s-OLD.yaml
..........

Total Duration: 0.186s
Count: 10, Failed: 0, Skipped: 0
ncn-m001:~/leliasen/leliasen # ./run_goss.sh common/goss-ceph-csi-k8s-NEW.yaml
.........

Total Duration: 0.184s
Count: 9, Failed: 0, Skipped: 0
ncn-m001:~/leliasen/leliasen #
ncn-m001:~/leliasen/leliasen # ./run_goss.sh ncn/goss-check-taints-OLD.yaml
.

Total Duration: 0.164s
Count: 1, Failed: 0, Skipped: 0
ncn-m001:~/leliasen/leliasen # ./run_goss.sh ncn/goss-check-taints-NEW.yaml
.

Total Duration: 0.396s
Count: 1, Failed: 0, Skipped: 0
```


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

