### PR TITLE
CRAYSAT-2006, CRAYSAT-2035: Improve `sat bootprep` tests

### DIFF
--- a/src/csm_testing/tests/sat_functional/bootprep/data/configs-images-and-session-templates.yaml
+++ b/src/csm_testing/tests/sat_functional/bootprep/data/configs-images-and-session-templates.yaml
@@ -10,26 +10,32 @@ configurations:
       branch: "main"
 
 images:
-# An image based on the CSM barebones image and customized with the simple configuration
+# An image built from the CSM barebones recipe
 - name: "{{test.image_name}}"
+  ref_name: "barebones-image"
   base:
     product:
       name: csm
       version: "{{csm.version}}"
-      type: image
+      type: recipe
       filter:
         arch: x86_64
         wildcard: "*barebones*"
+
+# A second image which references the first image as its base and configures it with the simple configuration
+- name: "{{test.image_name}}-configured"
+  ref_name: "configured-image"
+  base:
+    image_ref: "barebones-image"
   configuration: "{{test.config_name}}"
   configuration_group_names:
   - Compute
 
 session_templates:
-# A session template that references an IMS image by ID and the simple configuration
+# A session template that references an IMS image by its ref_name and the simple configuration
 - name: "{{test.session_template_name}}"
   image:
-    ims:
-      id: "{{csm.image_id}}"
+    image_ref: "configured-image"
   configuration: "{{test.config_name}}"
   bos_parameters:
     boot_sets:

--- a/src/csm_testing/tests/sat_functional/bootprep/data/limit-test.yaml
+++ b/src/csm_testing/tests/sat_functional/bootprep/data/limit-test.yaml
@@ -1,5 +1,4 @@
 ---
-# Define a session template that references an existing IMS image
 configurations:
 # A simple configuration that has just one layer that runs a simple playbook
 - name: "{{test.config_name}}"
@@ -10,7 +9,23 @@ configurations:
       url: "https://api-gw-service-nmn.local/vcs/cray/{{test.vcs_repo_name}}.git"
       branch: "main"
 
+images:
+# An image configured from the CSM barebones image
+- name: "{{test.image_name}}"
+  base:
+    product:
+      name: csm
+      version: "{{csm.version}}"
+      type: image
+      filter:
+        arch: x86_64
+        wildcard: "*barebones*"
+  configuration: "{{test.config_name}}"
+  configuration_group_names:
+  - Compute
+
 session_templates:
+# A session template that references an existing IMS image and the simple configuration
 - name: "{{test.session_template_name}}"
   image:
     ims:

--- a/src/csm_testing/tests/sat_functional/bootprep/test_bootprep.py
+++ b/src/csm_testing/tests/sat_functional/bootprep/test_bootprep.py
@@ -519,19 +519,21 @@ class BootprepTestCase(SATTestCase):
 
         This relies on the cray CLI being configured and authenticated on the system.
         """
-        find_command = 'cray ims images list'
+        resource_types = ('images', 'deleted images')
         found_image_ids = []
-        try:
-            proc = subprocess.run(shlex.split(find_command), stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                  check=True)
-            images_json = json.loads(proc.stdout.decode())
-            for image in images_json:
-                if image['name'].startswith(cls.test_prefix):
-                    found_image_ids.append(image['id'])
+        for resource_type in resource_types:
+            find_command = f'cray ims {resource_type} list --format json'
+            try:
+                proc = subprocess.run(shlex.split(find_command), stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                      check=True)
+                images_json = json.loads(proc.stdout.decode())
+                for image in images_json:
+                    if image['name'].startswith(cls.test_prefix):
+                        found_image_ids.append(image['id'])
 
-        except subprocess.CalledProcessError as err:
-            logging.warning('Failed to find IMS images with prefix "%s" '
-                            'created by test: %s', cls.test_prefix, err.stderr)
+            except subprocess.CalledProcessError as err:
+                logging.warning('Failed to find IMS %s with prefix "%s" '
+                                'created by test: %s', resource_type, cls.test_prefix, err.stderr)
 
         for image_id in found_image_ids:
             BootprepTestCase.delete_ims_image(image_id)

--- a/src/csm_testing/tests/sat_functional/bootprep/test_bootprep.py
+++ b/src/csm_testing/tests/sat_functional/bootprep/test_bootprep.py
@@ -442,6 +442,37 @@ class BootprepTestCase(SATTestCase):
         self.assertTrue(any(message_substring in message for message in messages),
                         f'No {level} log message containing "{message_substring}" found in stderr')
 
+    def assert_not_in_log_messages(self, level: str, message_substring: str, stderr: str) -> None:
+        """Assert that the given substring does not appear in a log message prefixed with the given level.
+
+        Args:
+            level: The log level to check for the messages.
+            message_substring: The message to look for
+            stderr: The stderr output from running the command
+
+        Returns:
+            None
+        """
+        messages = [line for line in stderr.splitlines() if line.startswith(level)]
+        self.assertFalse(any(message_substring in message for message in messages),
+                         f'{level} log message containing "{message_substring}" found in stderr')
+
+    def assert_info_messages(self, expected_present: List[str], expected_absent: List[str], stderr: str):
+        """Assert that the expected present and absent info messages are in the stderr
+
+        Args:
+            expected_present: List of expected present info messages
+            expected_absent: List of expected absent info messages
+            stderr: The stderr output from running the command
+
+        Returns:
+            None
+        """
+        for message in expected_present:
+            self.assert_in_log_messages("INFO", message, stderr)
+        for message in expected_absent:
+            self.assert_not_in_log_messages("INFO", message, stderr)
+
     @classmethod
     def run_shell_command(cls, command, path):
         """Run a shell command and return the output."""
@@ -990,12 +1021,17 @@ class TestBootprepConfigsImagesAndSessionTemplates(BootprepTestCase):
         skip_options = ' '.join([f'--skip-existing-{item}' for item in ('configs', 'images', 'templates')])
         overwrite_options = ' '.join([f'--overwrite-{item}' for item in ('configs', 'images', 'templates')])
 
-        # Speed up the tests by creating an empty IMS image to start with
-        empty_image = self.create_empty_ims_image(self.image_name)
-        empty_image_id = empty_image['id']
-        # Create the configurations and session templates with bootprep
-        result = self.run_bootprep('configs-images-and-session-templates.yaml',
-                                   f'{bootprep_options} --limit configurations --limit session_templates')
+        # Speed up the tests by creating empty IMS images to start with
+        empty_barebones_image = self.create_empty_ims_image(self.image_name)
+        empty_barebones_image_id = empty_barebones_image['id']
+        empty_configured_image = self.create_empty_ims_image(f'{self.image_name}-configured')
+        empty_configured_image_id = empty_configured_image['id']
+
+        # Create the configurations and session templates with bootprep using another simpler bootprep
+        # file that contains only a configuration named self.config_name and a session template named
+        # self.session_template_name.
+        result = self.run_bootprep('ims-image-session-template.yaml',
+                                   f'{bootprep_options}')
         report = json.loads(result.stdout.decode())
         self.assertEqual(1, len(report['configurations']))
         self.assertEqual(1, len(report['session_templates']))
@@ -1008,10 +1044,11 @@ class TestBootprepConfigsImagesAndSessionTemplates(BootprepTestCase):
         self.assertNotIn('images', skip_report)
         self.assertNotIn('session_templates', skip_report)
         self.assertEqual(1, len(skip_report['skipped_configurations']))
-        self.assertEqual(1, len(skip_report['skipped_images']))
+        self.assertEqual(2, len(skip_report['skipped_images']))
         self.assertEqual(1, len(skip_report['skipped_session_templates']))
         self.assertTrue(self.configuration_exists(self.config_name))
-        self.assertTrue(self.image_exists(empty_image_id, check_deleted=False))
+        self.assertTrue(self.image_exists(empty_barebones_image_id, check_deleted=False))
+        self.assertTrue(self.image_exists(empty_configured_image_id, check_deleted=False))
         self.assertTrue(self.session_template_exists(self.session_template_name))
 
         # This should overwrite everything, and the original items should be replaced
@@ -1020,12 +1057,14 @@ class TestBootprepConfigsImagesAndSessionTemplates(BootprepTestCase):
         overwrite_report = json.loads(overwrite_result.stdout.decode())
 
         self.assertTrue(self.configuration_exists(self.config_name))
-        # The overwritten image is deleted, but not fully
-        self.assertFalse(self.image_exists(empty_image_id, check_deleted=False))
-        self.assertTrue(self.deleted_image_exists(empty_image_id))
+        # The overwritten images are deleted, but not fully
+        self.assertFalse(self.image_exists(empty_barebones_image_id, check_deleted=False))
+        self.assertTrue(self.deleted_image_exists(empty_barebones_image_id))
+        self.assertFalse(self.image_exists(empty_configured_image_id, check_deleted=False))
+        self.assertTrue(self.deleted_image_exists(empty_configured_image_id))
         self.assertTrue(self.session_template_exists(self.session_template_name))
         self.assertEqual(1, len(overwrite_report['configurations']))
-        self.assertEqual(1, len(overwrite_report['images']))
+        self.assertEqual(2, len(overwrite_report['images']))
         self.assertEqual(1, len(overwrite_report['session_templates']))
         self.assertNotIn('skipped_configurations', overwrite_report)
         self.assertNotIn('skipped_images', overwrite_report)
@@ -1046,19 +1085,13 @@ class TestBootprepDryRun(BootprepTestCase):
         ])
         result = self.run_bootprep('configs-images-and-session-templates.yaml', bootprep_opts)
 
-        self.assert_in_log_messages(
-            "INFO",
-            "Would create 1 CFS configuration",
-            result.stderr.decode()
-        )
-        self.assert_in_log_messages(
-            "INFO",
-            "Would create 1 images",
-            result.stderr.decode()
-        )
-        self.assert_in_log_messages(
-            "INFO",
-            "Would create 1 BOS session template",
+        self.assert_info_messages(
+            [
+                "Would create 1 CFS configuration",
+                "Would create 2 images",
+                "Would create 1 BOS session template",
+            ],
+            [],
             result.stderr.decode()
         )
 
@@ -1075,53 +1108,53 @@ class TestBootprepLimitOption(BootprepTestCase):
 
     @skip_test_if_csm_var_missing(['image_id', 'version'])
     def test_limit_option(self):
-        """Test limit option when creating items"""
-        overwrite_options = ' '.join([f'--overwrite-{item}' for item in ('configs', 'images', 'templates')])
+        """Test limit option when creating items. Use dry-run for images to speed up the test"""
         base_bootprep_opts = '--format json'
+        overwrite_options = ' '.join([f'--overwrite-{item}' for item in ('configs', 'images', 'templates')])
 
         limit_configs_result = self.run_bootprep(
-            'configs-images-and-session-templates.yaml',
+            'limit-test.yaml',
             f'{base_bootprep_opts} --limit configurations'
         )
-        limit_images_result = self.run_bootprep(
-            'configs-images-and-session-templates.yaml',
-            f'{base_bootprep_opts} --limit images'
-        )
-        limit_session_templates_result = self.run_bootprep(
-            'configs-images-and-session-templates.yaml',
-            f'{base_bootprep_opts} --limit session_templates'
-        )
-        # Have to specify overwrite options since the configurations and session templates exist
-        limit_two_result = self.run_bootprep(
-            'configs-images-and-session-templates.yaml',
-            f'{base_bootprep_opts} {overwrite_options} --limit configurations --limit session_templates'
-        )
-
         configs_report = json.loads(limit_configs_result.stdout.decode())
         self.assertEqual(1, len(configs_report['configurations']))
         self.assertNotIn('images', configs_report)
         self.assertNotIn('session_templates', configs_report)
 
-        for config in configs_report['configurations']:
-            self.validate_cfs_config(config['name'])
+        limit_images_result = self.run_bootprep(
+            'limit-test.yaml',
+            f'{base_bootprep_opts} --dry-run --limit images'
+        )
+        self.assert_info_messages(
+            [
+                "Would create 1 images",
+                "Skipping creation of CFS configurations based on value of --limit option",
+                "Skipping creation of BOS session templates based on value of --limit option",
+            ],
+            [
+                "Would create 1 CFS configuration",
+                "Would create 1 BOS session template",
+            ],
+            limit_images_result.stderr.decode()
+        )
 
-        images_report = json.loads(limit_images_result.stdout.decode())
-        self.assertEqual(1, len(images_report['images']))
-        self.assertNotIn('configurations', images_report)
-        self.assertNotIn('session_templates', images_report)
-
+        limit_session_templates_result = self.run_bootprep(
+            'limit-test.yaml',
+            f'{base_bootprep_opts} --limit session_templates'
+        )
         session_templates_report = json.loads(limit_session_templates_result.stdout.decode())
         self.assertEqual(1, len(session_templates_report['session_templates']))
-        self.assertNotIn('images', session_templates_report)
         self.assertNotIn('configurations', session_templates_report)
+        self.assertNotIn('images', session_templates_report)
 
+        limit_two_result = self.run_bootprep(
+            'limit-test.yaml',
+            f'{base_bootprep_opts} {overwrite_options} --limit configurations --limit session_templates'
+        )
         limit_two_report = json.loads(limit_two_result.stdout.decode())
         self.assertEqual(1, len(limit_two_report['configurations']))
         self.assertEqual(1, len(limit_two_report['session_templates']))
         self.assertNotIn('images', limit_two_report)
-
-        for config in limit_two_report['configurations']:
-            self.validate_cfs_config(config['name'])
 
 
 class TestBootprepIfExistsProperty(BootprepTestCase):


### PR DESCRIPTION
## Summary and Scope

* CRAYSAT-2006: Add 'sat bootprep' test for image_ref

  Modify the `configs-images-and-session-templates.yaml` bootprep input
  file used by `test_configs_images_and_session_templates` to include
  multiple images where one image depends on another image and refers to
  it by its `ref_name` with the `base.image_ref` property. The first image
  is built from a recipe, and the second is configured from that resulting
  image.  In addition, update the session template to refer to the image
  by its `ref_name` with `image.image_ref`. This is important to test
  because this is how our default bootprep input files that get delivered
  with the HPC CSM software recipe are set up.

  Modify `test_dry_run_and_save` to check for the right log messages being
  logged now that there are two images in the input file.

  Modify `test_limit_option` to use a separate input file that uses a
  simpler input file that only defines one config, one image, and one
  session template, none of which use `image_ref` and `ref_name`. It does
  not work to use `image_ref` to refer to an image in the input file if
  you use `--limit session_templates` because bootprep does not know the
  image ID for the referenced image if it was not created by `bootprep`.
  This is arguably a bug in `bootprep`, but it is not new, and it is not a
  critical use case, fortunately. So just fix the test to not try to do
  this. Additionally use `--dry-run` on the image use case to reduce the
  amount of time spent building images in the tests.

* CRAYSAT-2035: Clean up deleted images after `sat bootprep` tests

  The `sat bootprep` functional tests perform tests that check that `sat
  bootprep` will overwrite existing images. When `sat bootprep` does that,
  it deletes the old image, but does not permanently delete it, so it
  remains in IMS `/deleted/images`. Clean this up in the `tearDown` of the
  `BootprepTestCase` class so that we don't leave that cruft on the
  system, which will accumulate over time as these tests execute.

## Issues and Related PRs

* Resolves CRAYSAT-2006
* Resolves CRAYSAT-2035

## Testing

### Tested on:

  * vinland

### Test description:

Extracted testing RPM and ran with Goss on vinland. Verified that no
artifacts remained on the system that started with the "sat-test" prefix
after tests had finished executing.

## Risks and Mitigations

Low risk improvements to `sat bootprep` tests. The tests may take slightly
longer given that one of the bootprep tests now performs an image build from
recipe followed by an image customization. However, this is an important test
case to cover.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

