### PR TITLE
CASMCMS-9199: Add cray-product-catalog Python module to virtual environment

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,5 @@
 colorama>=0.4.5,<0.5
+cray-product-catalog>=2.6,<2.7
 PyYAML>=6.0.1,<6.1
 # CASMPET-7271: This requests version is specified to match the version in the base NCN images,
 # to avoid version conflicts

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 --extra-index-url http://artifactory.algol60.net/artifactory/csm-python-modules/simple
 -c constraints.txt
 colorama
+cray-product-catalog
 PyYAML
 requests-retry-session
 


### PR DESCRIPTION
The IUF team needs this Python module available in the `csm-testing` Python virtual environment. This PR adds it. No changes to tests or automation -- this is just prep work for the incoming IUF development.

I installed this on mug and ran through the NCN/K8S combined suite, just to make sure that nothing unexpected broke.