### PR TITLE
CASMTRIAGE-8447 - k8s_nexus_can_pull test uses invalid image

### DIFF
--- a/goss-testing/tests/ncn/goss-k8s-nexus-can-pull.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-nexus-can-pull.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2014-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2014-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/goss-testing/tests/ncn/goss-k8s-nexus-can-pull.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-nexus-can-pull.yaml
@@ -31,7 +31,7 @@ command:
             desc: If this test fails, look at the state of the nexus pods (kubectl get po -n nexus) to determine why the test was unable to pull a docker image.
             sev: 0
         exec: |-
-            pause_image=$(grep sandbox_image /etc/containerd/config.toml  | awk '{ gsub(/"/, "", $3); print $3 }')
+            pause_image=$(kubectl -n nexus get cm cray-precache-images -o jsonpath='{.data.images_to_cache}' | grep pause | head -1)
             "{{$logrun}}" -l "{{$testlabel}}" \
                 crictl pull ${pause_image}
         exit-status: 0

--- a/goss-testing/tests/ncn/goss-k8s-nexus-can-pull.yaml
+++ b/goss-testing/tests/ncn/goss-k8s-nexus-can-pull.yaml
@@ -31,8 +31,9 @@ command:
             desc: If this test fails, look at the state of the nexus pods (kubectl get po -n nexus) to determine why the test was unable to pull a docker image.
             sev: 0
         exec: |-
+            pause_image=$(grep sandbox_image /etc/containerd/config.toml  | awk '{ gsub(/"/, "", $3); print $3 }')
             "{{$logrun}}" -l "{{$testlabel}}" \
-                crictl pull artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.7
+                crictl pull ${pause_image}
         exit-status: 0
         timeout: 20000
         skip: false


### PR DESCRIPTION
## Summary and Scope

The `goss-k8s-nexus-can-pull.yaml` test uses a hard-coded image and the image tag doesn't exist in CSM 1.7.

This PR modifies the test to get the image to use from the `cray-precache-images` ConfigMap.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-8447](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8447)

## Testing

### Tested on:

  * `starlord`

### Test description:

Before fix
```
ncn-m001:/opt/cray/tests/install/ncn/tests # goss  -g goss-k8s-nexus-can-pull.yaml validate
F

Failures/Skipped:

Title: Validate nexus (registry.local) can pull images
Meta:
    desc: If this test fails, look at the state of the nexus pods (kubectl get po -n nexus) to determine why the test was unable to pull a docker image.
    sev: 0
Command: k8s_nexus_can_pull: exit-status:
Expected
    <int>: 1
to equal
    <int>: 0

Total Duration: 0.127s
Count: 1, Failed: 1, Skipped: 0
```

With fix
```
ncn-m001:/opt/cray/tests/install/ncn/tests # goss  -g goss-k8s-nexus-can-pull.yaml validate
.

Total Duration: 0.256s
Count: 1, Failed: 0, Skipped: 0
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

