### PR TITLE
CASMPET-7271: Remove requests dependencies from virtual environment

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,7 +1,6 @@
-certifi==2024.8.30
-charset-normalizer>=2.0.12,<2.1
 colorama>=0.4.5,<0.5
-idna>=2.6,<2.7
 PyYAML>=6.0.1,<6.1
+# CASMPET-7271: This requests version is specified to match the version in the base NCN images,
+# to avoid version conflicts
+requests==2.25.1
 requests-retry-session>=0.1,<0.2
-urllib3>=1.26,<1.27

--- a/csm-testing.spec
+++ b/csm-testing.spec
@@ -87,18 +87,26 @@ Requires: (python%{python_version_nodots}-base or python3-base >= %{py_version})
 BuildRequires: python3-pip
 Requires: python3-boto3
 Requires: python3-botocore
+Requires: python3-certifi
+Requires: python3-chardet
+Requires: python3-idna
 Requires: python3-kubernetes
 Requires: python3-rados
 Requires: python3-requests
+Requires: python3-urllib3
 
 %else
 
 BuildRequires: python%{python_version_nodots}-pip
 Requires: python%{python_version_nodots}-boto3
 Requires: python%{python_version_nodots}-botocore
+Requires: python%{python_version_nodots}-certifi
+Requires: python%{python_version_nodots}-chardet
+Requires: python%{python_version_nodots}-idna
 Requires: python%{python_version_nodots}-kubernetes
 Requires: python%{python_version_nodots}-rados
 Requires: python%{python_version_nodots}-requests
+Requires: python%{python_version_nodots}-urllib3
 
 %endif
 
@@ -276,17 +284,25 @@ Requires: (python%{python_version_nodots}-base or python3-base >= %{py_version})
 
 Requires: python3-boto3
 Requires: python3-botocore
+Requires: python3-certifi
+Requires: python3-chardet
+Requires: python3-idna
 Requires: python3-kubernetes
 Requires: python3-rados
 Requires: python3-requests
+Requires: python3-urllib3
 
 %else
 
 Requires: python%{python_version_nodots}-boto3
 Requires: python%{python_version_nodots}-botocore
+Requires: python%{python_version_nodots}-certifi
+Requires: python%{python_version_nodots}-chardet
+Requires: python%{python_version_nodots}-idna
 Requires: python%{python_version_nodots}-kubernetes
 Requires: python%{python_version_nodots}-rados
 Requires: python%{python_version_nodots}-requests
+Requires: python%{python_version_nodots}-urllib3
 
 %endif
 

--- a/csm-testing.spec
+++ b/csm-testing.spec
@@ -38,6 +38,14 @@
 %define python_venv_dir %{install_dir}/%{python_venv_name}
 %define python_venv_bin %{python_venv_dir}/bin/python
 
+%if "%{py_version}" == "3.6"
+%define py_rpm_prefix python3
+%else
+%define py_rpm_prefix python%{python_version_nodots}
+%endif
+
+%global csm_testing_requirements %include inc/csm-testing-requirements.spec
+
 Name: %(echo $NAME)
 License: HPE Software License Agreement
 Summary: Goss tests to test out installation set-up
@@ -50,65 +58,13 @@ BuildArchitectures: %(echo $ARCH)
 # Using or statements in spec files requires RPM and rpm-build >= 4.13
 BuildRequires: rpm-build >= 4.13
 BuildRequires: (python%{python_version_nodots}-base or python3-base >= %{py_version})
+BuildRequires: %{py_rpm_prefix}-pip
 BuildRequires: coreutils
 BuildRequires: findutils
 BuildRequires: sed
 
-# Many of these requires are for various commands/tools used in shell scripts
-Requires: awk
-Requires: bash
-Requires: bind-utils
-Requires: coreutils
-Requires: curl
-Requires: diff
-Requires: findutils
-Requires: goss
-Requires: grep
-Requires: hostname
-# yq version 3 is used, which is provided by hpe-yq 4 or 3 <= yq < 4
-Requires: ((hpe-yq >= 4) or ((yq >= 3) and (yq < 4)))
-Requires: ipmitool
-Requires: iproute2
-Requires: jq >= 1.6
-Requires: (kubectl or kubernetes-client-provider)
-Requires: nmap
-Requires: openssh-clients
-Requires: pdsh
-Requires: rpm >= 4.13
-Requires: sed
-Requires: systemd
-Requires: util-linux
-Requires: util-linux-systemd
-
-Requires: (python%{python_version_nodots}-base or python3-base >= %{py_version})
-
-%if "%{py_version}" == "3.6"
-
-BuildRequires: python3-pip
-Requires: python3-boto3
-Requires: python3-botocore
-Requires: python3-certifi
-Requires: python3-chardet
-Requires: python3-idna
-Requires: python3-kubernetes
-Requires: python3-rados
-Requires: python3-requests
-Requires: python3-urllib3
-
-%else
-
-BuildRequires: python%{python_version_nodots}-pip
-Requires: python%{python_version_nodots}-boto3
-Requires: python%{python_version_nodots}-botocore
-Requires: python%{python_version_nodots}-certifi
-Requires: python%{python_version_nodots}-chardet
-Requires: python%{python_version_nodots}-idna
-Requires: python%{python_version_nodots}-kubernetes
-Requires: python%{python_version_nodots}-rados
-Requires: python%{python_version_nodots}-requests
-Requires: python%{python_version_nodots}-urllib3
-
-%endif
+# Pull in the requirements from csm-testing-requirements.spec
+%csm_testing_requirements
 
 %description
 Tests to test the set-up during installation.
@@ -248,6 +204,13 @@ Summary: Goss Health Check Endpoint Service
 BuildArchitectures: %(echo $ARCH)
 BuildRequires: systemd-rpm-macros
 
+# First, specify again the requirements for csm-testing. goss-servers itself does not need all
+# of these, but we do not include csm-testing in our base node images, only goss-servers. We want
+# to make sure these requirements are included in the base node images, so we list them here as well.
+%csm_testing_requirements
+
+# And now list the requirements of goss-servers itself
+
 Requires: awk
 Requires: bash
 Requires: bind-utils
@@ -257,54 +220,6 @@ Requires: grep
 Requires: hostname
 Requires: iproute2
 Requires: systemd
-
-# The rest of these requirements are really for csm-testing, but we do not include csm-testing
-# in our node images, only goss-servers. We want to make sure these requirements are included
-# in the node images, so we list them here as well.
-Requires: curl
-Requires: diff
-Requires: findutils
-# yq version 3 is used, which is provided by hpe-yq 4 or 3 <= yq < 4
-Requires: ((hpe-yq >= 4) or ((yq >= 3) and (yq < 4)))
-Requires: ipmitool
-Requires: iproute2
-Requires: jq >= 1.6
-Requires: (kubectl or kubernetes-client-provider)
-Requires: nmap
-Requires: openssh-clients
-Requires: pdsh
-Requires: rpm >= 4.13
-Requires: sed
-Requires: util-linux
-Requires: util-linux-systemd
-
-Requires: (python%{python_version_nodots}-base or python3-base >= %{py_version})
-
-%if "%{py_version}" == "3.6"
-
-Requires: python3-boto3
-Requires: python3-botocore
-Requires: python3-certifi
-Requires: python3-chardet
-Requires: python3-idna
-Requires: python3-kubernetes
-Requires: python3-rados
-Requires: python3-requests
-Requires: python3-urllib3
-
-%else
-
-Requires: python%{python_version_nodots}-boto3
-Requires: python%{python_version_nodots}-botocore
-Requires: python%{python_version_nodots}-certifi
-Requires: python%{python_version_nodots}-chardet
-Requires: python%{python_version_nodots}-idna
-Requires: python%{python_version_nodots}-kubernetes
-Requires: python%{python_version_nodots}-rados
-Requires: python%{python_version_nodots}-requests
-Requires: python%{python_version_nodots}-urllib3
-
-%endif
 
 # helps when installing a program whose unit files makes use of a feature only available in a newer systemd version
 # If the program is installed on its own, it will have to make do with the available features

--- a/inc/csm-testing-requirements.spec
+++ b/inc/csm-testing-requirements.spec
@@ -1,0 +1,66 @@
+#
+# MIT License
+#
+# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# This is just a list of requirements (but not build requirements) for the csm-testing RPM
+# It is included by the main csm-testing spec file. Any variables/macros used in here are
+# defined in the main spec file
+
+# Many of these requires are for various commands/tools used in shell scripts
+Requires: awk
+Requires: bash
+Requires: bind-utils
+Requires: coreutils
+Requires: curl
+Requires: diff
+Requires: findutils
+Requires: goss
+Requires: grep
+Requires: hostname
+
+# yq version 3 is used, which is provided by hpe-yq 4 or 3 <= yq < 4
+Requires: ((hpe-yq >= 4) or ((yq >= 3) and (yq < 4)))
+
+Requires: ipmitool
+Requires: iproute2
+Requires: jq >= 1.6
+Requires: (kubectl or kubernetes-client-provider)
+Requires: nmap
+Requires: openssh-clients
+Requires: pdsh
+Requires: rpm >= 4.13
+Requires: sed
+Requires: systemd
+Requires: util-linux
+Requires: util-linux-systemd
+
+Requires: (python%{python_version_nodots}-base or python3-base >= %{py_version})
+
+Requires: %{py_rpm_prefix}-boto3
+Requires: %{py_rpm_prefix}-botocore
+Requires: %{py_rpm_prefix}-certifi
+Requires: %{py_rpm_prefix}-chardet
+Requires: %{py_rpm_prefix}-idna
+Requires: %{py_rpm_prefix}-kubernetes
+Requires: %{py_rpm_prefix}-rados
+Requires: %{py_rpm_prefix}-requests
+Requires: %{py_rpm_prefix}-urllib3

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,11 @@ requests-retry-session
 # the system Python install, this is the simplest way.
 
 #system_python:requests
+
+# CASMPET-7271: We also want to use the system version of the requests dependencies,
+# in order to avoid SSL errors or dependency warnings
+
+#system_python:certifi
+#system_python:chardet
+#system_python:idna
+#system_python:urllib3


### PR DESCRIPTION
On the latest vshasta run with the updated csm-testing RPM, it hit hit SSL failures and dependency warnings when trying to use the requests package. I determined that the problem was that even though we were using the system requests package, we also needed to use the system versions of its package dependencies. That will both resolve the dependency warnings and allow it to make requests using the system certificates.

This PR does the above, moving the dependent packages out of the virtual environment and adding them as RPM requirements. I verified that this fixes the problem on vex, and also tested it further on mug, to make sure there were no problems.

This PR also makes the RPM spec file slightly more concise by moving some of the repeated requirements lines into a separate include file. That makes no functional difference, but makes the SPEC file slightly less cluttered.