### PR TITLE
Linting based on pylint report; add minimum pylint code quality gate

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -93,6 +93,8 @@ pipeline {
             }
             environment {
                 PY_BIN_PATH = getPythonBinaryPath(PY_VERSION)
+                // If pylint rates the code lower than this, the build will fail
+                MIN_PYLINT_RATING = 8.6
             }
             steps {
                 sh "make pylint"

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ BUILD_DIR ?= $(PWD)/dist/rpmbuild
 SOURCE_PATH := ${BUILD_DIR}/SOURCES/${SOURCE_NAME}.tar.bz2
 PYLINT_VENV_DIR := pylint-venv
 PYLINT_VENV_PYBIN := $(PYLINT_VENV_DIR)/bin/python3
+MIN_PYLINT_RATING ?= 8.6
 
 rpm: rpm_package_source rpm_build_source rpm_build
 
@@ -71,7 +72,7 @@ pylint:
 	$(PYLINT_VENV_PYBIN) -m pip install --disable-pip-version-check --no-cache -r pylint-requirements.txt pylint csm_testing*.whl
 	$(PYLINT_VENV_PYBIN) -m pip list --format freeze
 	$(PYLINT_VENV_PYBIN) -m pylint --errors-only csm_testing
-	$(PYLINT_VENV_PYBIN) -m pylint --fail-under 9 csm_testing || true
+	$(PYLINT_VENV_PYBIN) -m pylint --fail-under $(MIN_PYLINT_RATING) csm_testing
 
 prepare:
 	@echo $(NAME)

--- a/src/csm_testing/tests/check_ncn_uan_ip_dns/__main__.py
+++ b/src/csm_testing/tests/check_ncn_uan_ip_dns/__main__.py
@@ -22,15 +22,16 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 import base64
-import subprocess
 import json
-import sys
 import logging
+import subprocess
+import sys
+from urllib.parse import urljoin
+
+from kubernetes import client, config
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
-from urllib.parse import urljoin
-from kubernetes import client, config
 
 
 class APIRequest:
@@ -170,22 +171,24 @@ def main():  # pylint: disable=missing-function-docstring
     ip_set = set()
     for smd_entry in smd_ethernet_interfaces:
         # print (smd_entry)
-        if smd_entry['IPAddresses'] != '[]':
-            ip_addresses = smd_entry['IPAddresses']
-            for ips in ip_addresses:
-                ip = ips['IPAddress']
-                # print (ip)
-                if ip != '':
-                    if ip in ip_set:
-                        log.error('Error: found duplicate IP: %s', ip)
-                        error_found = True
-                        nslookup_cmd = subprocess.Popen(('nslookup', ip),
-                                                        stdout=subprocess.PIPE,
-                                                        stderr=subprocess.PIPE)
-                        output, _ = nslookup_cmd.communicate()
-                        print(output.decode('ascii'))
-                    else:
-                        ip_set.add(ip)
+        if smd_entry['IPAddresses'] == '[]':
+            continue
+        ip_addresses = smd_entry['IPAddresses']
+        for ips in ip_addresses:
+            ip = ips['IPAddress']
+            # print (ip)
+            if ip == '':
+                continue
+            if ip not in ip_set:
+                ip_set.add(ip)
+                continue
+            log.error('Error: found duplicate IP: %s', ip)
+            error_found = True
+            nslookup_cmd = subprocess.Popen(('nslookup', ip),
+                                            stdout=subprocess.PIPE,
+                                            stderr=subprocess.PIPE)
+            output, _ = nslookup_cmd.communicate()
+            print(output.decode('ascii'))
 
     hostname_list = []
 
@@ -197,18 +200,18 @@ def main():  # pylint: disable=missing-function-docstring
         if hardware['ExtraProperties']['Role'] in {
                 'Application', 'Management'
         }:
-            hostname_list.append(hardware['ExtraProperties']['Aliases'][0] +
-                                 '.nmn')
-            hostname_list.append(hardware['ExtraProperties']['Aliases'][0] +
-                                 '.can')
-            hostname_list.append(hardware['ExtraProperties']['Aliases'][0] +
-                                 '.hmn')
-            hostname_list.append(hardware['ExtraProperties']['Aliases'][0] +
-                                 '-mgmt')
-            hostname_list.append(hardware['ExtraProperties']['Aliases'][0] +
-                                 '.cmn')
-            hostname_list.append(hardware['ExtraProperties']['Aliases'][0] +
-                                 '.chn')
+            hostname_list.append(
+                f"{hardware['ExtraProperties']['Aliases'][0]}.nmn")
+            hostname_list.append(
+                f"{hardware['ExtraProperties']['Aliases'][0]}.can")
+            hostname_list.append(
+                f"{hardware['ExtraProperties']['Aliases'][0]}.hmn")
+            hostname_list.append(
+                f"{hardware['ExtraProperties']['Aliases'][0]}-mgmt")
+            hostname_list.append(
+                f"{hardware['ExtraProperties']['Aliases'][0]}.cmn")
+            hostname_list.append(
+                f"{hardware['ExtraProperties']['Aliases'][0]}.chn")
 
     for hostname in hostname_list:
 
@@ -222,15 +225,14 @@ def main():  # pylint: disable=missing-function-docstring
             nslookup_cmd = subprocess.Popen(('nslookup', hostname),
                                             stdout=subprocess.PIPE,
                                             stderr=subprocess.PIPE)
-            output, errors = nslookup_cmd.communicate()
+            output, _ = nslookup_cmd.communicate()
             print(f"{output.decode('ascii')}")
 
     if error_found:
         log.error('ERRORS: see above output.')
         sys.exit(1)
-    else:
-        log.debug('No errors found.')
-        sys.exit(0)
+    log.debug('No errors found.')
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/src/csm_testing/tests/compare_k8s_ncns/__main__.py
+++ b/src/csm_testing/tests/compare_k8s_ncns/__main__.py
@@ -27,13 +27,35 @@ all workers have the same kernel version, and all Kubernetes NCNs have the
 same values for several other fields (enumerated below in KubernetesNodeInfoFields)
 """
 
-import kubernetes
 import sys
+from typing import Any, Dict, List, NamedTuple, Tuple
+
+import kubernetes
 
 KubernetesNodeInfoFields = [
     "container_runtime_version", "kube_proxy_version", "kubelet_version",
     "os_image"
 ]
+
+# For type checking
+
+# map from kernel version to list of NCN names with that version
+NcnKernelVersionMapType = Dict[str, List[str]]
+
+# map from node info field name to:
+#     map from values for that field to list of NCN names with that value
+NcnNodeInfoValuesMap = Dict[str, Dict[Any, List[str]]]
+
+
+class K8sNodeInfo(NamedTuple):
+    """
+    Information about the Kubernetes nodes on the system
+    """
+    master_kernel_version: NcnKernelVersionMapType
+    worker_kernel_version: NcnKernelVersionMapType
+    node_info_values: NcnNodeInfoValuesMap
+    num_workers: int
+    num_masters: int
 
 
 def print_err(msg: str) -> None:
@@ -43,13 +65,18 @@ def print_err(msg: str) -> None:
     sys.stderr.write(f"ERROR: {msg}\n")
 
 
-def main() -> None:  # pylint: disable=missing-function-docstring
+def get_k8s_ncn_info() -> Tuple[K8sNodeInfo, bool]:
+    """
+    List all Kubernetes nodes and return information about them, as well as a boolean indicating
+    pass/fail, in case problems were found during the checking
+    """
+
     print("Loading Kubernetes configuration")
     kubernetes.config.load_kube_config()
     print("Initializing Kubernetes client")
-    v1 = kubernetes.client.CoreV1Api()
+    k8s_v1 = kubernetes.client.CoreV1Api()
     print("Listing Kubernetes nodes")
-    node_list = v1.list_node()
+    node_list = k8s_v1.list_node()
 
     passed = True
 
@@ -124,6 +151,24 @@ def main() -> None:  # pylint: disable=missing-function-docstring
                     f"Unable to find {field} field in node_info for {ncn_name}"
                 )
                 passed = False
+    return K8sNodeInfo(master_kernel_version=master_kernel_version,
+                       worker_kernel_version=worker_kernel_version,
+                       node_info_values=node_info_values,
+                       num_workers=num_workers,
+                       num_masters=num_masters), passed
+
+
+def check_k8s_node_info(k8s_node_info: K8sNodeInfo) -> bool:
+    """
+    Does a validation of the Kubernetes node information that was collected.
+    Returns a boolean, with True indicating no problems found, and False otherwise.
+    """
+    passed = True
+    num_masters = k8s_node_info.num_masters
+    num_workers = k8s_node_info.num_workers
+    worker_kernel_version = k8s_node_info.worker_kernel_version
+    master_kernel_version = k8s_node_info.master_kernel_version
+    node_info_values = k8s_node_info.node_info_values
 
     # The purpose of this test is not to make sure the number of NCNs found is correct. However,
     # because at least 2 masters and 2 workers are needed in order to do any value comparisons,
@@ -165,6 +210,12 @@ def main() -> None:  # pylint: disable=missing-function-docstring
             print_err(f"Not all Kubernetes NCNs have the same {field}")
             print(f"{node_info_values[field]}\n")
             passed = False
+
+
+def main() -> None:  # pylint: disable=missing-function-docstring
+    k8s_node_info, passed = get_k8s_ncn_info()
+    if not check_k8s_node_info(k8s_node_info):
+        passed = False
 
     if passed:
         print("PASSED")

--- a/src/csm_testing/tests/data_json_multiple_dns_server_entries/__main__.py
+++ b/src/csm_testing/tests/data_json_multiple_dns_server_entries/__main__.py
@@ -21,21 +21,25 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+"""
+Parses data.json and prints the number of dns-server entries found in the global meta-data
+"""
+
 import logging
 import sys
 import csm_testing.lib.data_json_parser as dp
 
-logging.basicConfig(filename='/tmp/data_json_dns_server_test.log',
-                    level=logging.DEBUG)
-logging.info("Starting up")
-
 
 def main() -> int:  # pylint: disable=missing-function-docstring
+    logging.basicConfig(filename='/tmp/data_json_dns_server_test.log',
+                        level=logging.DEBUG)
+    logging.info("Starting up")
+
     # Goss sends [.Args.datajson] as string with the brackets
     filename = sys.argv[1].strip('[').strip(']')
     logging.debug("Using file: %s", filename)
-    dj = dp.dataJson(filename)
-    glbal = dj.payload['Global']['meta-data']
+    data_json = dp.dataJson(filename)
+    glbal = data_json.payload['Global']['meta-data']
 
     count = 0
     for k in glbal:

--- a/src/csm_testing/tests/ips_in_dnsmasq_d_in_correct_order/__main__.py
+++ b/src/csm_testing/tests/ips_in_dnsmasq_d_in_correct_order/__main__.py
@@ -21,11 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-import ipaddress
-import sys
-import logging
-import datetime
-'''
+"""
 Simple script to ensure that the dhcp-range in the /etc/dnsmasq.d/{net}.conf files
   are in the correct order. This error was encountered on surtur and caused problems
 The location of the files is already known, as well as the file names. If that changes
@@ -37,55 +33,59 @@ Note: It's possible to get the filenames from GOSS variables, so if the names ch
 
 USAGE: pyTest-dhcp-reange-in-dnsmasq_d-in-correct-order.py
 Goss will search the output for the word FAIL
+"""
 
-'''
-
-
-def now():
-    # convenience function because it'll be used for logging
-    return str(datetime.datetime.now())
-
+import ipaddress
+import sys
+import logging
+import datetime
 
 # In case we want to make this script more user-friendly and add argparse or configparser
 # CRITICAL 50, ERROR 40, WARNING 30, INFO 20, DEBUG 10, NOTSET 0
-l_lvl = logging.INFO
-# Start the logger
-logging.basicConfig(filename='/tmp/' + sys.argv[0].split('/')[-1] + '.log',
-                    level=l_lvl)
-logging.info(now() + " Starting up")
+L_LVL = logging.INFO
+
+
+def now() -> str:
+    """Convenience function because it'll be used for logging"""
+    return str(datetime.datetime.now())
 
 
 def main() -> int:  # pylint: disable=missing-function-docstring
+    # Start the logger
+    logging.basicConfig(filename='/tmp/' + sys.argv[0].split('/')[-1] + '.log',
+                        level=L_LVL)
+    logging.info("%s Starting up", now())
+
     fileDir = "/etc/dnsmasq.d/"
     fileNames = ['CAN', 'NMN', 'HMN', 'mtl']
-    contents = []
+    #contents = []
 
     # Iterate over the list of filenames and try to open the file
     for fileName in fileNames:
         # clear the start and end strings
-        logging.info(now() + " Checking %s.", fileDir + fileName)
+        logging.info("%s Checking %s%s.", now(), fileDir, fileName)
         start = end = ''
         try:
-            f = open(fileDir + fileName + ".conf", 'r')
-            #contents = f.read().split('\n')
-        except:
-            logging.critical(now() + " Couldn't open %s.",
-                             fileDir + fileName + '.conf')
+            with open(fileDir + fileName + ".conf", 'r') as f:
+                #contents = f.read().split('\n')
+                file_lines = f.readlines()
+        except Exception:
+            logging.critical("%s Couldn't open %s%s.conf.", now(), fileDir,
+                             fileName)
             print("Unable to open file: " + fileName + ".conf")
             return 1
 
         # if the contents of the file !NULL - read the file line-by-line
         # and check if the line contains 'dhcp-range'
         # it's a really good bet that the format of that line will not change
-        line = f.readline()
-        while line:
-            logging.debug(now() + " line from %s: %s", fileName, line.strip())
+
+        for line in file_lines:
+            logging.debug("%s line from %s: %s", now(), fileName, line.strip())
             # If the line continas 'dhcp-range' extract the start and end addresses
             if 'dhcp-range' in line:
                 start = line.split(',')[1]
                 end = line.split(',')[2]
                 logging.debug("Start IP = %s, End IP = %s.", start, end)
-            line = f.readline()
 
         # If we found the start IP, ensure that it is less than the end IP
         if start:
@@ -95,9 +95,8 @@ def main() -> int:  # pylint: disable=missing-function-docstring
                 end_ip = ipaddress.ip_address(end)
             except:
                 logging.critical(
-                    now() +
-                    " Could not convert either start = %s or end = %s to IP addresses.",
-                    start, end)
+                    "%s Could not convert either start = %s or end = %s to IP addresses.",
+                    now(), start, end)
                 print("FAIL: Conversion of strings to IP addresses failed")
                 return 2
 
@@ -105,8 +104,8 @@ def main() -> int:  # pylint: disable=missing-function-docstring
                 print("PASS")
                 return 0
             logging.error(
-                now() + " The file %s failed. Start IP (%s) >= End IP (%s).",
-                fileDir + fileName + ".conf", start, end)
+                "%s The file %s%s.conf failed. Start IP (%s) >= End IP (%s).",
+                now(), fileDir, fileName, start, end)
             print("FAIL for file:" + fileDir + fileName + ".conf")
             return 3
         print("FAIL - no starting IP address found")


### PR DESCRIPTION
More basic linting based on the pylint report.

Also, this modifies the build pipeline so that pylint can cause the build to fail if the code quality is below a specified value. Currently, this PR sets that value to be equal to what our current Python code quality is. In other words, this means that we won't let any PRs in that reduces our code quality further. We can gradually bump this up as we continue the linting. This will help ensure that we aren't fighting a losing battle, by making sure new code doesn't enter the repo if it has quality issues.