### PR TITLE
CASMINST-7108 Simplify filename pattern override for license checker

### DIFF
--- a/.license_check.yaml
+++ b/.license_check.yaml
@@ -23,12 +23,14 @@
 #
 
 # Define custom types for our script files which should have licenses
-# but do not match a default pattern. Use yaml for .spec and .service
+# but do not match a default pattern. Use yaml for .spec, .service and .preset
 # files -- they are not in YAML, but as far as license checking is
 # concerned, they can be considered the same.
 
 file_types:
   "*.service":
+    type: yaml
+  "*.preset":
     type: yaml
   "*.spec":
     type: yaml
@@ -36,5 +38,3 @@ file_types:
     type: shell_or_python
   "build-testing/*":
     type: shell_or_python
-
-

--- a/.license_check.yaml
+++ b/.license_check.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022,2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -28,51 +28,13 @@
 # concerned, they can be considered the same.
 
 file_types:
-  - pattern: "*.service"
+  "*.service":
     type: yaml
-  - pattern: "*.spec"
+  "*.spec":
     type: yaml
-  - pattern: "*.sh"
+  "goss-testing/automated/*":
     type: shell_or_python
-  - pattern: "*.bash"
-    type: shell_or_python
-  - pattern: "*.py"
-    type: shell_or_python
-  - pattern: "Dockerfile*"
-    type: docker
-  - pattern: "*/Dockerfile*"
-    type: docker
-  - pattern: "*.java"
-    type: java
-  - pattern: "*.groovy"
-    type: java
-  - pattern: "*.css"
-    type: java
-  - pattern: "*.js"
-    type: java
-  - pattern: "Jenkinsfile*"
-    type: java
-  - pattern: "*.go"
-    type: go
-  - pattern: "*.xml"
-    type: xml
-  - pattern: "*.html"
-    type: html
-  - pattern: "*/templates/*.yaml"
-    type: go_template
-  - pattern: "*.yaml"
-    type: yaml
-  - pattern: "*.yml"
-    type: yaml
-  - pattern: LICENSE
-    type: plain
-  - pattern: "Makefile*"
-    type: docker
-  - pattern: "*/Makefile*"
-    type: docker
-  - pattern: "goss-testing/automated/*"
-    type: shell_or_python
-  - pattern: "build-testing/*"
+  "build-testing/*":
     type: shell_or_python
 
 


### PR DESCRIPTION
## Summary and Scope

New version of license checker supports filename pattern config as `<pattern> => {type: <type}` map. Change is backwards compatible, old config format is also recognized by license checker. However, new format allows overriding for individual entries, instead of replicating full list. 

## Issues and Related PRs

* Resolves [CASMINST-7108](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7108)

## Testing
### Tested on:

  * Local development environment

### Test description:
    
    # test pattern defined in override
    $ docker run -it --rm -v $(pwd):/github/workspace artifactory.algol60.net/csm-docker/stable/license-checker --log-level=debug csm-testing.spec | grep matched
    [DEBUG] Matching csm-testing.spec against *.spec to determine file type .... matched!
    
    # test pattern defined in base config
    $ docker run -it --rm -v $(pwd):/github/workspace artifactory.algol60.net/csm-docker/stable/license-checker --log-level=debug goss-testing/scripts/ceph-service-status.sh | grep matched
    [DEBUG] Matching goss-testing/scripts/ceph-service-status.sh against *.sh to determine file type .... matched!

## Risks and Mitigations

Low - build time check only.

