### PR TITLE
CASMINST-7114: Correct syntax error with lru_cache decorator

### DIFF
--- a/src/csm_testing/tests/rgw_endpoint_check/__main__.py
+++ b/src/csm_testing/tests/rgw_endpoint_check/__main__.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022, 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -100,7 +100,7 @@ def main():  # pylint: disable=missing-function-docstring
             "--upload, --delete-file, --list")
 
 
-@lru_cache
+@lru_cache()
 def get_credentials() -> dict:
     """get credentials"""
     jdata = json.loads(


### PR DESCRIPTION
The `rgw_endpoint_check` test is failing because of a Python syntax error. This PR corrects it. I have tested the fix on drax (where the problem was reported) and verified that it fixes the issue.