### PR TITLE
CASMPET-7269: Create Python symlinks with correct names

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -32,5 +32,7 @@
 #shellcheck disable=SC2034
 SYMLINK_PREFIX="#python-script-symlink"
 
+# The field separator needs to be a character that does not have a special meaning for regular expressions
+# (e.g. do not use '|')
 #shellcheck disable=SC2034
-SYMLINK_FS="|"
+SYMLINK_FS=","

--- a/create-python-script-symlinks.sh
+++ b/create-python-script-symlinks.sh
@@ -29,7 +29,7 @@ source ./common.sh
 
 # Usage: create-python-script-symlinks.sh <path to buildroot>
 #                                         <path to Python virtual env>
-#                                         <tests|tools>
+#                                         <test|tool>
 #                                         <target subdir1 in buildroot for symlinks>
 #                                        [<target subdir2 in buildroot for symlinks>] ...
 
@@ -46,7 +46,7 @@ venv_path="$2"
 script_type="$3"
 
 # Sanity check some of the arguments
-[[ ${script_type} == tests || ${script_type} == tools ]] || err_exit "Script type argument must be tests or tools. Invalid: $*"
+[[ ${script_type} == test || ${script_type} == tool ]] || err_exit "Script type argument must be tests or tools. Invalid: $*"
 [[ -n ${buildroot} ]] || err_exit "Build root path may not be blank"
 [[ -d ${buildroot} ]] || err_exit "Build root path does not exist or is not a directory"
 [[ -n ${venv_path} ]] || err_exit "Venv path may not be blank"

--- a/csm-testing.spec
+++ b/csm-testing.spec
@@ -205,10 +205,10 @@ find %{buildroot}%{python_venv_dir} -type d -name __pycache__ -exec rm -rvf {} \
 find %{buildroot}%{python_venv_dir}/bin -type f | xargs -t -i sed -i 's:%{buildroot}%{python_venv_dir}:%{python_venv_dir}:g' {}
 
 # Create symlinks for Python test scripts
-./create-python-script-symlinks.sh %{buildroot} %{python_venv_dir} tests %{livecd}/scripts/python %{ncn}/scripts/python
+./create-python-script-symlinks.sh %{buildroot} %{python_venv_dir} test %{livecd}/scripts/python %{ncn}/scripts/python
 
 # Create symlinks for Python tool scripts
-./create-python-script-symlinks.sh %{buildroot} %{python_venv_dir} tools %{livecd}/automated/python %{ncn}/automated/python
+./create-python-script-symlinks.sh %{buildroot} %{python_venv_dir} tool %{livecd}/automated/python %{ncn}/automated/python
 
 %clean
 rm -rf %{buildroot}%{dat}


### PR DESCRIPTION
My changes in https://github.com/Cray-HPE/csm-testing/pull/624 contained two bugs, which this PR fixes:

1. As part of my changes, the input to the symlink creation script for the type argument should have been `test` or `tool` instead of `tests` or `tools`. The logic inside the script relied on that, but I forgot to make that change.

Normally that would have caused the script to find no symlink lines in the TOML file, and cause the build to fail. But this obviously did not happen, because of:

2. The use of `|` as the field separator for the symlink lines was a poor decision, because of how `grep` interprets it. The result was that the symlink creation script appeared to work fine, because it ended up finding all of the symlink info lines in the TOML file. However, because of bug 1, the links it created had the wrong names.

After making these fixes, I can see on mug that goss-servers starts up fine, and all of the symlinks look good:
```
ncn-m001:/tmp # ls -al /opt/cray/tests/install/ncn/automated/python
total 4
drwxr-xr-x 3 root root  106 Nov  8 15:44 .
drwxr-xr-x 3 root root 4096 Nov  8 15:44 ..
lrwxrwxrwx 1 root root   57 Nov  8 15:41 goss_suite_urls -> ../../../csm-testing-python-venv/bin/tool_goss_suite_urls
lrwxrwxrwx 1 root root   69 Nov  8 15:41 goss_suites_endpoints_ports -> ../../../csm-testing-python-venv/bin/tool_goss_suites_endpoints_ports
lrwxrwxrwx 1 root root   65 Nov  8 15:41 print_goss_json_results -> ../../../csm-testing-python-venv/bin/tool_print_goss_json_results
ncn-m001:/tmp # ls -al /opt/cray/tests/install/livecd/automated/python
total 4
drwxr-xr-x 2 root root   95 Nov  8 15:44 .
drwxr-xr-x 3 root root 4096 Nov  8 15:44 ..
lrwxrwxrwx 1 root root   57 Nov  8 15:41 goss_suite_urls -> ../../../csm-testing-python-venv/bin/tool_goss_suite_urls
lrwxrwxrwx 1 root root   69 Nov  8 15:41 goss_suites_endpoints_ports -> ../../../csm-testing-python-venv/bin/tool_goss_suites_endpoints_ports
lrwxrwxrwx 1 root root   65 Nov  8 15:41 print_goss_json_results -> ../../../csm-testing-python-venv/bin/tool_print_goss_json_results
ncn-m001:/tmp # ls -al /opt/cray/tests/install/ncn/scripts/python
total 2712
drwxr-xr-x 4 root root    4096 Nov  8 15:44 .
drwxr-xr-x 3 root root    4096 Nov  8 15:44 ..
lrwxrwxrwx 1 root root      66 Nov  8 15:41 cfs_state_reporter_check -> ../../../csm-testing-python-venv/bin/test_cfs_state_reporter_check
lrwxrwxrwx 1 root root      65 Nov  8 15:41 check_for_unused_drives -> ../../../csm-testing-python-venv/bin/test_check_for_unused_drives
lrwxrwxrwx 1 root root      62 Nov  8 15:41 check_ncn_uan_ip_dns -> ../../../csm-testing-python-venv/bin/test_check_ncn_uan_ip_dns
lrwxrwxrwx 1 root root      74 Nov  8 15:41 check_remote_mac_against_configs -> ../../../csm-testing-python-venv/bin/test_check_remote_mac_against_configs
lrwxrwxrwx 1 root root      84 Nov  8 15:41 check_remote_resolv_conf_against_data_json -> ../../../csm-testing-python-venv/bin/test_check_remote_resolv_conf_against_data_json
lrwxrwxrwx 1 root root      58 Nov  8 15:41 compare_k8s_ncns -> ../../../csm-testing-python-venv/bin/test_compare_k8s_ncns
lrwxrwxrwx 1 root root      65 Nov  8 15:41 console_verify_services -> ../../../csm-testing-python-venv/bin/test_console_verify_services
lrwxrwxrwx 1 root root      64 Nov  8 15:41 csi_validate_dns_check -> ../../../csm-testing-python-venv/bin/test_csi_validate_dns_check
lrwxrwxrwx 1 root root      79 Nov  8 15:41 data_json_multiple_dns_server_entries -> ../../../csm-testing-python-venv/bin/test_data_json_multiple_dns_server_entries
lrwxrwxrwx 1 root root      56 Nov  8 15:41 data_validator -> ../../../csm-testing-python-venv/bin/test_data_validator
lrwxrwxrwx 1 root root      81 Nov  8 15:41 ims_validate_dependent_images_available -> ../../../csm-testing-python-venv/bin/test_ims_validate_dependent_images_available
lrwxrwxrwx 1 root root      60 Nov  8 15:41 ip_not_in_ip_pools -> ../../../csm-testing-python-venv/bin/test_ip_not_in_ip_pools
lrwxrwxrwx 1 root root      75 Nov  8 15:41 ips_in_dnsmasq_d_in_correct_order -> ../../../csm-testing-python-venv/bin/test_ips_in_dnsmasq_d_in_correct_order
lrwxrwxrwx 1 root root      60 Nov  8 15:41 rgw_endpoint_check -> ../../../csm-testing-python-venv/bin/test_rgw_endpoint_check
ncn-m001:/tmp # ls -al /opt/cray/tests/install/livecd/scripts/python
total 8
drwxr-xr-x 2 root root 4096 Nov  8 15:44 .
drwxr-xr-x 3 root root 4096 Nov  8 15:44 ..
lrwxrwxrwx 1 root root   66 Nov  8 15:41 cfs_state_reporter_check -> ../../../csm-testing-python-venv/bin/test_cfs_state_reporter_check
lrwxrwxrwx 1 root root   65 Nov  8 15:41 check_for_unused_drives -> ../../../csm-testing-python-venv/bin/test_check_for_unused_drives
lrwxrwxrwx 1 root root   62 Nov  8 15:41 check_ncn_uan_ip_dns -> ../../../csm-testing-python-venv/bin/test_check_ncn_uan_ip_dns
lrwxrwxrwx 1 root root   74 Nov  8 15:41 check_remote_mac_against_configs -> ../../../csm-testing-python-venv/bin/test_check_remote_mac_against_configs
lrwxrwxrwx 1 root root   84 Nov  8 15:41 check_remote_resolv_conf_against_data_json -> ../../../csm-testing-python-venv/bin/test_check_remote_resolv_conf_against_data_json
lrwxrwxrwx 1 root root   58 Nov  8 15:41 compare_k8s_ncns -> ../../../csm-testing-python-venv/bin/test_compare_k8s_ncns
lrwxrwxrwx 1 root root   65 Nov  8 15:41 console_verify_services -> ../../../csm-testing-python-venv/bin/test_console_verify_services
lrwxrwxrwx 1 root root   64 Nov  8 15:41 csi_validate_dns_check -> ../../../csm-testing-python-venv/bin/test_csi_validate_dns_check
lrwxrwxrwx 1 root root   79 Nov  8 15:41 data_json_multiple_dns_server_entries -> ../../../csm-testing-python-venv/bin/test_data_json_multiple_dns_server_entries
lrwxrwxrwx 1 root root   56 Nov  8 15:41 data_validator -> ../../../csm-testing-python-venv/bin/test_data_validator
lrwxrwxrwx 1 root root   81 Nov  8 15:41 ims_validate_dependent_images_available -> ../../../csm-testing-python-venv/bin/test_ims_validate_dependent_images_available
lrwxrwxrwx 1 root root   60 Nov  8 15:41 ip_not_in_ip_pools -> ../../../csm-testing-python-venv/bin/test_ip_not_in_ip_pools
lrwxrwxrwx 1 root root   75 Nov  8 15:41 ips_in_dnsmasq_d_in_correct_order -> ../../../csm-testing-python-venv/bin/test_ips_in_dnsmasq_d_in_correct_order
lrwxrwxrwx 1 root root   60 Nov  8 15:41 rgw_endpoint_check -> ../../../csm-testing-python-venv/bin/test_rgw_endpoint_check
ncn-m001:/tmp #
```