### PR TITLE
CRAYSAT-1968: create functional tests for sat status --format in csm-testing

### DIFF
--- a/src/csm_testing/tests/sat_functional/sat_testing_utils.py
+++ b/src/csm_testing/tests/sat_functional/sat_testing_utils.py
@@ -29,40 +29,36 @@ import sys
 import yaml
 
 
-class SatTestingUtils:
+def validate_json(json_string: str) -> json:
+    """
+    Validates a json string and returns the validated json
 
-    @staticmethod
-    def validate_json(json_string: str) -> bool:
-        """
-        Validates a json string
+    Args:
+        json_string (str): string containing json
 
-        Args:
-            json_string (str): string containing json
+    Returns:
+        json: a json object
+    """
+    try:
+        return json.loads(json_string)
+    except json.JSONDecodeError as err:
+        sys.stderr.write(f'Unable to decode json with error: {err}')
+        assert False, f"The provided string is not valid json: {json_string}"
 
-        Returns:
-            bool: True if json is valid false otherwise
-        """
-        try:
-            json.loads(json_string)
-            return True
-        except json.JSONDecodeError as err:
-            sys.stderr.write(f'Unable to load json with error: {err}')
-            return False
 
-    @staticmethod
-    def validate_yaml(yaml_string: str) -> bool:
-        """
-        Validates a yaml string
+def validate_yaml(yaml_string: str) -> yaml:
+    """
+    Validates a yaml string and returns the validated yaml
 
-        Args:
-            yaml_string (str): string containing yaml
+    Args:
+        yaml_string (str): string containing yaml.
 
-        Returns:
-            bool: True if yaml is valid false otherwise
-        """
-        try:
-            yaml.safe_load(yaml_string)
-            return True
-        except yaml.YAMLError as err:
-            sys.stderr.write(f'Unable to load yaml with error: {err}')
-            return False
+    Returns:
+        yaml: a yaml object.
+    """
+    try:
+        return yaml.safe_load(yaml_string)
+    except yaml.YAMLError as err:
+        sys.stderr.write(f'Unable to load yaml with error: {err}')
+        assert False, f"The provided string is not valid yaml: {yaml_string}"
+

--- a/src/csm_testing/tests/sat_functional/sat_testing_utils.py
+++ b/src/csm_testing/tests/sat_functional/sat_testing_utils.py
@@ -1,0 +1,68 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Defines utility functions used across the sat_functional tests
+"""
+import json
+import sys
+import yaml
+
+
+class SatTestingUtils:
+
+    @staticmethod
+    def validate_json(json_string: str) -> bool:
+        """
+        Validates a json string
+
+        Args:
+            json_string (str): string containing json
+
+        Returns:
+            bool: True if json is valid false otherwise
+        """
+        try:
+            json.loads(json_string)
+            return True
+        except json.JSONDecodeError as err:
+            sys.stderr.write(f'Unable to load json with error: {err}')
+            return False
+
+    @staticmethod
+    def validate_yaml(yaml_string: str) -> bool:
+        """
+        Validates a yaml string
+
+        Args:
+            yaml_string (str): string containing yaml
+
+        Returns:
+            bool: True if yaml is valid false otherwise
+        """
+        try:
+            yaml.safe_load(yaml_string)
+            return True
+        except yaml.YAMLError as err:
+            sys.stderr.write(f'Unable to load yaml with error: {err}')
+            return False

--- a/src/csm_testing/tests/sat_functional/sat_testing_utils.py
+++ b/src/csm_testing/tests/sat_functional/sat_testing_utils.py
@@ -30,8 +30,7 @@ import yaml
 
 
 def validate_json(json_string: str) -> json:
-    """
-    Validates a json string and returns the validated json
+    """Validates a json string and returns the validated json
 
     Args:
         json_string (str): string containing json
@@ -47,8 +46,7 @@ def validate_json(json_string: str) -> json:
 
 
 def validate_yaml(yaml_string: str) -> yaml:
-    """
-    Validates a yaml string and returns the validated yaml
+    """Validates a yaml string and returns the validated yaml
 
     Args:
         yaml_string (str): string containing yaml.

--- a/src/csm_testing/tests/sat_functional/status/test_status.py
+++ b/src/csm_testing/tests/sat_functional/status/test_status.py
@@ -130,7 +130,7 @@ class TestStatus(unittest.TestCase):
 
         self.assertTrue(json_response)
 
-        json_header_keys = json_response[0].keys()
+        json_header_keys = list(json_response[0].keys())
 
         status_command = 'sat status'
         status_output, status_err, status_output_header_str = get_header(status_command, 3)
@@ -148,7 +148,7 @@ class TestStatus(unittest.TestCase):
 
         self.assertTrue(yaml_response)
 
-        yaml_header_keys = yaml_response[0].keys()
+        yaml_header_keys = list(yaml_response[0].keys())
 
         status_command = 'sat status'
         status_output, status_err, status_output_header_str = get_header(status_command, 3)

--- a/src/csm_testing/tests/sat_functional/status/test_status.py
+++ b/src/csm_testing/tests/sat_functional/status/test_status.py
@@ -30,7 +30,7 @@ import re
 from typing import List, Tuple
 import unittest
 
-from csm_testing.tests.sat_functional.sat_testing_utils import *
+from csm_testing.tests.sat_functional.sat_testing_utils import validate_json, validate_yaml
 
 SAT_STATUS_HEADER = ['xname', 'Aliases', 'Type', 'NID', 'State', 'Flag', 'Enabled', 'Arch',
                      'Class', 'Role', 'SubRole', 'Net Type', 'Locked', 'Desired Config',

--- a/src/csm_testing/tests/sat_functional/status/test_status.py
+++ b/src/csm_testing/tests/sat_functional/status/test_status.py
@@ -132,7 +132,8 @@ class TestStatus(unittest.TestCase):
 
         json_header_keys = json_response[0].keys()
 
-        status_output, status_err, status_output_header_str = get_header(json_command, 3)
+        status_command = 'sat status'
+        status_output, status_err, status_output_header_str = get_header(status_command, 3)
         status_all_output = status_output + '\n' + status_err
         expected_header = adjust_expected_header(SAT_STATUS_HEADER, status_all_output)
 
@@ -146,6 +147,15 @@ class TestStatus(unittest.TestCase):
         yaml_response = validate_yaml(yaml_std_out)
 
         self.assertTrue(yaml_response)
+
+        yaml_header_keys = yaml_response[0].keys()
+
+        status_command = 'sat status'
+        status_output, status_err, status_output_header_str = get_header(status_command, 3)
+        status_all_output = status_output + '\n' + status_err
+        expected_header = adjust_expected_header(SAT_STATUS_HEADER, status_all_output)
+
+        self.assertEqual(expected_header, yaml_header_keys)
 
     def test_status_fields_command(self) -> None:
         """Test that `sat status --fields xname,aliases` returns the proper header."""

--- a/src/csm_testing/tests/sat_functional/status/test_status.py
+++ b/src/csm_testing/tests/sat_functional/status/test_status.py
@@ -49,9 +49,13 @@ SAT_BOS_FIELDS_HEADER = ['xname', 'Boot Status', 'Most Recent BOS Session',
 
 
 def get_command_output(command: str) -> Tuple[str, str]:
-    """
-    Run the specified command.
-    Return the standard output and standard error
+    """Run the specified command.
+
+    Args:
+        command (str): command to be run
+
+    Returns:
+        Tuple ([str, str]): standard output and standard error
     """
     # Use stdout and stderr instead of capture_output=True for Python 3.6 compatibility
     proc = subprocess.run(shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.PIPE,
@@ -62,10 +66,15 @@ def get_command_output(command: str) -> Tuple[str, str]:
     return std_output, std_err
 
 def get_header(command: str, num_lines_in_header: int) -> Tuple[str, str, str]:
-    """
-    Run the specified command.
-    Return the standard output, standard error, and the header (meaning the first
-    num_lines_in_header lines in the output)
+    """ Run the specified command.
+
+    Args:
+        command (str): command to be run
+        num_lines_in_header (int): number of lines in the output to be returned
+
+    Returns:
+         Tuple (str, str, str): the standard output, standard error, and the header (meaning the first
+         num_lines_in_header lines in the output)
     """
     status_output, status_err = get_command_output(command)
     status_output_header = '\n'.join(status_output.splitlines()[:num_lines_in_header])

--- a/src/csm_testing/tests/sat_functional/status/test_status.py
+++ b/src/csm_testing/tests/sat_functional/status/test_status.py
@@ -29,7 +29,8 @@ import subprocess
 import re
 from typing import List, Tuple
 import unittest
-from ..sat_testing_utils import  SatTestingUtils
+
+from csm_testing.tests.sat_functional.sat_testing_utils import SatTestingUtils
 
 SAT_STATUS_HEADER = ['xname', 'Aliases', 'Type', 'NID', 'State', 'Flag', 'Enabled', 'Arch',
                      'Class', 'Role', 'SubRole', 'Net Type', 'Locked', 'Desired Config',

--- a/src/csm_testing/tests/sat_functional/status/test_status.py
+++ b/src/csm_testing/tests/sat_functional/status/test_status.py
@@ -29,6 +29,7 @@ import subprocess
 import re
 from typing import List, Tuple
 import unittest
+from ..sat_testing_utils import  SatTestingUtils
 
 SAT_STATUS_HEADER = ['xname', 'Aliases', 'Type', 'NID', 'State', 'Flag', 'Enabled', 'Arch',
                      'Class', 'Role', 'SubRole', 'Net Type', 'Locked', 'Desired Config',
@@ -46,17 +47,26 @@ SAT_BOS_FIELDS_HEADER = ['xname', 'Boot Status', 'Most Recent BOS Session',
                          'Most Recent Session Template', 'Most Recent Image']
 
 
+def get_command_output(command: str) -> Tuple[str, str]:
+    """
+    Run the specified command.
+    Return the standard output and standard error
+    """
+    # Use stdout and stderr instead of capture_output=True for Python 3.6 compatibility
+    proc = subprocess.run(shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                          check=True)
+    std_output = proc.stdout.decode().strip()
+    std_err = proc.stderr.decode().strip()
+
+    return std_output, std_err
+
 def get_header(command: str, num_lines_in_header: int) -> Tuple[str, str, str]:
     """
     Run the specified command.
     Return the standard output, standard error, and the header (meaning the first
     num_lines_in_header lines in the output)
     """
-    # Use stdout and stderr instead of capture_output=True for Python 3.6 compatibility
-    proc = subprocess.run(shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                          check=True)
-    status_output = proc.stdout.decode().strip()
-    status_err = proc.stderr.decode().strip()
+    status_output, status_err = get_command_output(command)
     status_output_header = '\n'.join(status_output.splitlines()[:num_lines_in_header])
     return status_output, status_err, status_output_header
 
@@ -100,6 +110,17 @@ class TestStatus(unittest.TestCase):
         expected_header = adjust_expected_header(SAT_STATUS_HEADER, status_all_output)
 
         self.assertEqual(expected_header, status_output_header)
+
+    def test_status_formatting_command(self) -> None:
+        """Test that `sat status --format (json | yaml)` returns the properly formatted response"""
+        json_command = 'sat status --format json'
+        yaml_command = 'sat status --format yaml'
+
+        json_std_out, json_std_err = get_command_output(json_command)
+        yaml_std_out, yaml_std_err = get_command_output(yaml_command)
+
+        self.assertTrue(SatTestingUtils.validate_json(json_std_out))
+        self.assertTrue(SatTestingUtils.validate_yaml(yaml_std_out))
 
     def test_status_fields_command(self) -> None:
         """Test that `sat status --fields xname,aliases` returns the proper header."""

--- a/src/csm_testing/tests/sat_functional/status/test_status.py
+++ b/src/csm_testing/tests/sat_functional/status/test_status.py
@@ -117,16 +117,18 @@ class TestStatus(unittest.TestCase):
         json_command = 'sat status --format json'
 
         json_std_out, json_std_err = get_command_output(json_command)
+        json_response = SatTestingUtils.validate_json(json_std_out)
 
-        self.assertTrue(SatTestingUtils.validate_json(json_std_out))
+        self.assertTrue(json_response)
 
     def test_status_formatting_yaml(self) -> None:
         """Test that `sat status --format yaml` returns the properly formatted response"""
         yaml_command = 'sat status --format yaml'
 
         yaml_std_out, yaml_std_err = get_command_output(yaml_command)
+        yaml_response = SatTestingUtils.validate_yaml(yaml_std_out)
 
-        self.assertTrue(SatTestingUtils.validate_yaml(yaml_std_out))
+        self.assertTrue(yaml_response)
 
     def test_status_fields_command(self) -> None:
         """Test that `sat status --fields xname,aliases` returns the proper header."""

--- a/src/csm_testing/tests/sat_functional/status/test_status.py
+++ b/src/csm_testing/tests/sat_functional/status/test_status.py
@@ -132,10 +132,7 @@ class TestStatus(unittest.TestCase):
 
         json_header_keys = list(json_response[0].keys())
 
-        status_command = 'sat status'
-        status_output, status_err, status_output_header_str = get_header(status_command, 3)
-        status_all_output = status_output + '\n' + status_err
-        expected_header = adjust_expected_header(SAT_STATUS_HEADER, status_all_output)
+        expected_header = adjust_expected_header(SAT_STATUS_HEADER, json_std_err)
 
         self.assertEqual(expected_header, json_header_keys)
 
@@ -150,10 +147,7 @@ class TestStatus(unittest.TestCase):
 
         yaml_header_keys = list(yaml_response[0].keys())
 
-        status_command = 'sat status'
-        status_output, status_err, status_output_header_str = get_header(status_command, 3)
-        status_all_output = status_output + '\n' + status_err
-        expected_header = adjust_expected_header(SAT_STATUS_HEADER, status_all_output)
+        expected_header = adjust_expected_header(SAT_STATUS_HEADER, yaml_std_err)
 
         self.assertEqual(expected_header, yaml_header_keys)
 

--- a/src/csm_testing/tests/sat_functional/status/test_status.py
+++ b/src/csm_testing/tests/sat_functional/status/test_status.py
@@ -112,15 +112,20 @@ class TestStatus(unittest.TestCase):
 
         self.assertEqual(expected_header, status_output_header)
 
-    def test_status_formatting_command(self) -> None:
-        """Test that `sat status --format (json | yaml)` returns the properly formatted response"""
+    def test_status_formatting_json(self) -> None:
+        """Test that `sat status --format json` returns the properly formatted response"""
         json_command = 'sat status --format json'
-        yaml_command = 'sat status --format yaml'
 
         json_std_out, json_std_err = get_command_output(json_command)
-        yaml_std_out, yaml_std_err = get_command_output(yaml_command)
 
         self.assertTrue(SatTestingUtils.validate_json(json_std_out))
+
+    def test_status_formatting_yaml(self) -> None:
+        """Test that `sat status --format yaml` returns the properly formatted response"""
+        yaml_command = 'sat status --format yaml'
+
+        yaml_std_out, yaml_std_err = get_command_output(yaml_command)
+
         self.assertTrue(SatTestingUtils.validate_yaml(yaml_std_out))
 
     def test_status_fields_command(self) -> None:

--- a/src/csm_testing/tests/sat_functional/status/test_status.py
+++ b/src/csm_testing/tests/sat_functional/status/test_status.py
@@ -30,7 +30,7 @@ import re
 from typing import List, Tuple
 import unittest
 
-from csm_testing.tests.sat_functional.sat_testing_utils import SatTestingUtils
+from src.csm_testing.tests.sat_functional.sat_testing_utils import *
 
 SAT_STATUS_HEADER = ['xname', 'Aliases', 'Type', 'NID', 'State', 'Flag', 'Enabled', 'Arch',
                      'Class', 'Role', 'SubRole', 'Net Type', 'Locked', 'Desired Config',
@@ -117,7 +117,7 @@ class TestStatus(unittest.TestCase):
         json_command = 'sat status --format json'
 
         json_std_out, json_std_err = get_command_output(json_command)
-        json_response = SatTestingUtils.validate_json(json_std_out)
+        json_response = validate_json(json_std_out)
 
         self.assertTrue(json_response)
 
@@ -126,7 +126,7 @@ class TestStatus(unittest.TestCase):
         yaml_command = 'sat status --format yaml'
 
         yaml_std_out, yaml_std_err = get_command_output(yaml_command)
-        yaml_response = SatTestingUtils.validate_yaml(yaml_std_out)
+        yaml_response = validate_yaml(yaml_std_out)
 
         self.assertTrue(yaml_response)
 

--- a/src/csm_testing/tests/sat_functional/status/test_status.py
+++ b/src/csm_testing/tests/sat_functional/status/test_status.py
@@ -30,7 +30,7 @@ import re
 from typing import List, Tuple
 import unittest
 
-from src.csm_testing.tests.sat_functional.sat_testing_utils import *
+from csm_testing.tests.sat_functional.sat_testing_utils import *
 
 SAT_STATUS_HEADER = ['xname', 'Aliases', 'Type', 'NID', 'State', 'Flag', 'Enabled', 'Arch',
                      'Class', 'Role', 'SubRole', 'Net Type', 'Locked', 'Desired Config',

--- a/src/csm_testing/tests/sat_functional/status/test_status.py
+++ b/src/csm_testing/tests/sat_functional/status/test_status.py
@@ -130,6 +130,14 @@ class TestStatus(unittest.TestCase):
 
         self.assertTrue(json_response)
 
+        json_header_keys = json_response[0].keys()
+
+        status_output, status_err, status_output_header_str = get_header(json_command, 3)
+        status_all_output = status_output + '\n' + status_err
+        expected_header = adjust_expected_header(SAT_STATUS_HEADER, status_all_output)
+
+        self.assertEqual(expected_header, json_header_keys)
+
     def test_status_formatting_yaml(self) -> None:
         """Test that `sat status --format yaml` returns the properly formatted response"""
         yaml_command = 'sat status --format yaml'


### PR DESCRIPTION
## Summary and Scope

Create functional tests for "sat status --format" in csm-testing

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1968](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1968)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * rocket
  * tyr
  * Local development environment

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? yes
- Were continuous integration tests run? If not, why? yes
- Was upgrade tested? If not, why? yes 
- Was downgrade tested? If not, why? yes 
- Were new tests (or test issues/Jiras) created for this change? no

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_ no


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

