### PR TITLE
CASMPET-7103, CASMTRIAGE-7780 fix intermittent failures in `check_key_id_in_jwks.sh`

### DIFF
--- a/goss-testing/scripts/check_key_id_in_jwks.sh
+++ b/goss-testing/scripts/check_key_id_in_jwks.sh
@@ -25,26 +25,45 @@
 
 set -euo pipefail
 
-jwt=$(/usr/bin/heartbeat-spire-agent api fetch jwt -socketPath /var/lib/spire/agent.sock -audience goss-test \
-  | head -n2 | awk -F. 'FNR==2{sub(/^[ \t]+/, ""); print $1}') || exit 10
+jwt=$(/usr/bin/heartbeat-spire-agent api fetch jwt -socketPath /var/lib/spire/agent.sock -audience goss-test -output json \
+  | jq -r '.[]?.svids[]?.svid') || exit 10
 
 # Make sure the value of the variable is not empty
 [[ -n ${jwt} ]] || exit 20
 
+# Split the JWT into its three parts
+jwt_header=$(echo "${jwt}" | cut -d '.' -f1)
+# jwt_payload=$(echo "${jwt}" | cut -d '.' -f2)
+# jwt_signature=$(echo "${jwt}" | cut -d '.' -f3) 
+
+# Decode the header (header and payload are base64-encoded; signature is not typically decoded)
 # The base64 decoder will be unhappy if we give it a string whose length (in characters) is not a multiple of 4
 # (See: https://unix.stackexchange.com/questions/631501/base64-d-decodes-but-says-invalid-input)
 # To avoid this, if the length is not already a multiple of 4, it should have = characters added at the end, to pad it out.
-jwt_len=${#jwt}
-len_mod_4=$((jwt_len % 4))
-jwt_len=$((jwt_len + 4 - len_mod_4))
-jwt="${jwt}==="
+decode_base64() {
+  local input=$1
+  # to avoid this use the following logic:
+  # length % 4 = 2 -> Add 2 = characters
+  # length % 4 = 3 -> Add 1 = character
+  # length % 4 = 0 -> No padding needed
+  local len_mod_4=$(( ${#input} % 4 ))
+  if [ $len_mod_4 -ne 0 ]; then
+    # use printf to append the required number of = characters
+    input="${input}$(printf '=%.0s' $(seq 1 $((4 - len_mod_4))))"
+  fi
+  echo "${input}" | base64 -d | jq . 2>/dev/null
+}
 
-jwt_kid=$(echo ${jwt::jwt_len} | base64 -d | jq -r .kid) || exit 30
+# Decode the header
+decoded_header=$(decode_base64 "${jwt_header}")
+
+# Extract the "kid" field from the header
+jwt_kid=$(echo "${decoded_header}" | jq -r .kid) || exit 30
 
 # Make sure the value we found is non-empty
 [[ -n ${jwt_kid} ]] || exit 40
 
-kubectl exec -n spire spire-postgres-0 -c postgres -- curl http://cray-spire-jwks/keys \
+kubectl exec -n spire spire-postgres-0 -c postgres -- curl -s http://cray-spire-jwks/keys \
   | jq -r '.[][].kid' | grep -Eq "^${jwt_kid}$" || exit 50
 
 echo "PASSED"

--- a/goss-testing/scripts/check_key_id_in_jwks.sh
+++ b/goss-testing/scripts/check_key_id_in_jwks.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION


autotriage has detected intermittent, but continued failures with this script.  I have seen failures at all exit codes, `10`, `30`, and `50`.

first, this reduces pipes when calling `heartbeat-spire-agent api fetch jwt` by using `-output json` and then parsing that output with `jq`. this works more efficiently by ensuring the output is machine-readable. this should address exit `10` and make it more resilient.

after the web token is in the `$jwt` variable, I extract the header, leaving room for expansion of this script for the other two parts, payload and signature.  per the munging happening to make the base64 decoder happy, there are a few more cases the current code did not account for.  I mentioned those in a comment and I changed the decode logic to be in its own function and then decode the header passed as input to that function.

exit `30` has reduced pipes now because the decoding is done prior to that, and it is simply a small `jq` call now.

exit `50` should be more resilient by way of the other two changes.  I also added `-s` to curl to reduce noisy output.  this helps when testing the script in parallel at scale and parsing for pass/fail.
