### PR TITLE
CRAYSAT-2018: Fix duplicate Goss results for SAT tests

### DIFF
--- a/goss-testing/tests/ncn/goss-sat-bootprep.yaml
+++ b/goss-testing/tests/ncn/goss-sat-bootprep.yaml
@@ -36,6 +36,4 @@ command:
             "{{$logrun}}" -l "{{$test_label}}" \
                 "{{$sat_test}}" "bootprep.test_bootprep.TestBootprepCreateConfigs"
         exit-status: 0
-        stderr:
-        - OK
         timeout: 2700000 # timeout in milliseconds, currently set to 45 minutes

--- a/goss-testing/tests/ncn/goss-sat-firmware.yaml
+++ b/goss-testing/tests/ncn/goss-sat-firmware.yaml
@@ -36,6 +36,4 @@ command:
             "{{$logrun}}" -l "{{$test_label}}" \
                 "{{$sat_test}}" "firmware.test_firmware"
         exit-status: 0
-        stderr:
-        - OK
         timeout: 200000 # timeout in milliseconds

--- a/goss-testing/tests/ncn/goss-sat-init.yaml
+++ b/goss-testing/tests/ncn/goss-sat-init.yaml
@@ -36,6 +36,4 @@ command:
             "{{$logrun}}" -l "{{$test_label}}" \
                 "{{$sat_test}}" "init.test_init"
         exit-status: 0
-        stderr:
-        - OK
         timeout: 100000 # timeout in milliseconds

--- a/goss-testing/tests/ncn/goss-sat-nid2xname.yaml
+++ b/goss-testing/tests/ncn/goss-sat-nid2xname.yaml
@@ -36,6 +36,4 @@ command:
             "{{$logrun}}" -l "{{$test_label}}" \
                 "{{$sat_test}}" "nid2xname.test_nid2xname"
         exit-status: 0
-        stderr:
-        - OK
         timeout: 100000 # timeout in milliseconds

--- a/goss-testing/tests/ncn/goss-sat-showrev.yaml
+++ b/goss-testing/tests/ncn/goss-sat-showrev.yaml
@@ -36,6 +36,4 @@ command:
             "{{$logrun}}" -l "{{$test_label}}" \
                 "{{$sat_test}}" "showrev.test_showrev"
         exit-status: 0
-        stderr:
-        - OK
         timeout: 200000 # timeout in milliseconds

--- a/goss-testing/tests/ncn/goss-sat-status.yaml
+++ b/goss-testing/tests/ncn/goss-sat-status.yaml
@@ -36,6 +36,4 @@ command:
             "{{$logrun}}" -l "{{$test_label}}" \
                 "{{$sat_test}}" "status.test_status"
         exit-status: 0
-        stderr:
-        - OK
         timeout: 100000 # timeout in milliseconds

--- a/goss-testing/tests/ncn/goss-sat-version.yaml
+++ b/goss-testing/tests/ncn/goss-sat-version.yaml
@@ -36,6 +36,4 @@ command:
             "{{$logrun}}" -l "{{$test_label}}" \
                 "{{$sat_test}}" "version.test_version"
         exit-status: 0
-        stderr:
-        - OK
         timeout: 5000 # timeout in milliseconds


### PR DESCRIPTION
## Summary and Scope

The usage of both `stderr` and `exit-status` checks in the Goss files
for the SAT functional tests resulted in duplicate results for each
test. Remove the `stderr` check as `exit-status` is sufficient to check
for success or failure of the test.

## Issues and Related PRs

* Resolves CRAYSAT-2018

## Testing

### Tested on:

  * noname

### Test description:

Made this change to a single Goss test file on noname and executed the
goss test with `goss -g tests/goss-sat-version.yaml validate --format
json` and confirmed that only a single test result was returned.


## Risks and Mitigations

Low risk. This is just a minor change to SAT functional test Goss files.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

