### PR TITLE
CRAYSAT-2048: Stop deleting failed IMS jobs in SAT bootpref functional tests suite

### DIFF
--- a/src/csm_testing/tests/sat_functional/bootprep/test_bootprep.py
+++ b/src/csm_testing/tests/sat_functional/bootprep/test_bootprep.py
@@ -686,6 +686,9 @@ class BootprepTestCase(SATTestCase):
             for job in jobs_json:
                 archive_name = job.get('image_root_archive_name', '')
                 if archive_name.startswith(cls.test_prefix):
+                    if job.get('status') == 'error':
+                        logging.warning('Skipping deletion of IMS job with ID %s, to allow for debugging', job.get('id'))
+                        continue
                     try:
                         found_job_ids.append(job['id'])
                     except KeyError:


### PR DESCRIPTION
## Summary and Scope

Stop deleting failed IMS jobs in "sat bootprep" functional tests to allow debugging

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CRAYSAT-2048](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-2048)


## Testing

_List the environments in which these changes were tested._

### Tested on:

  * tyr
  * vinland

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

