### PR TITLE
CRAYSAT-1962: Fix errors produced when running sat functional tests on vShasta

### DIFF
--- a/src/csm_testing/tests/sat_functional/firmware/test_firmware.py
+++ b/src/csm_testing/tests/sat_functional/firmware/test_firmware.py
@@ -36,6 +36,13 @@ from csm_testing.tests.sat_functional.util import SATTestCase
 
 SAT_FIRMWARE_HEADER = ['xname', 'name', 'target_name', 'version']
 
+def sort_xnames(xnames: List[str]) -> List[str]:
+    """sort xnames in custom order: Mountain, Hill, River"""
+    mountain_xnames = [ xname for xname in xnames if xname.startswith("x1000") ]
+    hill_xnames = [ xname for xname in xnames if xname.startswith("x9000") ]
+    other_xnames = [ xname for xname in xnames if xname not in mountain_xnames and xname not in hill_xnames ]
+
+    return mountain_xnames + hill_xnames + other_xnames
 
 def get_xnames() -> List[str]:
     """Get xnames from cray hsm inventory list"""
@@ -43,7 +50,14 @@ def get_xnames() -> List[str]:
     proc = subprocess.run(shlex.split(command), stdout=subprocess.PIPE,
                           stderr=subprocess.PIPE, check=True)
     xnames = [item['ID'] for item in json.loads(proc.stdout)]
-    return xnames
+
+    # custom sort of xnames Mountain, Hill, River
+    # FAS only works with mountain and hill nodes
+    # on vhsasta so those need to be sorted to
+    # the top
+    sorted_xnames = sort_xnames(xnames)
+
+    return sorted_xnames
 
 
 @unittest.skipIf(len(get_xnames()) < 2, "Not enough xnames available for testing. Skipping tests")


### PR DESCRIPTION
## Summary and Scope

Fix errors produced when running sat functional tests on vShasta.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-1962](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1962)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * beau
  * pike
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

