### PR TITLE
CRAYSAT-2019: Capture output when deleting items in bootprep tests

### DIFF
--- a/src/csm_testing/tests/sat_functional/bootprep/test_bootprep.py
+++ b/src/csm_testing/tests/sat_functional/bootprep/test_bootprep.py
@@ -420,7 +420,8 @@ class BootprepRunTestCase(unittest.TestCase):
         """
         delete_command = f'cray cfs configurations delete {cfs_config_name}'
         try:
-            subprocess.run(shlex.split(delete_command), check=True)
+            subprocess.run(shlex.split(delete_command), check=True,
+                           stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except subprocess.CalledProcessError as err:
             logging.warning('Failed to delete CFS configuration "%s" '
                             'created by test: %s', cfs_config_name, err.stderr)
@@ -534,7 +535,8 @@ class BootprepRunTestCase(unittest.TestCase):
             """Helper function to delete an IMS image or deleted IMS image."""
             delete_command = f'cray ims {"deleted" if deleted else ""} images delete {ims_image_id}'
             try:
-                subprocess.run(shlex.split(delete_command), check=True)
+                subprocess.run(shlex.split(delete_command), check=True,
+                               stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             except subprocess.CalledProcessError as err:
                 logging.warning('Failed to delete IMS %s with ID "%s": %s',
                                 'deleted image' if deleted else 'image',
@@ -561,7 +563,8 @@ class BootprepRunTestCase(unittest.TestCase):
         """
         delete_command = f'cray bos sessiontemplates delete {bos_session_template_name}'
         try:
-            subprocess.run(shlex.split(delete_command), check=True)
+            subprocess.run(shlex.split(delete_command), check=True,
+                           stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except subprocess.CalledProcessError as err:
             logging.warning('Failed to delete BOS session template "%s" '
                             'created by test: {%s}', bos_session_template_name, err.stderr)


### PR DESCRIPTION
## Summary and Scope

Capture stderr and stdout when running `cray` commands to delete CFS
configurations, IMS images, and BOS session templates in the functional
tests for `sat bootprep`. These commands output a newline, which, if not
captured, results in extra blank lines being printed during the cleanup
tasks that occur in `tearDown` for each test.

## Issues and Related PRs

* Resolves CRAYSAT-2019 

## Testing

### Tested on:

  * rocket

### Test description:

Executed the test method `test_configs_images_and_session_templates` and
confirmed extra new lines were not printed. This test method was chosen
because it creates items of all types and deletes them, so it exercises
all the delete methods that were changed.

## Risks and Mitigations

Low risk change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

