### PR TITLE
CASMPET-7626: Add/improve modules in csm_testing.lib

### DIFF
--- a/src/csm_testing/lib/api_requests.py
+++ b/src/csm_testing/lib/api_requests.py
@@ -1,0 +1,225 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: API requests"""
+
+import base64
+import copy
+import logging
+import time
+from typing import Any, Callable, Container, Dict, Optional, Tuple, Union
+
+import requests
+
+from csm_testing.lib import k8s
+
+
+ADMIN_CLIENT_SECRET_NAME = "admin-client-auth"
+ADMIN_CLIENT_SECRET_NAMESPACE = "default"
+API_GW_BASE_URL = "https://api-gw-service-nmn.local"
+AUTH_TOKEN_URL = f"{API_GW_BASE_URL}/keycloak/realms/shasta/protocol/openid-connect/token"
+
+
+# For type hints
+ApiResponse = requests.models.Response
+
+
+class ApiException(Exception):
+    """ Generic API exception class """
+
+
+def get_admin_client_token(k8s_client: k8s.CoreV1API) -> str:
+    """
+    Return the token string needed to get API token
+    """
+    secret_label = f"{ADMIN_CLIENT_SECRET_NAMESPACE}/{ADMIN_CLIENT_SECRET_NAME} Kubernetes secret"
+    admin_client_secret_data = k8s_client.get_secret_data(name=ADMIN_CLIENT_SECRET_NAME,
+                                                          namespace=ADMIN_CLIENT_SECRET_NAMESPACE)
+    try:
+        encoded_client_secret = admin_client_secret_data["client-secret"]
+    except (KeyError, TypeError):
+        logging.error(f"{secret_label} has an unexpected format")
+        raise
+    # return decoded bytes as a string
+    return base64.standard_b64decode(encoded_client_secret).decode()
+
+
+def get_full_api_token(k8s_client: Optional[k8s.CoreV1API] = None) -> Tuple[str, Dict[str, Any]]:
+    """
+    Returns text string and JSON object of the full API auth token
+    """
+    if k8s_client is None:
+        k8s_client = k8s.Client()
+
+    token = get_admin_client_token(k8s_client)
+    request_data = {"grant_type": "client_credentials", "client_id": "admin-client",
+                    "client_secret": token}
+    # Explicitly set add_api_token to False. It's the default, but best to be paranoid when it
+    # comes to infinite loops.
+    resp = post_retry_validate(expected_status_codes=200, url=AUTH_TOKEN_URL, data=request_data,
+                               add_api_token=False)
+    if not resp.text:
+        raise ApiException("Keycloak request for API token succeeded but got empty response")
+    return resp.text, resp.json()
+
+
+def get_api_token(k8s_client: Optional[k8s.CoreV1API] = None) -> str:
+    """
+    Return the token needed for API calls
+    """
+    _, resp_json = get_full_api_token(k8s_client)
+    return resp_json["access_token"]
+
+
+def make_api_request_with_retries(request_method: Callable, url: str, add_api_token: bool = False,
+                                  k8s_client: Optional[k8s.CoreV1API] = None,
+                                  **request_kwargs) -> ApiResponse:
+    """
+    Makes request with specified method to specified URL with specified keyword arguments (if any).
+    If a 5xx status code is returned, the request will be retried after a brief wait, a limited
+    number of times. If this persists, an exception is raised. Otherwise, the response is returned.
+
+    If add_api_token is true, then an API authentication token is added to the request header.
+    """
+    method_name = request_method.__name__.upper()
+
+    if add_api_token:
+        logging.debug("Adding API token to API request")
+        try:
+            headers = copy.deepcopy(request_kwargs["headers"])
+        except KeyError:
+            headers = {}
+        token = get_api_token(k8s_client)
+        headers["Authorization"] = f"Bearer {token}"
+        request_kwargs["headers"] = headers
+
+    count = 0
+    max_attempts = 6
+    while count < max_attempts:
+        count += 1
+        logging.debug("Making %s request to %s", method_name, url)
+        try:
+            resp = request_method(url, **request_kwargs)
+        except Exception as exc:
+            raise ApiException(f"Error making {method_name} request to {url}") from exc
+        logging.debug("Response status code = %d", resp.status_code)
+        if not 500 <= resp.status_code <= 599:
+            return resp
+        logging.debug("Response reason = %s", resp.reason)
+        logging.debug("Response text = %s", resp.text)
+        if count >= max_attempts:
+            raise ApiException(f"API request unsuccessful even after {max_attempts} attempts")
+        logging.debug("Sleeping 3 seconds before retrying..")
+        time.sleep(3)
+    assert False, "PROGRAMMING LOGIC ERROR: make_api_request_with_retries function should never get here"
+
+
+def retry_request_validate_status(expected_status_codes: Union[int, Container[int]],
+                                  **kwargs_to_make_api_request_with_retries) -> ApiResponse:
+    """
+    Wrapper function for make_api_request_with_retries that validates the status code of the
+    response.
+    expected_status_codes specifies the expected status code(s) for the API request.
+    It can be a single int, or a collection of ints. If the response status code does not match,
+    an exception is raised. Otherwise, the response is returned.
+    """
+    if isinstance(expected_status_codes, int):
+        expected_status_codes = {expected_status_codes}
+    response = make_api_request_with_retries(
+        **kwargs_to_make_api_request_with_retries)
+    if response.status_code in expected_status_codes:
+        return response
+    raise ApiException(f"Response status code ({response.status_code}) does not match"
+                       f" any expected status codes ({expected_status_codes})")
+
+
+def delete_retry_validate(**kwargs) -> ApiResponse:
+    """
+    Wrapper function for retry_request_validate_status for DELETE requests.
+    """
+    return retry_request_validate_status(request_method=requests.delete, **kwargs)
+
+
+def get_retry_validate(**kwargs) -> ApiResponse:
+    """
+    Wrapper function for retry_request_validate_status for GET requests.
+    """
+    return retry_request_validate_status(request_method=requests.get, **kwargs)
+
+
+def patch_retry_validate(**kwargs) -> ApiResponse:
+    """
+    Wrapper function for retry_request_validate_status for PATCH requests.
+    """
+    return retry_request_validate_status(request_method=requests.patch, **kwargs)
+
+
+def post_retry_validate(**kwargs) -> ApiResponse:
+    """
+    Wrapper function for retry_request_validate_status for POST requests.
+    """
+    return retry_request_validate_status(request_method=requests.post, **kwargs)
+
+
+def put_retry_validate(**kwargs) -> ApiResponse:
+    """
+    Wrapper function for retry_request_validate_status for PUT requests.
+    """
+    return retry_request_validate_status(request_method=requests.put, **kwargs)
+
+
+def retry_request_validate_status_return_json(**kwargs) -> Any:
+    """
+    Wrapper function for retry_request_validate_status that returns the decoded
+    JSON instead of the response itself
+    """
+    resp = retry_request_validate_status(**kwargs)
+    return resp.json()
+
+
+def get_retry_validate_return_json(**kwargs) -> Any:
+    """
+    Wrapper function for retry_request_validate_status_return_json for GET requests.
+    """
+    return retry_request_validate_status_return_json(request_method=requests.get, **kwargs)
+
+
+def patch_retry_validate_return_json(**kwargs) -> Any:
+    """
+    Wrapper function for retry_request_validate_status_return_json for PATCH requests.
+    """
+    return retry_request_validate_status_return_json(request_method=requests.patch, **kwargs)
+
+
+def post_retry_validate_return_json(**kwargs) -> Any:
+    """
+    Wrapper function for retry_request_validate_status_return_json for POST requests.
+    """
+    return retry_request_validate_status_return_json(request_method=requests.post, **kwargs)
+
+
+def put_retry_validate_return_json(**kwargs) -> Any:
+    """
+    Wrapper function for retry_request_validate_status_return_json for PUT requests.
+    """
+    return retry_request_validate_status_return_json(request_method=requests.put, **kwargs)

--- a/src/csm_testing/lib/hsm/defs.py
+++ b/src/csm_testing/lib/hsm/defs.py
@@ -1,0 +1,34 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: HSM: definitions"""
+
+from typing_extensions import Literal
+
+from csm_testing.lib.api_requests import API_GW_BASE_URL
+
+
+SMD_BASE_URL = f"{API_GW_BASE_URL}/apis/smd"
+HSM_BASE_URL = f"{SMD_BASE_URL}/hsm"
+HSM_V2_BASE_URL = f"{HSM_BASE_URL}/v2"
+MGMT_NCN_HSM_SUBROLE = Literal['Master', 'Storage', 'Worker']

--- a/src/csm_testing/lib/hsm/groups.py
+++ b/src/csm_testing/lib/hsm/groups.py
@@ -1,0 +1,72 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: HSM: Groups"""
+
+from typing import List, Union
+from typing_extensions import Required, TypedDict
+
+from csm_testing.lib.api_requests import get_retry_validate
+from csm_testing.lib.hsm.defs import HSM_V2_BASE_URL
+
+SMD_HSM_GROUPS_URL = f"{HSM_V2_BASE_URL}/groups"
+
+
+class GroupMembersInfo(TypedDict, total=False):
+    """
+    https://github.com/Cray-HPE/hms-smd/blob/master/api/swagger_v2.yaml
+    '#/definitions/Members.1.0.0'
+    """
+    ids: List[str]
+
+
+class GroupInfo(TypedDict, total=False):
+    """
+    https://github.com/Cray-HPE/hms-smd/blob/master/api/swagger_v2.yaml
+    '#/definitions/Group.1.0.0'
+    """
+    label: Required[str]
+    description: str
+    exclusiveGroup: str
+    tags: List[str]
+    members: GroupMembersInfo
+
+
+def get_group(group_name: str) -> Union[GroupInfo, None]:
+    """
+    Returns the data about the group if it exists, otherwise returns None
+    """
+    resp = get_retry_validate(url=f"{SMD_HSM_GROUPS_URL}/{group_name}",
+                              expected_status_codes=(200,404),
+                              add_api_token=True)
+    if resp.status_code == 404:
+        return None
+    return resp.json()
+
+
+def get_members(group: GroupInfo) -> List[str]:
+    """
+    Return the 'ids' list of the group members, if available.
+    Otherwise return an empty list
+    """
+    return group.get("members", {}).get("ids", [])

--- a/src/csm_testing/lib/hsm/state_components.py
+++ b/src/csm_testing/lib/hsm/state_components.py
@@ -1,0 +1,44 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: HSM: State/Components"""
+
+from typing import List, Optional
+
+from csm_testing.lib.api_requests import get_retry_validate
+from csm_testing.lib.hsm.defs import MGMT_NCN_HSM_SUBROLE, HSM_V2_BASE_URL
+
+SMD_HSM_COMPONENTS_URL = f"{HSM_V2_BASE_URL}/State/Components"
+
+
+def get_management_ncn_xnames(subrole: Optional[MGMT_NCN_HSM_SUBROLE] = None) -> List[str]:
+    """
+    Return a sorted list of the xnames of the management NCNs
+    """
+    params = {"type": "Node", "role": "Management"}
+    if subrole is not None:
+        params["subrole"] = subrole
+    resp = get_retry_validate(url=SMD_HSM_COMPONENTS_URL, expected_status_codes=200,
+                              add_api_token=True, params=params)
+    component_list = resp.json()["Components"]
+    return sorted([comp["ID"] for comp in component_list])

--- a/src/csm_testing/lib/k8s.py
+++ b/src/csm_testing/lib/k8s.py
@@ -1,0 +1,109 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""Shared Python function library: Kubernetes"""
+
+import logging
+from typing import Any
+
+import kubernetes
+import kubernetes.client
+import kubernetes.client.api
+import kubernetes.config
+
+
+# To help for type hinting in other modules
+CoreV1API = kubernetes.client.api.core_v1_api.CoreV1Api
+V1ClientConfiguration = kubernetes.client.configuration.Configuration
+V1ConfigMap = kubernetes.client.models.v1_config_map.V1ConfigMap
+V1Secret = kubernetes.client.models.v1_secret.V1Secret
+V1Service = kubernetes.client.models.v1_service.V1Service
+
+
+def get_configuration() -> V1ClientConfiguration:
+    """
+    Creates a default Kubernetes configuration and returns it.
+    """
+    logging.debug("Loading Kubernetes configuration")
+    kubernetes.config.load_kube_config()
+    logging.debug("Getting default copy of Kubernetes configuration")
+    return kubernetes.client.Configuration().get_default_copy()
+
+
+def get_api_client() -> CoreV1API:
+    """
+    Creates a Kubernetes API client and returns it.
+    """
+    logging.debug("Initializing Kubernetes client")
+    k8s_config = get_configuration()
+    logging.debug("Setting client default Kubernetes configuration")
+    kubernetes.client.Configuration.set_default(k8s_config)
+    return kubernetes.client.api.core_v1_api.CoreV1Api()
+
+
+class Client:
+    """
+    Kubernetes API client object. Takes care of the setup steps and provides simplified API calls.
+    """
+    def __init__(self):
+        self.client = get_api_client()
+
+    def get_config_map(self, name: str, namespace: str) -> V1ConfigMap:
+        """
+        Wrapper for read_namespaced_config_map function
+        """
+        configmap_label = f"{namespace}/{name} Kubernetes configmap"
+        logging.debug("Getting %s", configmap_label)
+        return self.client.read_namespaced_config_map(name=name, namespace=namespace)
+
+    def get_config_map_data(self, name: str, namespace: str) -> Any:
+        """
+        Calls get_config_map function, then extracts the data field from the response.
+        """
+        configmap_label = f"{namespace}/{name} Kubernetes configmap"
+        configmap = self.get_config_map(name=name, namespace=namespace)
+        return configmap.data
+
+    def get_secret(self, name: str, namespace: str) -> V1Secret:
+        """
+        Wrapper for read_namespaced_secret function
+        """
+        secret_label = f"{namespace}/{name} Kubernetes secret"
+        logging.debug("Getting %s", secret_label)
+        return self.client.read_namespaced_secret(name=name, namespace=namespace)
+
+    def get_secret_data(self, name: str, namespace: str) -> Any:
+        """
+        Calls get_secret function, then extracts the data field from the response.
+        """
+        secret_label = f"{namespace}/{name} Kubernetes secret"
+        secret = self.get_secret(name=name, namespace=namespace)
+        return secret.data
+
+    def get_service(self, name: str, namespace: str) -> V1Service:
+        """
+        Wrapper for read_namespaced_service function
+        """
+        service_label = f"{namespace}/{name} Kubernetes service"
+        logging.debug("Getting %s", service_label)
+        return self.client.read_namespaced_service(name=name, namespace=namespace)


### PR DESCRIPTION
This is a backport of just the improvements/additions to the `csm_testing` Python library modules, from https://github.com/Cray-HPE/csm-testing/pull/724.
This does not contain the new test (or the modifications to the iSCSI Python module).
I don't plan on tagging a new RPM version after this merges, since by itself it changes nothing in any current tests. But I wanted to backport these improvements in case future tests make use of them.

These won't be backported further, since the current Python structure only goes back to CSM 1.6.