### PR TITLE
CASMPET-7270: Remove RPM dependency on requests-retry-session

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -3,4 +3,5 @@ charset-normalizer>=2.0.12,<2.1
 colorama>=0.4.5,<0.5
 idna>=2.6,<2.7
 PyYAML>=6.0.1,<6.1
+requests-retry-session>=0.1,<0.2
 urllib3>=1.26,<1.27

--- a/csm-testing.spec
+++ b/csm-testing.spec
@@ -90,7 +90,6 @@ Requires: python3-botocore
 Requires: python3-kubernetes
 Requires: python3-rados
 Requires: python3-requests
-Requires: python3-requests-retry-session
 
 %else
 
@@ -100,7 +99,6 @@ Requires: python%{python_version_nodots}-botocore
 Requires: python%{python_version_nodots}-kubernetes
 Requires: python%{python_version_nodots}-rados
 Requires: python%{python_version_nodots}-requests
-Requires: python%{python_version_nodots}-requests-retry-session
 
 %endif
 
@@ -281,7 +279,6 @@ Requires: python3-botocore
 Requires: python3-kubernetes
 Requires: python3-rados
 Requires: python3-requests
-Requires: python3-requests-retry-session
 
 %else
 
@@ -290,7 +287,6 @@ Requires: python%{python_version_nodots}-botocore
 Requires: python%{python_version_nodots}-kubernetes
 Requires: python%{python_version_nodots}-rados
 Requires: python%{python_version_nodots}-requests
-Requires: python%{python_version_nodots}-requests-retry-session
 
 %endif
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@
 -c constraints.txt
 colorama
 PyYAML
+requests-retry-session
 
 # There are some additional Python packages that test scripts can rely on that are
 # not listed above. This is because they are listed as requirements in the csm-testing
@@ -33,4 +34,3 @@ PyYAML
 # the system Python install, this is the simplest way.
 
 #system_python:requests
-#system_python:requests-retry-session


### PR DESCRIPTION
The upgrade to CSM 1.6.1 failed because it could not install `csm-testing` in `prerequisites.sh`. The install failure was because a required RPM (for `requests-retry-session`) could not be found. That required RPM is present in the CSM tarball, but the logic used in `prerequisites.sh` assumes that all dependencies are already installed on the node -- it does not handle the case where it has to pull in additional RPMs from the CSM tarball.

Long term we should fix that, but it's slightly tricky, and for this specific issue, it's not a problem just to move the `requests-retry-session` into the `csm-testing` virtual environment. That way the `csm-testing` RPM does not need to be dependent on the `requests-retry-session` RPM, because the content it needs is built into it.

So this PR does exactly that -- installs the `requests-retry-session` Python module into the virtual environment, and remove it as a dependency of the RPM.

I got onto vex (the vshasta system which hit this problem) and verified that these changes allow the RPMs to install (and I also checked and verified that goss-servers started successfully).