### PR TITLE
CRAYSAT-2024: Improve resiliency of sat_functional.version.test_version test

### DIFF
--- a/src/csm_testing/tests/sat_functional/version/test_version.py
+++ b/src/csm_testing/tests/sat_functional/version/test_version.py
@@ -28,6 +28,7 @@ just print the semantic version of the `sat` command.
 import shlex
 import subprocess
 from typing import Optional
+import os
 
 from csm_testing.tests.sat_functional.util import SATTestCase
 
@@ -52,11 +53,14 @@ class TestVersion(SATTestCase):
 
     def test_version_command(self):
         """Test that `sat --version` returns the semantic version."""
+        # Prepare a clean environment without SAT_IMAGE
+        env = os.environ.copy()
+        env.pop('SAT_IMAGE', None)
         command = 'sat --version'
 
         # Use stdout and stderr instead of capture_output=True for Python 3.6 compatibility
         proc = subprocess.run(shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                              check=True)
+                              check=True, env=env)
         version_output = proc.stdout.decode().strip()
 
         expected_version = get_version_file_contents()


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Improve the resiliency of the `version.test_version` tests, so that it will pass even when `SAT_IMAGE` is set in the environment.

Unset `SAT_IMAGE` in the environment before running the `sat --version` command.
It only removes `SAT_IMAGE` from the copied environment you pass to that `subprocess.run()` call. Your real process‐level `os.environ` remains unchanged.


## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-2024](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-2024)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * rocket

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- tested by running `version.test_version` tests

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_NO


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

