### PR TITLE
CRAYSAT-1981: Create BOS session template tests

### DIFF
--- a/goss-testing/tests/ncn/goss-sat-bootprep.yaml
+++ b/goss-testing/tests/ncn/goss-sat-bootprep.yaml
@@ -38,4 +38,4 @@ command:
         exit-status: 0
         stderr:
         - OK
-        timeout: 800000 # timeout in milliseconds
+        timeout: 1200000 # timeout in milliseconds

--- a/src/csm_testing/tests/sat_functional/bootprep/data/configs-images-and-session-templates.yaml
+++ b/src/csm_testing/tests/sat_functional/bootprep/data/configs-images-and-session-templates.yaml
@@ -1,0 +1,42 @@
+---
+# Define a session template that references an existing IMS image
+configurations:
+# A simple configuration that has just one layer that runs a simple playbook
+- name: "{{test.prefix}}-simple-passing-configuration"
+  layers:
+  - name: successful-layer
+    playbook: test.yml
+    git:
+      url: "https://api-gw-service-nmn.local/vcs/cray/{{test.vcs_repo_name}}.git"
+      branch: "main"
+
+images:
+- name: "{{test.prefix}}-simple-customized-image"
+  base:
+    product:
+      name: csm
+      version: "{{csm.version}}"
+      type: image
+      filter:
+        arch: x86_64
+        wildcard: "*barebones*"
+  configuration: "{{test.prefix}}-simple-passing-configuration"
+  configuration_group_names:
+  - Compute
+
+session_templates:
+- name: "{{test.prefix}}-simple-session-template"
+  image:
+    ims:
+      id: "{{csm.image_id}}"
+  configuration: "{{test.prefix}}-simple-passing-configuration"
+  bos_parameters:
+    boot_sets:
+      compute:
+        arch: X86
+        kernel_parameters: "spire_join_token=${SPIRE_JOIN_TOKEN}"
+        node_roles_groups:
+        - Compute
+        rootfs_provider: "sbps"
+        rootfs_provider_passthrough: "sbps:v1:iqn.2023-06.csm.iscsi:_sbps-hsn._tcp.{{default.system_name}}.{{default.site_domain}}:300"
+

--- a/src/csm_testing/tests/sat_functional/bootprep/test_bootprep.py
+++ b/src/csm_testing/tests/sat_functional/bootprep/test_bootprep.py
@@ -694,6 +694,43 @@ class TestBootprepCreateConfigs(BootprepRunTestCase):
             decoded_stderr
         )
 
+    def test_session_template(self):
+        """Test creating a bos session template"""
+        result = self.run_bootprep('ims-image-session-template.yaml', '--format json')
+
+        report = json.loads(result.stdout.decode())
+        self.assertEqual(1, len(report['configurations']))
+        self.assertEqual(1, len(report['session_templates']))
+
+        for config in report['configurations']:
+            self.validate_cfs_config(config['name'])
+
+        for config in report['configurations']:
+            self.items_to_delete['configurations'].append(config['name'])
+
+        for image in report['session_templates']:
+            self.items_to_delete['session_templates'].append(image['name'])
+
+    def test_configs_images_and_session_templates(self):
+        """Test creating a bos session template"""
+        result = self.run_bootprep('configs-images-and-session-templates.yaml', '--format json')
+
+        report = json.loads(result.stdout.decode())
+        self.assertEqual(1, len(report['configurations']))
+        self.assertEqual(1, len(report['images']))
+        self.assertEqual(1, len(report['session_templates']))
+
+        for config in report['configurations']:
+            self.validate_cfs_config(config['name'])
+
+        for config in report['configurations']:
+            self.items_to_delete['configurations'].append(config['name'])
+
+        for image in report['images']:
+            self.items_to_delete['images'].append(image['final_image_id'])
+
+        for image in report['session_templates']:
+            self.items_to_delete['session_templates'].append(image['name'])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary and Scope

Create BOS session template tests for "sat bootprep" in csm-testing

## Issues and Related PRs


* Resolves CRAYSAT-1981

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Drax
  * Local development environment

### Test description:


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? yes
- Were continuous integration tests run? If not, why? yes
- Was upgrade tested? If not, why? yes
- Was downgrade tested? If not, why? yes
- Were new tests (or test issues/Jiras) created for this change? no

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

