### PR TITLE
CASMPET-7599: remove SyncFailed check for the upgrade

### DIFF
--- a/goss-testing/suites/ncn-healthcheck-master-single-post-service-upgrade.yaml
+++ b/goss-testing/suites/ncn-healthcheck-master-single-post-service-upgrade.yaml
@@ -46,7 +46,6 @@ gossfile:
   ../tests/goss-spire-bss-metadata-exist.yaml: {}
   ../tests/goss-spire-verify-api-fetch-jwt.yaml: {}
   ../tests/goss-k8s-postgres-backups.yaml: {}
-  ../tests/goss-k8s-postgres-clusters-running.yaml: {}
   ../tests/goss-k8s-postgres-leader.yaml: {}
   ../tests/goss-k8s-postgres-pods-running.yaml: {}
   ../tests/goss-k8s-postgres-replication-lag.yaml: {}

--- a/goss-testing/suites/ncn-healthcheck-master-single.yaml
+++ b/goss-testing/suites/ncn-healthcheck-master-single.yaml
@@ -47,7 +47,6 @@ gossfile:
   ../tests/goss-spire-bss-metadata-exist.yaml: {}
   ../tests/goss-spire-verify-api-fetch-jwt.yaml: {}
   ../tests/goss-k8s-postgres-backups.yaml: {}
-  ../tests/goss-k8s-postgres-clusters-running.yaml: {}
   ../tests/goss-k8s-postgres-leader.yaml: {}
   ../tests/goss-k8s-postgres-pods-running.yaml: {}
   ../tests/goss-k8s-postgres-replication-lag.yaml: {}

--- a/goss-testing/suites/ncn-post-csm-service-upgrade-tests.yaml
+++ b/goss-testing/suites/ncn-post-csm-service-upgrade-tests.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -36,7 +36,6 @@ gossfile:
   ../tests/goss-k8s-ipxe-pod-running.yaml: {}
   ../tests/goss-k8s-kea-pod-running.yaml: {}
   ../tests/goss-k8s-tftp-pods-running.yaml: {}
-  ../tests/goss-postgresql-syncfailed.yaml: {}
   ../tests/goss-ip-dns-check.yaml: {}
   ../tests/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml: {}
   ../tests/goss-k8s-istio-endpoint.yaml: {}

--- a/goss-testing/suites/ncn-upgrade-preflight-tests.yaml
+++ b/goss-testing/suites/ncn-upgrade-preflight-tests.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2014-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -40,7 +40,6 @@ gossfile:
   ../tests/goss-k8s-ipxe-pod-running.yaml: {}
   ../tests/goss-k8s-kea-pod-running.yaml: {}
   ../tests/goss-k8s-tftp-pods-running.yaml: {}
-  ../tests/goss-postgresql-syncfailed.yaml: {}
   ../tests/goss-ip-dns-check.yaml: {}
   ../tests/goss-switch-bgp-neighbor-aruba-or-mellanox.yaml: {}
   ../tests/goss-k8s-nexus-space.yaml: {}


### PR DESCRIPTION
## Summary and Scope

During CSM 1.7.0 upgrade, we experience the issue that postgres clusters may end up with SyncFailed while the cluster itself is up and running. This PR removes SyncFailed check to allow automated upgrade to proceed.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7599](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7599)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low. This only removes a check from goss testing.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

