### PR TITLE
CRAYSAT-2015: fix sat showrev test fails on rocket

### DIFF
--- a/src/csm_testing/tests/sat_functional/showrev/test_showrev.py
+++ b/src/csm_testing/tests/sat_functional/showrev/test_showrev.py
@@ -180,7 +180,7 @@ class TestShowRev(unittest.TestCase):
                 kubectl_product_names.add(key)
 
         kubectl_product_count = len(kubectl_product_names)
-        self.assertEqual(sat_product_count, kubectl_product_count)
+        self.assertGreaterEqual(sat_product_count, kubectl_product_count)
 
     def test_showrev_system_headings(self):
         """Test that `sat showrev --system` returns the proper headings."""

--- a/src/csm_testing/tests/sat_functional/showrev/test_showrev.py
+++ b/src/csm_testing/tests/sat_functional/showrev/test_showrev.py
@@ -180,6 +180,9 @@ class TestShowRev(unittest.TestCase):
                 kubectl_product_names.add(key)
 
         kubectl_product_count = len(kubectl_product_names)
+        # >= is used here rather than == as sat can find custom
+        # products on systems that this kubectl command is unable to find
+        # (more info can be found in CRAYSAT-2015)
         self.assertGreaterEqual(sat_product_count, kubectl_product_count)
 
     def test_showrev_system_headings(self):


### PR DESCRIPTION
## Summary and Scope

Fix failing test of `sat showrev` on rocket.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-2015](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-2015)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `gamora`
  * Local development environment

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? yes
- Were continuous integration tests run? If not, why? yes
- Was upgrade tested? If not, why? yes 
- Was downgrade tested? If not, why? yes
- Were new tests (or test issues/Jiras) created for this change? no

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_ no


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

