### PR TITLE
CRAYSAT-2018: Update missed copyright years

### DIFF
--- a/goss-testing/tests/ncn/goss-sat-status.yaml
+++ b/goss-testing/tests/ncn/goss-sat-status.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/goss-testing/tests/ncn/goss-sat-version.yaml
+++ b/goss-testing/tests/ncn/goss-sat-version.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
## Summary and Scope

The previous commit neglected to update copyright years in a coupld of
the SAT goss test files. Update those.


## Issues and Related PRs

* Resolves CRAYSAT-2018

## Testing

### Test description:

Just a copyright update. No testing required.

## Risks and Mitigations

No risk, copyright update in a comment.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

