### PR TITLE
 CRAYSAT-2016: Automated functional tests fail with JSONDecodeError

### DIFF
--- a/src/csm_testing/tests/sat_functional/__main__.py
+++ b/src/csm_testing/tests/sat_functional/__main__.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -45,6 +45,10 @@ becomes:
 import argparse
 import sys
 import unittest
+import os
+
+
+os.environ['CRAY_FORMAT'] = 'json'
 
 
 def create_parser() -> argparse.ArgumentParser:


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

The cray CLI commands are not specifying `--format json`
So, Automated functional tests for `sat firmware` fail with `JSONDecodeError`
I have set `CRAY_FORMAT` with `json` in the environment in the `sat_functional` module to get cray outputs in json format which will be inlined with SAT output

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-2016](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-2016)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * wasp (sat 3.35.17 system)

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Logged in to the wasp system using ssh and then executed the `firmware` automation test to verify it resolved the `JSONDecodeError`

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
NO

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

