### PR TITLE
CASMPET-7263: Force goss-servers to wait until hostname is set

### DIFF
--- a/systemd/start-goss-servers.sh
+++ b/systemd/start-goss-servers.sh
@@ -35,7 +35,15 @@ fi
 export KUBECONFIG=/etc/kubernetes/admin.conf
 
 # necessary for test that need to know the current hostname
+# It is possible for this service to start before cloud-init has assigned a hostname to the NCN.
+# If the hostname is not in one of the expected formats, sleep and check later.
+pattern="(ncn-[msw][0-9]{3}|-pit)$"
 HOSTNAME=$(hostname -s)
+while [[ ! ${HOSTNAME} =~ ${pattern} ]]; do
+    sleep 5
+    HOSTNAME=$(hostname -s)
+done
+
 export HOSTNAME
 
 # During the NCN image build, this service is started, even though the csm-testing RPM is not installed. In that

--- a/systemd/start-goss-servers.sh
+++ b/systemd/start-goss-servers.sh
@@ -52,6 +52,12 @@ export HOSTNAME
 # there is likewise a chance that this service is started just before the csm-testing RPM has been installed. In both
 # cases, the solution if the run-ncn-tests.sh file does not exist (or exists but is empty, for some weird reason)
 # is to sleep for a bit and check again.
+while ! rpm -q csm-testing > /dev/null 2>&1; do
+    sleep 5
+done
+# Include the versions of these to help with debugging
+rpm -q csm-testing goss-servers
+
 while [[ ! -s "${GOSS_BASE}/automated/run-ncn-tests.sh" ]]; do
     sleep 5
 done


### PR DESCRIPTION
On gamora recently, the goss servers started before cloud-init had set the system hostname. This caused some tests not to run, because the hostname in the Goss variable file was incorrect.

This PR changes the startup script for the goss-servers service to do a few things:

1. Wait for the hostname to be set before starting
2. Wait for the csm-testing RPM to be installed before starting
3. Include the versions of both the csm-testing and goss-servers RPM in the service log, to help with debugging

I tested this on mug.