### PR TITLE
CASMTRIAGE-7457: Fix bug causing some Python script symlinks from not being created

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 *       @Cray-HPE/metal
 *       @Cray-HPE/platform-engineering
-
+*       @mharding-hpe
+*       @jacobsalmela

--- a/common.sh
+++ b/common.sh
@@ -22,7 +22,15 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
+# No shebang line included in this file because it is only intended to be sourced, never
+# directly executed. But to let shellcheck know:
+# shellcheck shell=bash
+
 # Shared definitions for Bash scripts used in the build process
 
+# We know these variables are not used in this script -- they are defined to be used by scripts which source this one
+#shellcheck disable=SC2034
 SYMLINK_PREFIX="#python-script-symlink"
+
+#shellcheck disable=SC2034
 SYMLINK_FS="|"

--- a/common.sh
+++ b/common.sh
@@ -1,0 +1,28 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Shared definitions for Bash scripts used in the build process
+
+SYMLINK_PREFIX="#python-script-symlink"
+SYMLINK_FS="|"

--- a/create-python-script-symlinks.sh
+++ b/create-python-script-symlinks.sh
@@ -25,6 +25,8 @@
 
 set -euo pipefail
 
+source ./common.sh
+
 # Usage: create-python-script-symlinks.sh <path to buildroot>
 #                                         <path to Python virtual env>
 #                                         <tests|tools>
@@ -61,12 +63,14 @@ done
 
 [[ -s pyproject.toml ]] || err_exit "pyproject.toml does not exist or is not a non-empty file"
 
-grep "^[a-z][a-z_]*[a-z] = \"csm_testing[.]${script_type}[.][a-z][a-z_]*[a-z][.]__main__:main\"" pyproject.toml || err_exit "No script lines found in pyproject.toml"
+# SYMLINK_PREFIX and SYMLINK_FS are defined in common.sh
+full_pattern="^${SYMLINK_PREFIX}${SYMLINK_FS}${script_type}_"
+num_found=0
 
-for source_name_target_name in $(grep "^[a-z][a-z_]*[a-z] = \"csm_testing[.]${script_type}[.][a-z][a-z_]*[a-z][.]__main__:main\"" pyproject.toml |
-                              sed 's/^\([a-z][a-z_]*[a-z]\) .*[.]\([a-z][a-z_]*[a-z]\)[.]__main__:main".*$/\1:\2/'); do
-    source_script_name=${source_name_target_name%%:*}
-    target_script_name=${source_name_target_name##*:}
+for source_script_name in $(grep -E "${full_pattern}" pyproject.toml |
+                            cut -d"${SYMLINK_FS}" -f2); do
+    let num_found+=1
+    target_script_name=${source_script_name/${script_type}_/}
 
     source_script_path="${buildroot}${venv_path}/bin/${source_script_name}"
     [[ -f ${source_script_path} ]] || err_exit "Script does not exist or is not a regular file: ${source_script_path}"
@@ -78,3 +82,8 @@ for source_name_target_name in $(grep "^[a-z][a-z_]*[a-z] = \"csm_testing[.]${sc
         ln -rsv "${source_script_path}" "${target_script_path}"
     done
 done
+
+if [[ ${num_found} -eq 0 ]]; then
+    err_exit "No symlink script lines found in pyproject.toml"
+fi
+echo "Created symlinks for ${num_found} scripts"

--- a/update-pyproject.sh
+++ b/update-pyproject.sh
@@ -27,6 +27,8 @@ set -eu
 
 tmpfile=$(mktemp)
 
+source ./common.sh
+
 function addline {
     # Usage: <script_prefix> <mainfile-path>
     local prefix mainfile dirpath subdir script_name script_target
@@ -46,7 +48,12 @@ function addline {
     # Script target is dirpath with / replaced by ., appended with .__main__:main
     script_target=${dirpath//\//.}.__main__:main
 
-    echo "${script_name} = \"${script_target}\"" >> "${tmpfile}"
+    {
+        echo "${script_name} = \"${script_target}\""
+        # Also add a comment line, which will be used as input by the create-python-script-symlinks.sh script
+        # SYMLINK_PREFIX and SYMLINK_FS are defined in common.sh
+        echo "${SYMLINK_PREFIX}${SYMLINK_FS}${script_name}"
+    }  >> "${tmpfile}"
 }
 
 pushd src


### PR DESCRIPTION
An error in the regular expressions used in the `create-python-script-symlinks.sh` script resulted in no symlinks being created for some Python scripts in the virtual environment. Specifically, any scripts whose names contained numbers were omitted.

This PR refactors the build shell scripts to remove the need for that kind of regular expression. Now the script that creates the symlinks does not need to parse and transform the output from the script which updates pyproject.yaml. Instead, that latter script now adds two different types of lines to pyproject.yaml. One is the same as before, to be consumed by Python setuptools when building the package. The second is a comment line which provides exactly the data needed as input for the script that creates the Python symlinks. 

This hopefully reduces the chances of a bug like the one we saw, where the script was registered with the Python module, but no symlink was created.

I have tested this on mug and verified that the missing symlinks are now created.

This PR also adds me and @jacobsalmela to the codeowners file, since we do a lot of work in the repo, and probably should get tagged as PR reviewers.