### PR TITLE
CASMTRIAGE-8133 - monitoring_check.sh does not look for VictoriaMetrics services

### DIFF
--- a/goss-testing/scripts/monitoring_check.sh
+++ b/goss-testing/scripts/monitoring_check.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2022, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/goss-testing/scripts/monitoring_check.sh
+++ b/goss-testing/scripts/monitoring_check.sh
@@ -25,7 +25,7 @@
 # Verify that the monitoring URLs are redirecting and responding.
 
 failFlag=0
-monitoring="$(kubectl get vs -A --no-headers=false | awk '{print $1","$4}' | grep "kiali\|prometheus\|alertmanager\|grafana\|jaeger")"
+monitoring="$(kubectl get vs -A --no-headers=false | awk '{print $1","$4}' | grep "kiali\|prometheus\|alertmanager\|grafana\|jaeger\|vmselect\|vmagent")"
 
 for m in $monitoring
 do


### PR DESCRIPTION

## Summary and Scope

Found on an in house system, the `cray-sysmgmt-health` chart was installed with vmagent configuration missing from customizations.yaml.

This went unnoticed by the monitoring URL check because the test does not check for the VictoriaMetrics services.

## Issues and Related PRs

* Resolves [CASMTRIAGE-8133](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8133)

## Testing

### Tested on:

  * `tyr`

### Test description:

Ran fixed test script and confirmed it now fails for the misconfigured vmagent service.
```
ncn-m001:/mnt/developer/cspiller/sysmgmt-health # ./monitoring_check.sh
curl: (6) Could not resolve host: vmagent.local
Monitoring url https://vmagent.local/ in namespace sysmgmt-health failed to redirect for auth.
curl: (6) Could not resolve host: vmagent.local
Monitoring url https://vmagent.local/ in namespace sysmgmt-health failed to respond with OK.
FAIL
```
Fixed problem with vmagent virtual services and verified test now passes
```
ncn-m001:/mnt/developer/cspiller/sysmgmt-health # ./monitoring_check.sh
PASS
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

