### PR TITLE
CASMTRIAGE-5354: increase test timeout to 30 sec

### DIFF
--- a/goss-testing/tests/ncn/goss-platform-ca-in-bundle.yaml
+++ b/goss-testing/tests/ncn/goss-platform-ca-in-bundle.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022-2023] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2022-2025] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,5 +29,5 @@ command:
       sev: 0
     exec: "keytool -printcert -v -file /etc/pki/trust/anchors/platform-ca-certs.crt  | grep SHA1 | awk '{print $2}' | while read line; do if ! keytool -printcert -v -file /etc/ssl/ca-bundle.pem | grep -q $line; then exit 1; fi; done"
     exit-status: 0
-    timeout: 20000
+    timeout: 30000
     skip: false


### PR DESCRIPTION
## Summary and Scope

Occasionally platform-ca-in-bundle goss testing in vshasta takes longer than 20 seconds. This PR bumps it to 30 seconds.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-5354](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5354)
* Change will also be needed in `release/1.5.4`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

