### PR TITLE
CASMTRIAGE-8343: iscsi_sbps_sanity.sh tried to get hostname from non-…

### DIFF
--- a/goss-testing/scripts/iscsi_sbps_sanity.sh
+++ b/goss-testing/scripts/iscsi_sbps_sanity.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -101,7 +101,7 @@ echo "*******************************"
 
 # Verify DNS SRV and A records exist for the worker respective of the iSCSI portals
 
-host=$(kubectl get vs -n sysmgmt-health cray-sysmgmt-health-grafana -o jsonpath='{.spec.hosts[0]}' | sed -e 's/grafana\.[^.]*\.//')
+host=$(kubectl -n loftsman get secret site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d | yq4 .spec.network.dns.external)
 
 dig -t SRV +short _sbps-hsn._tcp."${host}" _sbps-nmn._tcp."${host}" >> tmp_file
 


### PR DESCRIPTION
## Summary and Scope

iscsi_sbps_sanity.sh (iSCSI SBPS goss tests) tried to get hostname from non-existent pod 'cray-sysmgmt-health-grafana'. This is unusall where this pod is non-existing. So the system domain name is now retrieved from site-init secret. 

## Issues and Related PRs
None.

* Resolves [issue id](issue link): CASMTRIAGE-8343
* Change will also be needed in `<insert branch name here>`: N/A 
* Future work required by [issue id](issue link): N/A 
* Documentation changes required in [issue id](issue link): N/A
* Merge with/before/after `<insert PR URL here>`: N/A 

## Testing
Tested on Lemondrop having CSM 1.6.1-rc.7 installed.  

### Tested on:
Lemondrop.

### Test description:
Tested running goss tests individually on a single node and also by running ncn-health checks on master node which intern invokes iSCSI SBPS goss tests. 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?: Yes
- Were continuous integration tests run? If not, why?: N/A
- Was upgrade tested? If not, why?: N/A
- Was downgrade tested? If not, why?: : N/A 
- Were new tests (or test issues/Jiras) created for this change?: No 

## Risks and Mitigations
None. 

## Pull Request Checklist

- [NA] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [NA] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [NA ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable