### PR TITLE
CASMPET-7266: Fix hostname regex in start-goss-servers.sh

### DIFF
--- a/systemd/start-goss-servers.sh
+++ b/systemd/start-goss-servers.sh
@@ -34,10 +34,18 @@ fi
 # necessary for kubectl commands to run
 export KUBECONFIG=/etc/kubernetes/admin.conf
 
-# necessary for test that need to know the current hostname
+# Some tests need to know the current hostname.
+#
 # It is possible for this service to start before cloud-init has assigned a hostname to the NCN.
 # If the hostname is not in one of the expected formats, sleep and check later.
-pattern="(ncn-[msw][0-9]{3}|-pit)$"
+#
+# This will also have the effect that if goss-servers is installed on a node which is not an
+# NCN or PIT, it will never proceed beyond this point -- which is fine because those are the only
+# node types defined in dat/goss-servers.cfg, and therefore are the only node types where this service
+# will start up any test endpoints.
+#
+# This regex should match the ones used in lib/endpoints.py for determining node type
+pattern="^(ncn-[msw][0-9]{3}|pit)$"
 HOSTNAME=$(hostname -s)
 while [[ ! ${HOSTNAME} =~ ${pattern} ]]; do
     sleep 5


### PR DESCRIPTION
On the CSM 1.6.1 vshasta deployment last night, the `goss-servers` service failed to start properly on the PIT node, because of a bad regex in my PR for [CASMPET-7263](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7263).

This PR corrects the regex, making it exactly match the ones used in `lib/endpoints.py`, which is what the `goss-servers` service uses to determine what test endpoints to start up.

I also added a more detailed comment about the hostname check and the corresponding regex, making the link between those two things clear.

There are backports for CSM 1.5 and CSM 1.4, since this change went into those as well:
1.5: https://github.com/Cray-HPE/csm-testing/pull/619
1.4: https://github.com/Cray-HPE/csm-testing/pull/620