### PR TITLE
CASMTRIAGE-7946 fix ceph-service-status.sh script when specific daemon type is supplied

### DIFF
--- a/goss-testing/scripts/ceph-service-status.sh
+++ b/goss-testing/scripts/ceph-service-status.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -42,8 +42,8 @@ do
              exit 0;;
           \?) echo "usage:  ceph-service-status.sh # runs a simple ceph health check"
              echo "        ceph-service-status.sh -n <node> -s <service> # checks a single service on a single node"
-             echo "        ceph-service-status.sh -n <node> -A true # checks all Ceph services on a node"
-             echo "        ceph-service-status.sh -a true # checks all Ceph services on all nodes in a rolling fashion"
+             echo "        ceph-service-status.sh -n <node> -a true # checks all Ceph services on a node"
+             echo "        ceph-service-status.sh -A true # checks all Ceph services on all nodes in a rolling fashion"
              echo "        ceph-service-status.sh -s <service name> # will find the where the service is running and report its status"
              exit 1;;
   esac
@@ -157,7 +157,11 @@ function check_service(){
       fi
       # adding service_name_2 to make the selection more specific, sometimes a random string contains mds, rgw, etc. which fails a test
       service_name_2=$(echo $service|cut -d "." -f 2)
-      read -r -d "\n" service_unit status  < <(pdsh -N -w "$host" podman ps --format json 2>&1|grep -v "Permanently added"|jq --arg service "${service_name}-${service_name_2}" -r '.[]|select(.Names[]|contains($service))|.Names[], .State')
+      specific_service_name="${service_name}"
+      if [[ "$service_name_2" != "$service" ]]; then
+	      specific_service_name="${service_name}-${service_name_2}"
+      fi
+      read -r -d "\n" service_unit status  < <(pdsh -N -w "$host" podman ps --format json 2>&1|grep -v "Permanently added"|jq --arg service "${specific_service_name}" -r '.[]|select(.Names[]|contains($service))|.Names[], .State')
       (( tests++ ))
       if [[ "$service_unit" =~ $FSID_STR-$service_name ]]
       then


### PR DESCRIPTION
## Summary and Scope

The ceph-service-status.sh script can report a false error when health is being checked for a specific type of daemon. For example, the following error was observed

```bash
# /opt/cray/tests/install/ncn/scripts/ceph-service-status.sh  -v true -s mon
FSID: ef3f659a-a1fc-11ef-8032-1402ecdabe48  FSID_STR: ceph-ef3f659a-a1fc-11ef-8032-1402ecdabe48
Ceph is reporting a status of HEALTH_OK
Updating ssh keys..
HOST: ncn-s001#######################
Service mon on ncn-s001 has been restarted and up for 3628579 seconds
mon's status is: running
Service unit name:
Status:
HOST: ncn-s002#######################
Service mon on ncn-s002 has been restarted and up for 3629543 seconds
mon's status is: running
Service unit name:
Status:
HOST: ncn-s003#######################
Service mon on ncn-s003 has been restarted and up for 3630996 seconds
mon's status is: running
Service unit name:
Status:
Tests run: 4  Tests Passed: 1
HEALTH_OK
```

This PR fixes the bug where the incorrect service name was being searched for so that the ceph-service-status.sh script does not report a false negative.

With this change, the output is

```text
# /opt/cray/tests/install/ncn/scripts/ceph-service-status.sh  -v true -s mon
FSID: d38dce22-f139-11ef-9335-42010afc0104  FSID_STR: ceph-d38dce22-f139-11ef-9335-42010afc0104
Ceph is reporting a status of HEALTH_OK
Updating ssh keys..

HOST: ncn-s001#######################
Service mon on ncn-s001 has been restarted and up for 1379291 seconds
mon's status is: running
Service unit name: ceph-d38dce22-f139-11ef-9335-42010afc0104-mon-ncn-s001
Status: running

HOST: ncn-s002#######################
Service mon on ncn-s002 has been restarted and up for 1379192 seconds
mon's status is: running
Service unit name: ceph-d38dce22-f139-11ef-9335-42010afc0104-mon-ncn-s002
Status: running

HOST: ncn-s003#######################
Service mon on ncn-s003 has been restarted and up for 1379168 seconds
mon's status is: running
Service unit name: ceph-d38dce22-f139-11ef-9335-42010afc0104-mon-ncn-s003
Status: running
Tests run: 4  Tests Passed: 4
```

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-7946](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7946)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Beau
 
### Test description:

Ran the script and observed no errors or False negatives.

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

