### PR TITLE
CASMTRIAGE-8458 :remove --short flag

### DIFF
--- a/src/csm_testing/tests/iuf_pre_checks/__main__.py
+++ b/src/csm_testing/tests/iuf_pre_checks/__main__.py
@@ -128,7 +128,7 @@ def check_k8s_version(minimum_version):
         None
     """
     k8s_version, returncode = run_command(
-        "kubectl version --short | grep -i 'server version' | awk '{print $3}'"
+        "kubectl version | grep -i 'server version' | awk '{print $3}'"
     )
     if returncode != 0:
         print(


### PR DESCRIPTION
## Summary and Scope

This PR addresses a failure in the precheck step caused by the deprecation of the --short flag in the kubectl version command. The flag has been removed from the command to ensure compatibility with newer Kubernetes versions.

## Issues and Related PRs

* Resolves [CASMTRIAGE-8458](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8458)

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

