### PR TITLE
CASMCMS-9468: Update Python dependency versions

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -13,8 +13,8 @@ importlib-metadata==4.8.3
 Jinja2==2.10.1
 jmespath==0.10.0
 jsonschema==3.2.0
-# CSM 1.6 uses Kubernetes v1.24
-kubernetes==24.2.0
+# CSM 1.7 uses Kubernetes v1.32
+kubernetes==32.0.1
 oauthlib==3.2.2
 packaging==21.3.0
 pyasn1==0.5.1
@@ -25,7 +25,9 @@ python-keycloak==0.27.1
 PyYAML==6.0.1
 requests==2.27.1
 requests-oauthlib==2.0.0
-requests-retry-session>=0.1,<0.2
+requests-retry-session>=0.5,<0.6    ; python_version < '3.9'
+requests-retry-session>=1.0,<1.1    ; python_version >= '3.9' and python_version < '3.10'
+requests-retry-session>=2.0,<2.1    ; python_version >= '3.10'
 rsa==4.9
 s3transfer==0.5.2
 semver==2.13.0


### PR DESCRIPTION
1. Update the `kubernetes` module version to match the CSM 1.7 k8s version
2. Make the `requests-retry-session` stanza vary based on the Python version, using the best version for the given Python version