### PR TITLE
CASMPET-7262: After installing csm-testing, restart goss-servers service if it is active

### DIFF
--- a/csm-testing.spec
+++ b/csm-testing.spec
@@ -229,6 +229,12 @@ rmdir %{buildroot}%{test_dir} || true
 %{ncn}
 %{python_venv_dir}
 
+%post
+# Restart goss-servers service, if installed and running
+if systemctl is-active goss-servers; then
+  systemctl try-restart goss-servers
+fi
+
 %changelog
 
 %package -n goss-servers


### PR DESCRIPTION
Currently, whenever we upgrade the `csm-testing` RPM, we have to restart the `goss-servers` service to pick up the changes. This PR modifies the `csm-testing` RPM so that after it is installed, it will automatically restart the `goss-servers` service, if it is installed and active.

I have tested this on mug and verified that it behaves as expected.

Backports:
1.5: https://github.com/Cray-HPE/csm-testing/pull/622
1.4: https://github.com/Cray-HPE/csm-testing/pull/623