### PR TITLE
CASMINST-7167 adjust k8s_nodes_ready_check.sh to allow

### DIFF
--- a/goss-testing/scripts/k8s_nodes_ready_check.sh
+++ b/goss-testing/scripts/k8s_nodes_ready_check.sh
@@ -71,9 +71,9 @@ while read NODE STATE REST ; do
         err_echo "Kubernetes node name does not match expected format: ${NODE}"
     fi
     
-    # And verify that the state is Ready
-    if [[ ${STATE} != Ready ]]; then
-        err_echo "Node '${NODE}' state is '${STATE}', not 'Ready'"
+    # Verify that the state is Ready or Ready,SchedulingDisabled
+    if [[ ${STATE} != "Ready" && ${STATE} != "Ready,SchedulingDisabled" ]]; then
+        err_echo "Node '${NODE}' state is '${STATE}', not 'Ready' or 'Ready,SchedulingDisabled'"
     fi
 done < "${TMPFILE}"
 


### PR DESCRIPTION
`Ready,SchedulingDisabled`

a customer complained that this test fails on large-scale systems, and we have also see it cause tickets to get created during nightly testing if the system happens to be in that state.  the node is technically still `Ready` so this change allows the test to pass when `SchedulingDisabled` is also set.

Here is the output from a test with a node in that state:

```
ncn-m001:~ # /opt/cray/tests/install/ncn/scripts/k8s_nodes_ready_check.sh
++ mktemp /tmp/.k8s_nodes_ready_check.4030338.XXXXXX.tmp
+ TMPFILE=/tmp/.k8s_nodes_ready_check.4030338.xk8mzO.tmp
+ [[ -n /tmp/.k8s_nodes_ready_check.4030338.xk8mzO.tmp ]]
+ [[ -f /tmp/.k8s_nodes_ready_check.4030338.xk8mzO.tmp ]]
+ kubectl get nodes --no-headers
+ tee /tmp/.k8s_nodes_ready_check.4030338.xk8mzO.tmp
ncn-m001   Ready                      control-plane   14d     v1.24.17
ncn-m002   Ready                      control-plane   18d     v1.24.17
ncn-m003   Ready                      control-plane   18d     v1.24.17
ncn-w001   Ready                      <none>          5h33m   v1.24.17
ncn-w002   Ready,SchedulingDisabled   <none>          14d     v1.24.17
ncn-w003   Ready                      <none>          14d     v1.24.17
ncn-w004   Ready                      <none>          14d     v1.24.17
+ COUNT=0
+ read NODE STATE REST
+ let COUNT+=1
+ [[ ncn-m001 =~ ^ncn-[mw][0-9]{3}$ ]]
+ [[ Ready != \R\e\a\d\y ]]
+ read NODE STATE REST
+ let COUNT+=1
+ [[ ncn-m002 =~ ^ncn-[mw][0-9]{3}$ ]]
+ [[ Ready != \R\e\a\d\y ]]
+ read NODE STATE REST
+ let COUNT+=1
+ [[ ncn-m003 =~ ^ncn-[mw][0-9]{3}$ ]]
+ [[ Ready != \R\e\a\d\y ]]
+ read NODE STATE REST
+ let COUNT+=1
+ [[ ncn-w001 =~ ^ncn-[mw][0-9]{3}$ ]]
+ [[ Ready != \R\e\a\d\y ]]
+ read NODE STATE REST
+ let COUNT+=1
+ [[ ncn-w002 =~ ^ncn-[mw][0-9]{3}$ ]]
+ [[ Ready,SchedulingDisabled != \R\e\a\d\y ]]
+ [[ Ready,SchedulingDisabled != \R\e\a\d\y\,\S\c\h\e\d\u\l\i\n\g\D\i\s\a\b\l\e\d ]]
+ read NODE STATE REST
+ let COUNT+=1
+ [[ ncn-w003 =~ ^ncn-[mw][0-9]{3}$ ]]
+ [[ Ready != \R\e\a\d\y ]]
+ read NODE STATE REST
+ let COUNT+=1
+ [[ ncn-w004 =~ ^ncn-[mw][0-9]{3}$ ]]
+ [[ Ready != \R\e\a\d\y ]]
+ read NODE STATE REST
+ rm /tmp/.k8s_nodes_ready_check.4030338.xk8mzO.tmp
+ [[ 7 -eq 0 ]]
+ [[ 0 -ne 0 ]]
+ echo PASS
PASS
+ exit 0
ncn-m001:~ #
```
