### PR TITLE
Revert changes from CASMTRIAGE-7569

### DIFF
--- a/goss-testing/suites/ncn-upgrade-tests-storage.yaml
+++ b/goss-testing/suites/ncn-upgrade-tests-storage.yaml
@@ -22,12 +22,6 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-# Note: The tests in this suite must be run using an automated script
-# that uses the `run_goss_tests` helper function.
-# This suite can be run by executing `/opt/cray/tests/install/ncn/automated/ncn-upgrade-tests-storage`.
-# This is required due to a temporary values file generated in the `run_goss_tests` function.
-# that will allow the tests to identify storage nodes.
-
 gossfile:
   ../tests/goss-check-static-routes.yaml: {}
   ../tests/goss-ceph-storage-health.yaml: {}
@@ -35,4 +29,3 @@ gossfile:
   ../tests/goss-ceph-storage-config-files.yaml: {}
   ../tests/goss-check-clock-skew.yaml: {}
   ../tests/goss-rgw-health.yaml: {}
-  ../tests/goss-unused-drives-on-storage-nodes.yaml: {}


### PR DESCRIPTION
## Summary and Scope

This PR reverts the changes made in https://github.com/Cray-HPE/csm-testing/pull/647. The decision was made to hold back this change until the 1.7 release, since it would have caused testing difficulties that outweighed the advantages of including this in 1.6.1.

## Issues and Related PRs

* Related to https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7569
* Future work tracked in https://jira-pro.it.hpe.com:8443/browse/CASMPET-7308
* PR that is being undone: https://github.com/Cray-HPE/csm-testing/pull/647

## Testing

As this is reverting to a previous state, there was no additional testing done on this PR.


## Risks and Mitigations

Need to make sure to properly update branches and remove the RPM from Artifactory so that it doesn't muddy the waters.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

