### PR TITLE
CASMPET-7104: Loop through label list and check that expected number of pods are in running status

### DIFF
--- a/goss-testing/scripts/k8s_kyverno_pods_running.sh
+++ b/goss-testing/scripts/k8s_kyverno_pods_running.sh
@@ -39,28 +39,59 @@ do
     esac
 done
 
-# Checks if all kyverno pods are running. There should be a total of 3 running pods.
+# Checks if all expected kyverno pods are running.
+# Component label and number of pods in running status should be:
+#   admission-controller: 3
+#   background-controller: 1
+#   cleanup-controller: 1
+#   reports-controller: 1
 
-running_pods=$(kubectl get pods -n kyverno -o json | jq '[.items[] | select(.metadata.labels.app == "kyverno").status.containerStatuses[0].state.running] | length')
-rc=$?
-if [[ ${rc} -ne 0 ]]
-then
-    # Split into two echo commands for code readability
-    echo -n "ERROR: Command pipeline failed (return code $rc): " 1>&2
-    echo "kubectl get pods -n kyverno -o json | jq '[.items[] | select(.metadata.labels.app == \"kyverno\").status.containerStatuses[0].state.running] | length'" 1>&2
-    echo "FAIL"
-    exit 10
-elif [[ ${running_pods} != 3 ]]
-then
+check_running() {
+    pod_label=$1
+    pod_count=$2
+    running_pods=$(kubectl get pods -n kyverno --field-selector=status.phase=Running -l "app.kubernetes.io/component=${pod_label}" --no-headers | wc -l)
+    rc=$?
+    if [[ ${rc} -ne 0 ]]
+    then
+        # Split into two echo commands for code readability
+        echo -n "ERROR: Command pipeline failed (return code $rc): " 1>&2
+        echo "kubectl get pods -n kyverno --field-selector=status.phase=Running -l "app.kubernetes.io/component=${pod_label}" --no-headers | wc -l" 1>&2
+        echo "FAIL"
+        exit 10
+    elif [[ ${running_pods} != ${pod_count} ]]
+    then
+        if [[ ${print_results} -eq 1 ]]
+        then
+            echo "ERROR: ${running_pods} out of ${pod_count} ${pod_label} pods are running."
+            if [[ "${pod_label}" == "admission-controller" ]]
+            then
+                echo "For high availability the recommended Kyverno ${pod_label} replica count is ${pod_count}."
+                echo "Check the logs, restart Kyverno, and ensure that all ${pod_count} Kyverno ${pod_label} pods are running."
+            fi
+        fi
+        echo "FAIL"
+        exit 1
+    fi
+
     if [[ ${print_results} -eq 1 ]]
     then
-        echo "ERROR: ${running_pods} out of 3 pods are running."
-        echo "For high availability the recommended Kyverno pod replica count is 3."
-        echo "Check the logs, restart Kyverno, and ensure that all 3 Kyverno pods are running."
+        echo "${pod_label} has ${running_pods} of ${pod_count} pods running."
     fi
-    echo "FAIL"
-    exit 1
-fi
+}
+
+# Loop through list of pod labels and expected pod count
+pod_labels="admission-controller background-controller cleanup-controller reports-controller"
+
+for pod in $pod_labels
+do
+    num_pods=1
+    if [[ "${pod}" == "admission-controller" ]]
+    then
+        num_pods=3
+    fi
+
+    check_running ${pod} ${num_pods}
+done
 
 echo "PASS"
 exit 0

--- a/goss-testing/scripts/k8s_kyverno_pods_running.sh
+++ b/goss-testing/scripts/k8s_kyverno_pods_running.sh
@@ -39,28 +39,59 @@ do
     esac
 done
 
-# Checks if all kyverno pods are running. There should be a total of 3 running pods.
+# Checks if all expected kyverno pods are running.
+# Component label and number of pods in running status should be:
+#   admission-controller: 3
+#   background-controller: 1
+#   cleanup-controller: 1
+#   reports-controller: 1
 
-running_pods=$(kubectl get pods -n kyverno -o json | jq '[.items[] | select(.metadata.labels.app == "kyverno").status.containerStatuses[0].state.running] | length')
-rc=$?
-if [[ ${rc} -ne 0 ]]
-then
-    # Split into two echo commands for code readability
-    echo -n "ERROR: Command pipeline failed (return code $rc): " 1>&2
-    echo "kubectl get pods -n kyverno -o json | jq '[.items[] | select(.metadata.labels.app == \"kyverno\").status.containerStatuses[0].state.running] | length'" 1>&2
-    echo "FAIL"
-    exit 10
-elif [[ ${running_pods} != 3 ]]
-then
+check_running() {
+    pod_label=$1
+    pod_count=$2
+    running_pods=$(kubectl get pods -n kyverno --field-selector=status.phase=Running -l "app.kubernetes.io/component=${pod_label}" --no-headers | wc -l)
+    rc=$?
+    if [[ ${rc} -ne 0 ]]
+    then
+        # Split into two echo commands for code readability
+        echo -n "ERROR: Command pipeline failed (return code $rc): " 1>&2
+        echo "kubectl get pods -n kyverno --field-selector=status.phase=Running -l "app.kubernetes.io/component=${pod_label}" --no-headers | wc -l" 1>&2
+        echo "FAIL"
+        exit 10
+    elif [[ ${running_pods} != ${pod_count} ]]
+    then
+        if [[ ${print_results} -eq 1 ]]
+        then
+            echo "ERROR: ${running_pods} out of ${pod_count} ${pod_label} pods are running."
+            if [[ ${pod_label} -eq "admission-controller" ]]
+            then
+                echo "For high availability the recommended Kyverno ${pod_label} replica count is ${pod_count}."
+                echo "Check the logs, restart Kyverno, and ensure that all ${pod_count} Kyverno ${pod_label} pods are running."
+            fi
+        fi
+        echo "FAIL"
+        exit 1
+    fi
+
     if [[ ${print_results} -eq 1 ]]
     then
-        echo "ERROR: ${running_pods} out of 3 pods are running."
-        echo "For high availability the recommended Kyverno pod replica count is 3."
-        echo "Check the logs, restart Kyverno, and ensure that all 3 Kyverno pods are running."
+        echo "${pod_label} has ${running_pods} of ${pod_count} pods running."
     fi
-    echo "FAIL"
-    exit 1
-fi
+}
+
+# Loop through list of pod labels and expected pod count
+pod_labels="admission-controller background-controller cleanup-controller reports-controller"
+
+for pod in $pod_labels
+do
+    num_pods=1
+    if [[ "${pod}" == "admission-controller" ]]
+    then
+        num_pods=3
+    fi
+
+    check_running ${pod} ${num_pods}
+done
 
 echo "PASS"
 exit 0


### PR DESCRIPTION
## Summary and Scope
For CSM 1.6, there are more kyverno pods running in the kyverno namespace than in CSM 1.5.  Loop through the list of kyverno component labels and verify that the expected number of pods are in `Running` status.

## Issues and Related PRs
* Resolves [CASMPET-7104](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7104)

## Testing
### Tested on:

  * `beau` vShasta system
  
### Test description:
Executed script with and without `-p` option.
```bash
pit:~ # ./k8s_kyverno_pods_running_16.sh -p
admission-controller has 3 of 3 pods running.
background-controller has 1 of 1 pods running.
cleanup-controller has 1 of 1 pods running.
reports-controller has 1 of 1 pods running.
PASS
pit:~ # ./k8s_kyverno_pods_running_16.sh
PASS
pit:~ #
```

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

