### PR TITLE
use find cmd instead of static path for finding goss-server pids

### DIFF
--- a/goss-testing/automated/dst-ct-results.sh
+++ b/goss-testing/automated/dst-ct-results.sh
@@ -122,7 +122,7 @@ set_vars() {
     export GOSS_BASE="/opt/cray/tests/install/ncn"
   fi
   # The cgroups file that contains the pids of the goss suites/vars that are linked to an http endpoint
-  GOSS_CGROUPS="/sys/fs/cgroup/systemd/system.slice/goss-servers.service/cgroup.procs"
+  GOSS_CGROUPS="$(find /sys/fs/cgroup -path '*/goss-servers.service/cgroup.procs' -type f)"
   # The CSM version is needed for the DST pipeline for showing the version of the product the test ran on in the dashboard
   CSM_VER="$(kubectl -n services get cm cray-product-catalog -o jsonpath='{.data.csm}' | yq r -j - | jq -r 'keys[]' | sed '/-/!{s/$/_/}' | sort -V | sed 's/_$//' | head -n1)"
   # The DST-compatible results file (see https://github.hpe.com/hpe/hpc-dst-ct-results-api/blob/master/docs/usage/getting-started.md#quick-start)


### PR DESCRIPTION
the path the file is found at can vary between nodes, so using the find command is safer and more resilient.
