### PR TITLE
CRAYSAT-2037: extent timeout to 30m for sat tests

### DIFF
--- a/goss-testing/tests/ncn/goss-sat-functional-tests.yaml
+++ b/goss-testing/tests/ncn/goss-sat-functional-tests.yaml
@@ -39,5 +39,5 @@ command:
         by running '{{ $sat_functional }} run {{ $test }}' on the node where it failed.
     exec: "{{ $logrun }} -l {{ $test_label }} {{ $sat_functional }} run {{ $test }}"
     exit-status: 0
-    timeout: 900000  # use a 15-minute timeout for each test
+    timeout: 1800000  # use a 30-minute timeout for each test
   {{ end }}


### PR DESCRIPTION
## Summary and Scope

Extend timeout for sat tests to avoid timeouts on vshasta systems

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-2037](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-2037)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * beau
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? yes
- Were continuous integration tests run? If not, why? yes
- Was upgrade tested? If not, why? yes
- Was downgrade tested? If not, why? yes
- Were new tests (or test issues/Jiras) created for this change? no

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

