### PR TITLE
CASMPET-7273: k8s-verify-cluster: Allow etcdbackup pods in states other than Running and Completed

### DIFF
--- a/goss-testing/tests/ncn/goss-k8s-verify-cluster.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-verify-cluster.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2014-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -53,9 +53,14 @@ command:
         meta:
             desc: All Kubernetes kube-system namespace pods are Running or Completed.
             sev: 0
+        # Look for pods that are not Running or Completed
+        # However, we do allow etcdbackup job pods to be in other "normal" lifecycle states
         exec: |-
             "{{$logrun}}" -l "{{$testlabel_2}}" \
-                "{{$kubectl}}" get po -n kube-system --no-headers | grep -Ev 'Running|Completed'
+                "{{$kubectl}}" get po -n kube-system --no-headers \
+                    | awk '{ print $1" "$3 }' \
+                    | grep -Ev ' (Running|Completed)$' \
+                    | grep -Ev '-etcdbackup-.* (ContainerCreating|Init:[0-9]+/[0-9]+|NotReady|Pending|PodInitializing|Terminating)$'
         # We expect no output and for the grep command to return non-0
         stdout:
             - "!/./"


### PR DESCRIPTION
This test fails if it finds any pods in the `kube-system` namespace that are not `Running` or `Completed`. In most cases, this is fine, but if it happens to run while an `etcdbackup` job pod is starting up or terminating, then it may catch that pod in states like `ContainerCreating` or `Terminating`. Basically, there are non-error states that those pods may be found in. This PR updates the test so that when checking the `kube-system` namespace, it fails if:
1. Any non-`etcdbackup` pod is in a state other than `Running` or `Completed`
2. Any `etcdbackup` pod is in a state other than `Running`, `Completed`, `ContainerCreating`, `Init:#/#`, `NotReady`, `Pending`, `PodInitializing`, or `Terminating`.

This will avoid the false failure that Mikhail reported when opening this ticket.

I have tested this on mug and ran the test repeatedly, verifying that it now correctly handles the case where an `etcdbackup` pod is in one of the other valid states.