### PR TITLE
CASMPET-7088: Increase validate_certifi_version test timeout to 20 sec

### DIFF
--- a/goss-testing/tests/ncn/goss-validate-certifi-version.yaml
+++ b/goss-testing/tests/ncn/goss-validate-certifi-version.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright [2022-2025] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -36,5 +36,5 @@ command:
     stdout:
       - "Version: 2018.1.18"
       - "Location: /usr/lib/python3.6/site-packages"
-    timeout: 10000
+    timeout: 20000
     skip: false


### PR DESCRIPTION
## Summary and Scope

Occasionally validate_certifi_version goss test in vshasta takes longer than 10 seconds to finish. This PR increases the timeout setting to 20 seconds.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7088](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7088)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

