### PR TITLE
CASMINST-7340 temporarily exclude slurmdbd-backup pod from goss test …

### DIFF
--- a/goss-testing/internal/tests/tenant-is-in-hsm.yml
+++ b/goss-testing/internal/tests/tenant-is-in-hsm.yml
@@ -55,7 +55,7 @@ matching:
               not:
                 match-regexp: "^x" # TODO: improve regex
 
-  tenant_{ .Env.TENANT_NAME }}_in_hsm_has_vcluster_prefix_in_tags:
+  tenant_{{ .Env.TENANT_NAME }}_in_hsm_has_vcluster_prefix_in_tags:
     title: "{{ .Env.TENANT_NAME }} has xnames assigned to members ids"
     meta:
       desc: "if this test fails, run 'cray hsm groups describe {{ .Env.TENANT_NAME }}' and check the tags for the vcluster prefix"  

--- a/goss-testing/internal/tests/tenant-slurmcluster-is-deployed.yml
+++ b/goss-testing/internal/tests/tenant-slurmcluster-is-deployed.yml
@@ -40,8 +40,9 @@ matching:
  {{ end }}
 
 {{ range $pod := .Vars.items }}
-  {{ with $pod.status.containerStatuses }}
-  {{ range $container := . }}
+  {{ if ne (index $pod.metadata.labels "app.kubernetes.io/name" | default "") "slurmdbd-backup" }} # revert when USS-3925 is resolved
+  {{ if hasKey $pod.status "containerStatuses" }}                                                  # revert when USS-3925 is resolved
+  {{ range $container := $pod.status.containerStatuses }}                                          # revert when USS-3925 is resolved
   container_{{ $container.name }}_in_pod_{{ $pod.metadata.name }}_is_running_or_completed:
     title: Pod {{ $pod.metadata.name }} container {{ $container.name }} is running or successful
     meta:
@@ -60,6 +61,7 @@ matching:
         - and:
           - have-key-with-value:
               ready: true
+    {{ end }}                                                # revert when USS-3925 is resolved
     {{ end }}
     {{ end }}
 {{ end }}


### PR DESCRIPTION
…until USS-3925 is resolved

USS-3925 is a known-issue where the slurmdbd-backup pod has 2/3 running containers, which can cause this test to fail.  until that is resolved, the existing test will always report failures.

the ansible play checks if the deployment is ready before proceeding, so there is a level of assurance the cluster is deployed.  but to prevent false tickets when this is in the pipeline, this test temporarily skips that pod.

this also fixes a missing `{` in a test title
