### PR TITLE
CASMTRIAGE-8117 parse just one token from `heartbeat-spire-agent`

### DIFF
--- a/goss-testing/scripts/check_key_id_in_jwks.sh
+++ b/goss-testing/scripts/check_key_id_in_jwks.sh
@@ -26,7 +26,7 @@
 set -euo pipefail
 
 jwt=$(/usr/bin/heartbeat-spire-agent api fetch jwt -socketPath /var/lib/spire/agent.sock -audience goss-test -output json \
-  | jq -r '.[]?.svids[]?.svid') || exit 10
+  | jq -r '.[0]?.svids[0]?.svid') || exit 10
 
 # Make sure the value of the variable is not empty
 [[ -n ${jwt} ]] || exit 20


### PR DESCRIPTION
the command can return more than one token, so the `jq` command is adjusted to get just the first.  Without this, the bash variables can have newlines and more than one token, which breaks the `base64 -d` command:

```
++ cut -d . -f1
+ jwt_header='abCdeFgHIJklmnOpQrsTUVwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz123
abCdeFgHIJklmnOpQrsTUVwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz123'
...
++ base64 -d
++ jq .
base64: invalid input
```

