### PR TITLE
CASMPET-7104: Check for running pods in kyverno namespace with app.kubernetes.io/component label kyverno

### DIFF
--- a/goss-testing/scripts/k8s_kyverno_pods_running.sh
+++ b/goss-testing/scripts/k8s_kyverno_pods_running.sh
@@ -41,13 +41,13 @@ done
 
 # Checks if all kyverno pods are running. There should be a total of 3 running pods.
 
-running_pods=$(kubectl get pods -n kyverno -o json | jq '[.items[] | select(.metadata.labels.app == "kyverno").status.containerStatuses[0].state.running] | length')
+running_pods=$(kubectl get pods -n kyverno --field-selector=status.phase=Running -l "app.kubernetes.io/component=kyverno" --no-headers | wc -l)
 rc=$?
 if [[ ${rc} -ne 0 ]]
 then
     # Split into two echo commands for code readability
     echo -n "ERROR: Command pipeline failed (return code $rc): " 1>&2
-    echo "kubectl get pods -n kyverno -o json | jq '[.items[] | select(.metadata.labels.app == \"kyverno\").status.containerStatuses[0].state.running] | length'" 1>&2
+    echo "kubectl get pods -n kyverno --field-selector=status.phase=Running -l \"app.kubernetes.io/component=kyverno\" --no-headers | wc -l" 1>&2
     echo "FAIL"
     exit 10
 elif [[ ${running_pods} != 3 ]]


### PR DESCRIPTION
## Summary and Scope
Fixes CASMPET-7104
In CSM 1.5, the kyverno pods have different labels than in CSM 1.4 causing the `k8s_kyverno_pods_running.sh` goss test to FAIL even though 3 kyverno pods are in `Running` status.  The jq statement in the script selects on a pod label.  The pod label `app` is no longer used in CSM 1.5.  The script was modified to use the label `app.kubernetes.io/component` instead, which does exist in CSM 1.5.  Selecting `Running` pods and label using `kubectl` statement options rather than using `jq`.

## Issues and Related PRs
* Resolves [CASMPET-7104](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7104) for CSM 1.5
* A different change will be needed in `release/1.6` since kyverno in CSM 1.6 has more pods with different component names.

## Testing
Tested on groot which is running CSM 1.5

### Test description:
Changes were verified by executing script on groot.

```bash
ncn-m001:~ # kubectl get pods -n kyverno --field-selector=status.phase=Running -l "app.kubernetes.io/component=kyverno" --no-headers
cray-kyverno-55bd6df486-8srzs   1/1   Running   0     58d
cray-kyverno-55bd6df486-k7shz   1/1   Running   0     58d
cray-kyverno-55bd6df486-s9gmd   1/1   Running   0     58d
ncn-m001:~ # ./k8s_kyverno_pods_running.sh -p
PASS
ncn-m001:~ #
```

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

