### PR TITLE
CASMNET-2294

### DIFF
--- a/goss-testing/suites/ncn-kubernetes-tests-master.yaml
+++ b/goss-testing/suites/ncn-kubernetes-tests-master.yaml
@@ -37,7 +37,5 @@ gossfile:
   ../tests/goss-etcdlvm-drive-master.yaml: {}
   ../tests/goss-k8s-etcd-service.yaml: {}
   ../tests/goss-ncn-xname.yaml: {}
-  ../tests/goss-weave-health.yaml: {}
-  ../tests/goss-weave-status-daemon-sets.yaml: {}
   ../tests/goss-check-taints.yaml: {}
   ../tests/goss-cilium-health.yaml: {}

--- a/goss-testing/suites/ncn-kubernetes-tests-worker.yaml
+++ b/goss-testing/suites/ncn-kubernetes-tests-worker.yaml
@@ -32,5 +32,3 @@
 gossfile:
   ../tests/goss-dedicated-drive-worker.yaml: {}
   ../tests/goss-ncn-xname.yaml: {}
-  ../tests/goss-weave-health.yaml: {}
-  ../tests/goss-weave-status-daemon-sets.yaml: {}

--- a/goss-testing/tests/ncn/goss-k8s-verify-cluster.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-verify-cluster.yaml
@@ -45,7 +45,6 @@ command:
             - /^kube-multus-ds-.*Running/
             - /^kube-proxy-.*Running/
             - /^kube-scheduler-.*Running/
-            - /^weave-net-.*Running/
         exit-status: 0
         timeout: 20000
     {{ $testlabel_2 := "k8s_verify_cluster_2" }}


### PR DESCRIPTION
## Summary and Scope
Weave is no longer enabled by default in CSM 1.7, hence weave tests can be removed. 
This PR is used to remove all the weave tests in the respective suite files.

## Issues and Related PRs
https://jira-pro.it.hpe.com:8443/browse/CASMNET-2294




