### PR TITLE
CASMTRIAGE-7569: Add unused drives test to upgrade suite and add notes about running tests

### DIFF
--- a/goss-testing/suites/ncn-storage-tests.yaml
+++ b/goss-testing/suites/ncn-storage-tests.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/goss-testing/suites/ncn-storage-tests.yaml
+++ b/goss-testing/suites/ncn-storage-tests.yaml
@@ -24,6 +24,7 @@
 
 #
 # This suite is run during CSM installs before CSM services have been deployed
+# Note: This suite is only executed from the PIT node.
 #
 
 # Use hostname from variable file, if set.

--- a/goss-testing/suites/ncn-upgrade-tests-storage.yaml
+++ b/goss-testing/suites/ncn-upgrade-tests-storage.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/goss-testing/suites/ncn-upgrade-tests-storage.yaml
+++ b/goss-testing/suites/ncn-upgrade-tests-storage.yaml
@@ -28,3 +28,4 @@ gossfile:
   ../tests/goss-ceph-storage-config-files.yaml: {}
   ../tests/goss-check-clock-skew.yaml: {}
   ../tests/goss-rgw-health.yaml: {}
+  ../tests/goss-unused-drives-on-storage-nods.yaml: {}

--- a/goss-testing/suites/ncn-upgrade-tests-storage.yaml
+++ b/goss-testing/suites/ncn-upgrade-tests-storage.yaml
@@ -28,4 +28,4 @@ gossfile:
   ../tests/goss-ceph-storage-config-files.yaml: {}
   ../tests/goss-check-clock-skew.yaml: {}
   ../tests/goss-rgw-health.yaml: {}
-  ../tests/goss-unused-drives-on-storage-nods.yaml: {}
+  ../tests/goss-unused-drives-on-storage-nodes.yaml: {}

--- a/goss-testing/suites/ncn-upgrade-tests-storage.yaml
+++ b/goss-testing/suites/ncn-upgrade-tests-storage.yaml
@@ -22,9 +22,10 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-# Note: The tests in this suite must be run using the `run_goss_tests` helper
-# function defined in `csm-testing/goss-testing/automated/run-ncn-tests.sh`.
-# This is required due to a temporary values file generated in the function
+# Note: The tests in this suite must be run using an automated script
+# that uses the `run_goss_tests` helper function.
+# This suite can be run by executing `/opt/cray/tests/install/ncn/automated/ncn-upgrade-tests-storage`.
+# This is required due to a temporary values file generated in the `run_goss_tests` function.
 # that will allow the tests to identify storage nodes.
 
 gossfile:

--- a/goss-testing/suites/ncn-upgrade-tests-storage.yaml
+++ b/goss-testing/suites/ncn-upgrade-tests-storage.yaml
@@ -21,6 +21,12 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+
+# Note: The tests in this suite must be run using the `run_goss_tests` helper
+# function defined in `csm-testing/goss-testing/automated/run-ncn-tests.sh`.
+# This is required due to a temporary values file generated in the function
+# that will allow the tests to identify storage nodes.
+
 gossfile:
   ../tests/goss-check-static-routes.yaml: {}
   ../tests/goss-ceph-storage-health.yaml: {}


### PR DESCRIPTION
## Summary and Scope
This pull request enhances NCN storage testing by adding a new test, `goss-unused-drives-on-storage-nodes`, to the `ncn-upgrade-tests-storage` suite. This ensures unused drives are properly identified during system upgrades. Additionally, the documentation is updated to clarify that ncn-storage-tests are executed exclusively on the pit node. To accommodate the new test, the `run_goss_tests` helper function is utilized, which leverages a different variables file to provide information about available storage nodes.

## Issues and Related PRs

* Related to https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7569
* Related [docs change](https://github.com/Cray-HPE/docs-csm/pull/5597)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Tested this by first running the tests of the old form on vShasta to observe the behavior and then loaded the RPM including this additional test and observed the behavior from that test. This change showed 14 total tests with this RPM and 13 total tests without this RPM, indicating that the additional test was run.

## Risks and Mitigations

There are no known issues with these changes.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable

