### PR TITLE
CASMCMS-9565 - increase timeout for cmsdev tests.

### DIFF
--- a/goss-testing/tests/ncn/goss-cms-tests.yaml
+++ b/goss-testing/tests/ncn/goss-cms-tests.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023,2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -33,7 +33,7 @@ command:
       desc: Performs a basic health check on the {{ $test }} service. If this test fails, then manually run '{{ $cmsdev }} test {{ $test }}' on the same node where the test failed. For more information, see 'troubleshooting/known_issues/sms_health_check.md' in the CSM documentation.
     exec: "{{$logrun}} -l cms-test-{{ $test }} {{ $cmsdev }} test -v {{ $test }}"
     exit-status: 0
-    timeout: 300000
+    timeout: 600000
     # If not on vshasta, do not skip any tests
     {{ if ne true $vshasta }}
     skip: false


### PR DESCRIPTION
## Summary and Scope

The bos tests in cmsdev are taking around 4:30 on an idle system. When running the full goss tests, they are sometimes timing out. This just increases the timeout from 5:00 to 10:00 for the cmsdev test suite.

## Issues and Related PRs
* Resolves [CASMCMS-9565](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9565)

## Testing

Didn't test - trivial change.

## Risks and Mitigations

Very low risk, just changing a timeout value.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct

