### PR TITLE
CRAYSAT-2039: Fix the TestNid2Xname.test_xname2nid_format_range

### DIFF
--- a/src/csm_testing/tests/sat_functional/nid2xname/test_nid2xname.py
+++ b/src/csm_testing/tests/sat_functional/nid2xname/test_nid2xname.py
@@ -35,6 +35,22 @@ class TestNid2Xname(SATTestCase):
         result = subprocess.run(command, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         return result.stdout.decode().strip()
 
+    def get_consecutive_components(self, min_count=3):
+        """
+        Return a list of components with at least min_count consecutive NIDs.
+        """
+        command = (
+            "cray hsm state components list --type Node --format json | "
+            "jq -r '.Components | map({NID: .NID, Xname: .ID}) | unique | sort_by(.NID)'"
+        )
+        components = json.loads(self.run_command(command))
+        nids_int = [int(c['NID']) for c in components]
+        for i in range(len(nids_int) - (min_count - 1)):
+            if all(nids_int[i + j] == nids_int[i] + j for j in range(min_count)):
+                indices = list(range(i, i + min_count))
+                return [components[idx] for idx in indices]
+        raise AssertionError(f"Could not find {min_count} consecutive NIDs in HSM output")
+
     def test_nid_to_xname(self):
         """Test converting nid to xname."""
         # Get the xname and nid from the HSM
@@ -98,22 +114,14 @@ class TestNid2Xname(SATTestCase):
 
             self.assertEqual(f"nid{int(expected_nid):06d}", converted_nid, f"Expected nid {int(expected_nid):06d} but got {converted_nid} for xname {xname}")
 
-
     def test_xname2nid_format_range(self):
-        """Test xname2nid with -f range option."""
-        # Get multiple xnames and nids from the HSM
-        command = "cray hsm state components list --type Node --format json | jq -r '.Components | map({NID: .NID, Xname: .ID}) | unique | sort_by(.NID) | .[0:3]'"
-        components = json.loads(self.run_command(command))
-
-        nids = [str(component['NID']) for component in components]
-        xnames = [component['Xname'] for component in components]
-
-        # Convert xnames to nid range using sat command
+        """Test xname2nid with -f range option using consecutive nids."""
+        consecutive_components = self.get_consecutive_components(min_count=3)
+        nids = [str(c['NID']) for c in consecutive_components]
+        xnames = [c['Xname'] for c in consecutive_components]
+        expected_nid_range = f"nid[{int(nids[0]):06d}-{int(nids[-1]):06d}]"
         sat_command_range = f"sat xname2nid -f range {' '.join(xnames)}"
         converted_nid_range = self.run_command(sat_command_range)
-
-        # Verify the range conversion
-        expected_nid_range = f"nid[{int(nids[0]):06d}-{int(nids[-1]):06d}]"
         self.assertEqual(expected_nid_range, converted_nid_range, f"Expected nid range {expected_nid_range} but got {converted_nid_range}")
 
     def test_xname2nid_format_nid(self):
@@ -134,36 +142,14 @@ class TestNid2Xname(SATTestCase):
         self.assertEqual(expected_nid_list, converted_nid_list, f"Expected nid list {expected_nid_list} but got {converted_nid_list}")
 
     def test_nid_range_to_xname(self):
-        """Test converting nid range to xnames."""
-        # Get multiple xnames and nids from the HSM
-        command = "cray hsm state components list --type Node --format json | jq -r '.Components | map({NID: .NID, Xname: .ID}) | unique | sort_by(.NID) | .[0:6]'"
-        components = json.loads(self.run_command(command))
-
-        nids = [str(component['NID']) for component in components]
-        xnames = [component['Xname'] for component in components]
-
-        # Define the NID range
-        nids_int = sorted(int(n) for n in nids)
-        ranges = []
-        start = prev = nids_int[0]
-        for nid in nids_int[1:]:
-            if nid == prev + 1:
-                prev = nid
-            else:
-                ranges.append((start, prev))
-                start = prev = nid
-
-        ranges.append((start, prev))
-        range_strs = ",".join(f"{s:06d}-{e:06d}" for s, e in ranges)
-        nid_range = f"nid[{range_strs}]"
-
-        # Expected xnames corresponding to the NID range
+        """Test converting nid range to xnames using consecutive nids."""
+        consecutive_components = self.get_consecutive_components(min_count=3)
+        nids = [str(c['NID']) for c in consecutive_components]
+        xnames = [c['Xname'] for c in consecutive_components]
+        nid_range = f"nid[{int(nids[0]):06d}-{int(nids[-1]):06d}]"
         expected_xnames = ','.join(xnames)
-
-        # Convert nid range to xnames using sat command
         sat_command = f"sat nid2xname {nid_range}"
         converted_xnames = self.run_command(sat_command)
-
         self.assertEqual(expected_xnames, converted_xnames, f"Expected xnames {expected_xnames} but got {converted_xnames} for nid range {nid_range}")
 
 

--- a/src/csm_testing/tests/sat_functional/nid2xname/test_nid2xname.py
+++ b/src/csm_testing/tests/sat_functional/nid2xname/test_nid2xname.py
@@ -30,89 +30,125 @@ from csm_testing.tests.sat_functional.util import SATTestCase
 
 class TestNid2Xname(SATTestCase):
 
-    def run_command(self, command):
-        """Run a shell command and return the output."""
-        result = subprocess.run(command, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        return result.stdout.decode().strip()
+    @classmethod
+    def setUpClass(cls):
+        """Set up data used by all test methods."""
+        super().setUpClass()
+        cls.components = cls.get_hsm_components()
+        cls.first_xname = cls.components[0]['Xname']
+        cls.first_nid = cls.components[0]['NID']
 
-    def get_consecutive_components(self, min_count=3):
-        """
-        Return a list of components with at least min_count consecutive NIDs.
-        """
-        command = (
-            "cray hsm state components list --type Node --format json | "
-            "jq -r '.Components | map({NID: .NID, Xname: .ID}) | unique | sort_by(.NID)'"
-        )
-        components = json.loads(self.run_command(command))
-        nids_int = [int(c['NID']) for c in components]
+    @classmethod
+    def get_hsm_components(cls):
+        """Get component data from HSM."""
+        command = "cray hsm state components list --type Node --format json"
+        command_args = command.split()
+        result = subprocess.run(command_args, check=True,
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        raw_data = json.loads(result.stdout.decode().strip())
+        components = []
+
+        # Extract just the NID and Xname (ID) fields from each component
+        for component in raw_data.get('Components', []):
+            if 'NID' in component and 'ID' in component:
+                components.append({
+                    'NID': component['NID'],
+                    'Xname': component['ID']
+                })
+
+        # Sort by NID (as integers)
+        components.sort(key=lambda c: int(c['NID']) if c['NID'] is not None else float('inf'))
+
+        return components
+
+    @classmethod
+    def get_consecutive_components(cls, min_count=3):
+        """Return a list of components with at least min_count consecutive NIDs."""
+        nids_int = [int(c['NID']) for c in cls.components]
         for i in range(len(nids_int) - (min_count - 1)):
             if all(nids_int[i + j] == nids_int[i] + j for j in range(min_count)):
                 indices = list(range(i, i + min_count))
-                return [components[idx] for idx in indices]
+                return [cls.components[idx] for idx in indices]
         raise AssertionError(f"Could not find {min_count} consecutive NIDs in HSM output")
+
+    def run_command(self, command):
+        """Run a shell command and return the output."""
+        command_args = command.split()
+        result = subprocess.run(command_args, check=True,
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return result.stdout.decode().strip()
 
     def test_nid_to_xname(self):
         """Test converting nid to xname."""
-        # Get the xname and nid from the HSM
-        xname_command = "cray hsm state components list --type Node --format json | jq -r '.Components[0].ID'"
-        nid_command = "cray hsm state components list --type Node --format json | jq -r '.Components[0].NID'"
-        
-        xname = self.run_command(xname_command)
-        nid = self.run_command(nid_command)
-        
+        # Use the pre-cached data
+        xname = self.first_xname
+        nid = self.first_nid
+
         # Convert nid to xname using sat command
         sat_command = f"sat nid2xname nid{nid}"
         converted_xname = self.run_command(sat_command)
-        
-        self.assertEqual(xname, converted_xname, f"Expected xname {xname} but got {converted_xname} for nid {nid}")
+
+        self.assertEqual(xname, converted_xname,
+                         f"Expected xname {xname} but got {converted_xname} for nid {nid}")
 
     def test_xname_to_nid(self):
         """Test converting xname to nid."""
-        # Get the xname and nid from the HSM
-        xname_command = "cray hsm state components list --type Node --format json | jq -r '.Components[0].ID'"
-        nid_command = "cray hsm state components list --type Node --format json | jq -r '.Components[0].NID'"
-
-        xname = self.run_command(xname_command)
-        nid = self.run_command(nid_command)
+        # Use the pre-cached data
+        xname = self.first_xname
+        nid = self.first_nid
 
         # Convert xname to nid using sat command
         sat_command_reverse = f"sat xname2nid {xname}"
         converted_nid = self.run_command(sat_command_reverse)
 
-        self.assertEqual(f"nid{int(nid):06d}", converted_nid, f"Expected nid {int(nid):06d} but got {converted_nid} for xname {xname}")
-
+        self.assertEqual(f"nid{int(nid):06d}", converted_nid,
+                         f"Expected nid {int(nid):06d} but got {converted_nid} for xname {xname}")
 
     def test_multiple_nid_to_xname(self):
-        """Test converting multiple nids to xnames."""
-        # Get multiple xnames and nids from the HSM
-        command = "cray hsm state components list --type Node --format json | jq -r '.Components | map({NID: .NID, Xname: .ID}) | unique | sort_by(.NID) | .[0:3]'"
-        components = json.loads(self.run_command(command))
+        """Test converting multiple nids to xnames in a single command call."""
+        # Use consecutive components for a better test
+        consecutive_components = self.get_consecutive_components(min_count=3)
+        nids = [str(component['NID']) for component in consecutive_components]
+        xnames = [component['Xname'] for component in consecutive_components]
 
-        nids = [str(component['NID']) for component in components]
-        xnames = [component['Xname'] for component in components]
+        # Test with space-separated nids
+        nid_args = ' '.join([f"nid{nid}" for nid in nids])
+        sat_command = f"sat nid2xname {nid_args}"
+        converted_xnames = self.run_command(sat_command)
+        expected_xnames = ','.join(xnames)
+        self.assertEqual(expected_xnames, converted_xnames,
+                        f"Space-separated test: Expected xnames {expected_xnames} but got {converted_xnames}")
 
-        for nid, expected_xname in zip(nids, xnames):
-            # Convert nid to xname using sat command
-            sat_command = f"sat nid2xname nid{nid}"
-            converted_xname = self.run_command(sat_command)
-
-            self.assertEqual(expected_xname, converted_xname, f"Expected xname {expected_xname} but got {converted_xname} for nid {nid}")
+        # Test with comma-separated nids
+        nid_list = ','.join([f"nid{nid}" for nid in nids])
+        sat_command = f"sat nid2xname {nid_list}"
+        converted_xnames = self.run_command(sat_command)
+        self.assertEqual(expected_xnames, converted_xnames,
+                        f"Comma-separated test: Expected xnames {expected_xnames} but got {converted_xnames}")
 
     def test_multiple_xname_to_nid(self):
-        """Test converting multiple xnames to nids."""
-        # Get multiple xnames and nids from the HSM
-        command = "cray hsm state components list --type Node --format json | jq -r '.Components | map({NID: .NID, Xname: .ID}) | unique | sort_by(.NID) | .[0:3]'"
-        components = json.loads(self.run_command(command))
+        """Test converting multiple xnames to nids in a single command call."""
+        # Use consecutive components for a better test
+        consecutive_components = self.get_consecutive_components(min_count=3)
+        nids = [str(c['NID']) for c in consecutive_components]
+        xnames = [c['Xname'] for c in consecutive_components]
 
-        nids = [str(component['NID']) for component in components]
-        xnames = [component['Xname'] for component in components]
+        # The default output format is range when multiple xnames are provided
+        expected_nid_range = f"nid[{int(nids[0]):06d}-{int(nids[-1]):06d}]"
 
-        for expected_nid, xname in zip(nids, xnames):
-            # Convert xname to nid using sat command
-            sat_command_reverse = f"sat xname2nid {xname}"
-            converted_nid = self.run_command(sat_command_reverse)
+        # Test with space-separated xnames
+        xname_args = ' '.join(xnames)
+        sat_command = f"sat xname2nid {xname_args}"
+        converted_nids = self.run_command(sat_command)
+        self.assertEqual(expected_nid_range, converted_nids,
+                        f"Space-separated test: Expected nid range {expected_nid_range} but got {converted_nids}")
 
-            self.assertEqual(f"nid{int(expected_nid):06d}", converted_nid, f"Expected nid {int(expected_nid):06d} but got {converted_nid} for xname {xname}")
+        # Test with comma-separated xnames
+        xname_list = ','.join(xnames)
+        sat_command = f"sat xname2nid {xname_list}"
+        converted_nids = self.run_command(sat_command)
+        self.assertEqual(expected_nid_range, converted_nids,
+                        f"Comma-separated test: Expected nid range {expected_nid_range} but got {converted_nids}")
 
     def test_xname2nid_format_range(self):
         """Test xname2nid with -f range option using consecutive nids."""
@@ -126,18 +162,14 @@ class TestNid2Xname(SATTestCase):
 
     def test_xname2nid_format_nid(self):
         """Test xname2nid with -f nid option."""
-        # Get multiple xnames and nids from the HSM
-        command = "cray hsm state components list --type Node --format json | jq -r '.Components | map({NID: .NID, Xname: .ID}) | unique | sort_by(.NID) | .[0:3]'"
-        components = json.loads(self.run_command(command))
+        # Use the first few components from the cached data
+        sample_components = self.components[:3]
+        nids = [str(component['NID']) for component in sample_components]
+        xnames = [component['Xname'] for component in sample_components]
 
-        nids = [str(component['NID']) for component in components]
-        xnames = [component['Xname'] for component in components]
-
-        # Convert xnames to individual nids using sat command
         sat_command_nid = f"sat xname2nid -f nid {' '.join(xnames)}"
         converted_nid_list = self.run_command(sat_command_nid)
 
-        # Verify the individual nids conversion
         expected_nid_list = ','.join([f"nid{int(nid):06d}" for nid in nids])
         self.assertEqual(expected_nid_list, converted_nid_list, f"Expected nid list {expected_nid_list} but got {converted_nid_list}")
 


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Fix the invalid logic of `TestNid2Xname.test_xname2nid_format_range` by removing the wrong assumptions of nid range_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-2039](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-2039)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * rocket
  * tyr

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Tested `nid2xname` test cases to ensure it rightly conert nids to xname and vice versa.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
NO


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

