### PR TITLE
CASMPET-7261: Fix regular expression in iSCSI test to work as intended

### DIFF
--- a/goss-testing/tests/ncn/goss-validate-iscsi-sbps-config.yaml
+++ b/goss-testing/tests/ncn/goss-validate-iscsi-sbps-config.yaml
@@ -29,12 +29,12 @@
 {{ $logrun := $scripts | printf "%s/log_run.sh" }}
 command:
 
-   {{if $this_node_name | regexMatch "^ncn-(w*)"}}
+   {{if $this_node_name | regexMatch "^ncn-w.*"}}
        {{ $testlabel := "iscsi_cps_sanity" }}
        {{$testlabel}}:
-           title: iscsi boot content projection
+           title: iSCSI boot content projection
            meta:
-               desc: checks for iscsi portals and iscsi based boot content projection service is active and running.
+               desc: Checks for iSCSI portals and verifies that the iSCSI-based boot Content Projection Service is active and running.
                sev: 0
            exec: |-
              "{{$logrun}}" -l "{{$testlabel}}" \
@@ -42,4 +42,4 @@ command:
            exit-status: 0
            timeout: 20000
            skip: false
-    {{end}}
+   {{end}}


### PR DESCRIPTION
The regular expression in this test is intended to limit it to only run on worker nodes. However, the regex actually matches any hostname that begins with 'ncn-', not just workers. This PR corrects that. I've tested it on gamora and verified that it works.