### PR TITLE
CASMINST-6964 add test to validate a tenant is deployed

### DIFF
--- a/goss-testing/internal/tests/tenant-ips-are-reserved-in-sls.yml
+++ b/goss-testing/internal/tests/tenant-ips-are-reserved-in-sls.yml
@@ -1,0 +1,57 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# goss test
+
+# --vars <(cray sls networks describe HSN --format json)
+# --vars <(curl -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/sls/v1/networks)
+# see the workaround in USS-4222 if slurm-config is not at >= 1.6.0
+matching:
+  tenant_{{ .Env.TENANT_NAME }}_in_sls_has_four_ips_reserved:
+    title: tenant {{ .Env.TENANT_NAME }} has ips reserved in sls
+    meta:
+      desc: "if this test fails, ensure the slurm-config pod is at >= 1.6.0 and run 'cray sls networks describe HSN --format json | jq '.ExtraProperties.Subnets[].IPReservations'' to see reserved ips"
+    content: {{ (.Vars.ExtraProperties.Subnets | first).IPReservations | toJson }} # a bit dumb, but sls only has one subnet in this list
+    matches:
+      and:
+        - contain-element:
+            and:
+              - have-key: IPAddress
+              - have-key-with-value:
+                  Name: "{{ .Env.TENANT_NAME }}-slurmctld"
+        - contain-element:
+            and:
+              - have-key: IPAddress
+              - have-key-with-value:
+                  Name: "{{ .Env.TENANT_NAME }}-slurmctld-backup"
+        - contain-element:
+            and:
+              - have-key: IPAddress
+              - have-key-with-value:
+                  Name: "{{ .Env.TENANT_NAME }}-slurmdbd"
+        - contain-element:
+            and:
+              - have-key: IPAddress
+              - have-key-with-value:
+                  Name: "{{ .Env.TENANT_NAME }}-slurmdbd-backup"

--- a/goss-testing/internal/tests/tenant-is-deployed.yml
+++ b/goss-testing/internal/tests/tenant-is-deployed.yml
@@ -1,0 +1,34 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# goss test
+
+# --vars <(kubectl get tenant -n tenants vcluster-$TENANT_NAME -o json)
+matching:
+  tenant_{{ .Vars.metadata.name }}_in_tenants_namespace_is_deployed:
+    title: tenant {{ .Vars.metadata.name }} exists
+    meta:
+      desc: "if this test fails, run 'kubectl get tenants -n tenants' to see existing tenants"
+    content: {{ .Vars.spec.state | toJson }}
+    matches: Deployed

--- a/goss-testing/internal/tests/tenant-is-in-hsm.yml
+++ b/goss-testing/internal/tests/tenant-is-in-hsm.yml
@@ -1,0 +1,66 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# goss test (v0.3.x-compatible)
+
+# --vars <(cray hsm groups describe $TENANT_NAME --format json)
+# --vars <(curl -H "Authorization: Bearer ${TOKEN}" https://api-gw-service-nmn.local/apis/smd/hsm/v2/groups/${TENANT_NAME})
+matching:
+  tenant_{{ .Env.TENANT_NAME }}_in_hsm_exists_and_has_valid_keys:
+    title: "{{ .Env.TENANT_NAME }} group exists in HSM"
+    meta:
+      desc: "if this test fails, run 'cray hsm groups list' to see existing groups"
+    content: {{ .Vars | toJson }}
+    matches:
+      and: 
+        - have-len: 5 # the group should have 5 keys
+        - have-key-with-value: # the label should be the same as the tenant name
+            label: "{{ .Env.TENANT_NAME }}"
+        - have-key: description # we do not really care about what string the description is, just check that it exists
+        - have-key-with-value: # tenants always need tapms-exclusive-group-label as an exclusive group
+            exclusiveGroup: tapms-exclusive-group-label
+        - have-key: tags     # tags are checked below in a separate test
+        - have-key: members  # members are checked below in a separate test
+
+  tenant_{{ .Env.TENANT_NAME }}_in_hsm_has_valid_xnames_in_members_ids:
+    title: "{{ .Env.TENANT_NAME }} has xnames assigned to members ids"
+    meta:
+      desc: "if this test fails, run 'cray hsm groups describe {{ .Env.TENANT_NAME }}' and look for invalid xnames in members.ids"  
+    content: {{ .Vars.members.ids | toJson }}
+    matches:
+      and:
+        - not: # no element can fail the xname regex test (all must match)
+            contain-element:
+              not:
+                match-regexp: "^x" # TODO: improve regex
+
+  tenant_{ .Env.TENANT_NAME }}_in_hsm_has_vcluster_prefix_in_tags:
+    title: "{{ .Env.TENANT_NAME }} has xnames assigned to members ids"
+    meta:
+      desc: "if this test fails, run 'cray hsm groups describe {{ .Env.TENANT_NAME }}' and check the tags for the vcluster prefix"  
+    content: {{ .Vars.tags | toJson }}
+    matches:
+      and:
+        - contain-element:
+            match-regexp: "^vcluster-{{ .Env.TENANT_NAME }}$"

--- a/goss-testing/internal/tests/tenant-slurmcluster-is-deployed.yml
+++ b/goss-testing/internal/tests/tenant-slurmcluster-is-deployed.yml
@@ -1,0 +1,80 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# goss test (v0.3.x-compatible)
+
+# --vars <(kubectl get po -n vcluster-$TENANT_NAME-slurm -o json)
+matching:
+{{ range .Vars.items }}
+  pod_{{ .metadata.name }}_is_running:
+    title: Pod {{ .metadata.name }} is running
+    meta:
+      desc: "if this test fails, run 'kubectl logs {{ .metadata.name }} -n {{ .metadata.namespace }}' for more information"
+    content: {{ .status.phase | toJson }}
+    # each pod should be running or successful
+    matches:
+      or: 
+        - Running
+        - Succeeded
+ {{ end }}
+
+{{ range $pod := .Vars.items }}
+  {{ with $pod.status.containerStatuses }}
+  {{ range $container := . }}
+  container_{{ $container.name }}_in_pod_{{ $pod.metadata.name }}_is_running_or_completed:
+    title: Pod {{ $pod.metadata.name }} container {{ $container.name }} is running or successful
+    meta:
+      desc: "if this test fails, run 'kubectl logs {{ $pod.metadata.name }} -n {{ $pod.metadata.namespace }} {{ $container.name }}' for more information"
+    # Transform the content to extract only what we need - minimizing complexity
+    content:
+      phase: {{ $pod.status.phase }}
+      ready: {{ $container.ready }}
+    matches:
+      or:
+        # init or cron pods must be successful
+        - and:
+          - have-key-with-value:
+              phase: "Succeeded"
+        # regular containers must be ready
+        - and:
+          - have-key-with-value:
+              ready: true
+    {{ end }}
+    {{ end }}
+{{ end }}
+
+# sometimes init containers fail, preventing the cluster from starting so those need to be checked as well
+{{ range $pod := .Vars.items }}
+  {{ with (index $pod.status "initContainerStatuses") }}
+  {{ range $initContainer := . }}
+  init_container_{{ $initContainer.name }}_in_pod_{{ $pod.metadata.name }}_is_running:
+    title: Pod {{ $pod.metadata.name }} init container {{ $initContainer.name }} is running or completed
+    meta:
+      desc: "if this test fails, run 'kubectl logs {{ $pod.metadata.name }} -n {{ $pod.metadata.namespace }} {{ $initContainer.name }}' for more information"
+    content: {{ $initContainer.ready | toJson }}
+    # each init container should be ready or completed
+    matches: true
+    {{ end }}
+    {{ end }}
+{{ end }}


### PR DESCRIPTION
I created various tests that check kubernetes and csm endpoints for conditions described in the example workflow: https://cray-hpe.github.io/docs-csm/en-16/operations/multi-tenancy/exampleworkflow/#slurmcluster-ip-addresses

These are just goss files that can be called via any mechanism.  a tenant must be deployed via other means; this just tests the end state of one being deployed with a slurmcluster.

These tests can be dynamically run with following:

```shell
goss -g tenant-ips-are-reserved-in-sls.yml --vars <(cray sls networks
describe HSN --format json) v
```

```shell
goss -g tenant-is-deployed.yml --vars <(kubectl get tenant -n tenants
vcluster-$TENANT_NAME -o json) v
```

```shell
goss -g tenant-is-in-hsm.yml --vars <(cray hsm groups describe
$TENANT_NAME --format json) v
```

```shell
goss -g tenant-slurmcluster-is-deployed.yml --vars <(kubectl get po -n
vcluster-$TENANT_NAME-slurm -o json) v
```
